### PR TITLE
feat: 添加缓存与应用生命周期基础能力

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -383,12 +383,8 @@ func terminalState(runContext context.Context, primaryErr error, stopErr error) 
 
 func expectedContextTermination(runContext context.Context, primaryErr error) bool {
 	cause := context.Cause(runContext)
-	switch cause {
-	case context.Canceled, context.DeadlineExceeded:
-		return primaryErr == cause
-	default:
-		return false
-	}
+	return (errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded)) &&
+		errors.Is(primaryErr, cause)
 }
 
 func serverName(component server.Server) string {

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,399 @@
+// Package app coordinates the explicit lifecycle of a Keelith application.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/health"
+	"github.com/keelab/keelith/server"
+	"github.com/keelab/keelith/service"
+)
+
+var (
+	// ErrAlreadyRun is returned when Run is called more than once.
+	ErrAlreadyRun = errors.New("app: app has already been run")
+	// ErrInvalidOption is returned when an Option cannot produce a valid App.
+	ErrInvalidOption = errors.New("app: invalid option")
+	// ErrNilContext is returned when Run or Stop receives a nil context.
+	ErrNilContext = errors.New("app: nil context")
+	// ErrServerExited is returned when a Server Waiter exits without an error
+	// while the App is still running.
+	ErrServerExited = errors.New("app: server exited while app was running")
+
+	// errStopRequested is returned when the App is requested to stop.
+	errStopRequested = errors.New("app: stop requested")
+)
+
+// App coordinates hooks and servers without process-wide mutable state.
+//
+// An App can be run once. Multiple App instances can run independently in the
+// same process.
+type App struct {
+	servers     []server.Server
+	hooks       []Hook
+	health      *health.Registry
+	identity    *service.Identity
+	stopTimeout time.Duration
+
+	mu       sync.Mutex
+	state    State
+	cancel   context.CancelCauseFunc
+	done     chan struct{}
+	runErr   error
+	closeOne sync.Once
+}
+
+// New constructs an App and validates every Option.
+func New(optionList ...Option) (*App, error) {
+	settings := defaultOptions()
+
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	components, err := sortComponents(settings.components)
+	if err != nil {
+		return nil, fmt.Errorf("%w: components: %w", ErrInvalidOption, err)
+	}
+	for _, component := range components {
+		resource := component
+		settings.hooks = append(settings.hooks, Hook{
+			BeforeStart: resource.Start,
+			AfterStop:   resource.Stop,
+		})
+	}
+
+	return &App{
+		servers:     append([]server.Server(nil), settings.servers...),
+		hooks:       append([]Hook(nil), settings.hooks...),
+		health:      settings.health,
+		identity:    settings.identity,
+		stopTimeout: settings.stopTimeout,
+		state:       StateNew,
+		done:        make(chan struct{}),
+	}, nil
+}
+
+// Identity returns the immutable identity assigned to this App.
+func (app *App) Identity() (service.Identity, bool) {
+	if app == nil || app.identity == nil {
+		return service.Identity{}, false
+	}
+	return *app.identity, true
+}
+
+// Run starts the App and blocks until it stops.
+//
+// Root context cancellation is returned to the caller. A successful explicit
+// Stop makes Run return nil.
+func (app *App) Run(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	runContext, cancel := context.WithCancelCause(ctx)
+	if err := app.begin(cancel); err != nil {
+		cancel(nil)
+		return err
+	}
+	defer cancel(nil)
+
+	started, activeHooks, primaryErr := app.start(runContext)
+	if primaryErr == nil {
+		app.transition(StateReady)
+		primaryErr = app.wait(runContext, started)
+	}
+
+	if errors.Is(primaryErr, errStopRequested) {
+		primaryErr = nil
+	}
+
+	app.transition(StateDraining)
+	stopContext, stopCancel := context.WithTimeout(context.WithoutCancel(runContext), app.stopTimeout)
+	stopErr := app.shutdown(stopContext, started, activeHooks)
+	stopCancel()
+
+	result := errors.Join(primaryErr, stopErr)
+	app.complete(result, terminalState(runContext, primaryErr, stopErr))
+	return result
+}
+
+// Stop requests graceful shutdown and waits for it to finish or for ctx to
+// expire. Stop is safe to call concurrently and multiple times.
+func (app *App) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	app.mu.Lock()
+	switch app.state {
+	case StateNew:
+		app.mu.Unlock()
+		return nil
+	case StateStopped, StateFailed:
+		err := app.runErr
+		app.mu.Unlock()
+		return err
+	default:
+		cancel := app.cancel
+		done := app.done
+		app.mu.Unlock()
+
+		cancel(errStopRequested)
+		select {
+		case <-done:
+			app.mu.Lock()
+			err := app.runErr
+			app.mu.Unlock()
+			return err
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
+	}
+}
+
+// State returns the App's current lifecycle state.
+func (app *App) State() State {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	return app.state
+}
+
+// Description returns a bounded lifecycle snapshot suitable for diagnostics.
+func (app *App) Description() Description {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	return Description{
+		State:    app.state,
+		Terminal: app.state == StateStopped || app.state == StateFailed,
+		Failed:   app.state == StateFailed,
+	}
+}
+
+// Err returns the terminal Run result after the App reaches Stopped or Failed.
+//
+// Err returns nil while the App is non-terminal. Callers that need to wait for
+// completion should use Run or Stop instead of polling Err.
+func (app *App) Err() error {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	if app.state != StateStopped && app.state != StateFailed {
+		return nil
+	}
+	return app.runErr
+}
+
+func (app *App) begin(cancel context.CancelCauseFunc) error {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	if app.state != StateNew {
+		return ErrAlreadyRun
+	}
+	app.state = StateStarting
+	app.cancel = cancel
+	if app.health != nil {
+		app.health.Starting()
+	}
+	return nil
+}
+
+func (app *App) start(ctx context.Context) ([]server.Server, int, error) {
+	started := make([]server.Server, 0, len(app.servers))
+	activeHooks := 0
+
+	for index, hook := range app.hooks {
+		if err := context.Cause(ctx); err != nil {
+			return started, activeHooks, err
+		}
+		if hook.BeforeStart != nil {
+			if err := hook.BeforeStart(ctx); err != nil {
+				if cause := context.Cause(ctx); cause != nil {
+					return started, activeHooks, cause
+				}
+				return started, activeHooks, fmt.Errorf("app: hook %d before start: %w", index, err)
+			}
+		}
+		activeHooks++
+	}
+
+	for _, component := range app.servers {
+		if err := context.Cause(ctx); err != nil {
+			return started, activeHooks, err
+		}
+		if err := component.Start(ctx); err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				return started, activeHooks, cause
+			}
+			return started, activeHooks, fmt.Errorf("app: start server %q: %w", serverName(component), err)
+		}
+		started = append(started, component)
+	}
+
+	for index := range activeHooks {
+		if err := context.Cause(ctx); err != nil {
+			return started, activeHooks, err
+		}
+		hook := app.hooks[index]
+		if hook.AfterStart != nil {
+			if err := hook.AfterStart(ctx); err != nil {
+				if cause := context.Cause(ctx); cause != nil {
+					return started, activeHooks, cause
+				}
+
+				return started, activeHooks, fmt.Errorf("app: hook %d after start: %w", index, err)
+			}
+		}
+	}
+
+	if err := context.Cause(ctx); err != nil {
+		return started, activeHooks, err
+	}
+	return started, activeHooks, nil
+}
+
+func (app *App) wait(ctx context.Context, started []server.Server) error {
+	type waitResult struct {
+		name string
+		err  error
+	}
+
+	waiterCount := 0
+	for _, component := range started {
+		if _, ok := component.(server.Waiter); ok {
+			waiterCount++
+		}
+	}
+
+	results := make(chan waitResult, waiterCount)
+	for _, component := range started {
+		waiter, ok := component.(server.Waiter)
+		if !ok {
+			continue
+		}
+		name := serverName(component)
+		go func() {
+			results <- waitResult{name: name, err: waiter.Wait()}
+		}()
+	}
+
+	if waiterCount == 0 {
+		<-ctx.Done()
+		return context.Cause(ctx)
+	}
+
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case result := <-results:
+		if result.err == nil {
+			return fmt.Errorf("%w: %s", ErrServerExited, result.name)
+		}
+		return fmt.Errorf("app: server %q runtime failure: %w", result.name, result.err)
+	}
+}
+
+func (app *App) shutdown(ctx context.Context, started []server.Server, activeHooks int) error {
+	stopErrors := make([]error, 0)
+
+	for index := activeHooks - 1; index >= 0; index-- {
+		hook := app.hooks[index]
+		if hook.BeforeStop == nil {
+			continue
+		}
+		if err := hook.BeforeStop(ctx); err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("app: hook %d before stop: %w", index, err))
+		}
+	}
+
+	for index := len(started) - 1; index >= 0; index-- {
+		component := started[index]
+		if err := component.Stop(ctx); err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("app: stop server %q: %w", serverName(component), err))
+		}
+	}
+
+	for index := activeHooks - 1; index >= 0; index-- {
+		hook := app.hooks[index]
+		if hook.AfterStop == nil {
+			continue
+		}
+		if err := hook.AfterStop(ctx); err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("app: hook %d after stop: %w", index, err))
+		}
+	}
+
+	return errors.Join(stopErrors...)
+}
+
+func (app *App) transition(state State) {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	app.state = state
+	if app.health == nil {
+		return
+	}
+	switch state {
+	case StateReady:
+		app.health.Ready()
+	case StateDraining:
+		app.health.Draining()
+	case StateStopped:
+		app.health.Stopped()
+	case StateFailed:
+		app.health.Failed()
+	case StateNew, StateStarting:
+	}
+}
+
+func (app *App) complete(runErr error, terminal State) {
+	app.mu.Lock()
+	app.state = terminal
+	app.runErr = runErr
+	app.cancel = nil
+	if app.health != nil {
+		if terminal == StateFailed {
+			app.health.Failed()
+		} else {
+			app.health.Stopped()
+		}
+	}
+	app.closeOne.Do(func() {
+		close(app.done)
+	})
+	app.mu.Unlock()
+}
+
+func terminalState(runContext context.Context, primaryErr error, stopErr error) State {
+	if stopErr != nil {
+		return StateFailed
+	}
+	if primaryErr == nil || expectedContextTermination(runContext, primaryErr) {
+		return StateStopped
+	}
+	return StateFailed
+}
+
+func expectedContextTermination(runContext context.Context, primaryErr error) bool {
+	cause := context.Cause(runContext)
+	switch cause {
+	case context.Canceled, context.DeadlineExceeded:
+		return primaryErr == cause
+	default:
+		return false
+	}
+}
+
+func serverName(component server.Server) string {
+	if named, ok := component.(server.Named); ok && named.Name() != "" {
+		return named.Name()
+	}
+	return fmt.Sprintf("%T", component)
+}

--- a/app/component.go
+++ b/app/component.go
@@ -3,6 +3,9 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
+	"strings"
 )
 
 // ErrInvalidComponentGraph reports duplicate, missing, or cyclic component
@@ -58,4 +61,103 @@ func (c ComponentFunc) Stop(ctx context.Context) error {
 		return nil
 	}
 	return c.StopFunc(ctx)
+}
+
+func sortComponents(components []Component) ([]Component, error) {
+	byName := make(map[string]int, len(components))
+	names := make([]string, len(components))
+	dependencies := make([][]string, len(components))
+
+	for index, component := range components {
+		if isNilComponent(component) {
+			return nil, fmt.Errorf("%w: component %d is nil", ErrInvalidComponentGraph, index)
+		}
+		name := strings.TrimSpace(component.Name())
+		if name == "" || name != component.Name() {
+			return nil, fmt.Errorf("%w: component %d has an invalid name %q", ErrInvalidComponentGraph, index, component.Name())
+		}
+		if _, duplicate := byName[name]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate component %q", ErrInvalidComponentGraph, name)
+		}
+		byName[name] = index
+		names[index] = name
+		if provider, ok := component.(DependencyProvider); ok {
+			dependencies[index] = append([]string(nil), provider.Dependencies()...)
+		}
+	}
+
+	for index, required := range dependencies {
+		seen := make(map[string]struct{}, len(required))
+
+		for dependencyIndex, dependency := range required {
+			name := strings.TrimSpace(dependency)
+			if name == "" || name != dependency {
+				return nil, fmt.Errorf("%w: component %q dependency %d is invalid", ErrInvalidComponentGraph, names[index], dependencyIndex)
+			}
+			if name == names[index] {
+				return nil, fmt.Errorf("%w: component %q depends on itself", ErrInvalidComponentGraph, name)
+			}
+			if _, exists := byName[name]; !exists {
+				return nil, fmt.Errorf("%w: component %q requires unknown component %q", ErrInvalidComponentGraph, names[index], name)
+			}
+			if _, duplicate := seen[name]; duplicate {
+				return nil, fmt.Errorf("%w: component %q repeats dependency %q", ErrInvalidComponentGraph, names[index], name)
+			}
+			seen[name] = struct{}{}
+		}
+	}
+
+	const (
+		unvisited uint8 = iota
+		visiting
+		visited
+	)
+	states := make([]uint8, len(components))
+	stack := make([]string, 0, len(components))
+	order := make([]Component, 0, len(components))
+	var visit func(int) error
+	visit = func(index int) error {
+		switch states[index] {
+		case visited:
+			return nil
+		case visiting:
+			cycle := append(append([]string(nil), stack...), names[index])
+			return fmt.Errorf("%w: dependency cycle %s", ErrInvalidComponentGraph, strings.Join(cycle, " -> "))
+		}
+		states[index] = visiting
+		stack = append(stack, names[index])
+		for _, dependency := range dependencies[index] {
+			if err := visit(byName[dependency]); err != nil {
+				return err
+			}
+		}
+		stack = stack[:len(stack)-1]
+		states[index] = visited
+		order = append(order, components[index])
+		return nil
+	}
+	for index := range components {
+		if err := visit(index); err != nil {
+			return nil, err
+		}
+	}
+	return order, nil
+}
+
+func isNilComponent(component Component) bool {
+	if component == nil {
+		return true
+	}
+	value := reflect.ValueOf(component)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/app/options.go
+++ b/app/options.go
@@ -11,6 +11,8 @@ import (
 	"github.com/keelab/keelith/service"
 )
 
+const defaultStopTimeout = 30 * time.Second
+
 // Lifecycle is an instance-scoped resource initialized before Servers and
 // shut down after Servers. Telemetry providers and connection pools use this
 // contract without making app depend on their concrete packages.
@@ -147,6 +149,11 @@ func WithStopTimeout(timeout time.Duration) Option {
 	})
 }
 
+func defaultOptions() options {
+	return options{
+		stopTimeout: defaultStopTimeout,
+	}
+}
 func isNilServer(component server.Server) bool {
 	if component == nil {
 		return true

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,625 @@
+// Package cache provides backend-neutral read-through cache policy.
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/sync/singleflight"
+)
+
+var (
+	// ErrMiss reports that a backend does not contain a key.
+	ErrMiss = errors.New("cache: miss")
+	// ErrNotFound is the default stable negative loader result.
+	ErrNotFound = errors.New("cache: value not found")
+	// ErrCorrupt reports a malformed or undecodable cached value.
+	ErrCorrupt = errors.New("cache: corrupt value")
+	// ErrInvalidOption reports an invalid cache dependency or policy.
+	ErrInvalidOption = errors.New("cache: invalid option")
+	// ErrVersioningUnsupported reports a backend without atomic version guards.
+	ErrVersioningUnsupported = errors.New("cache: versioning unsupported")
+	// ErrStaleWrite reports an explicit Set that raced a newer invalidation.
+	ErrStaleWrite = errors.New("cache: stale write suppressed")
+	// ErrVersionRequired reports legacy deletion on a versioned Cache.
+	ErrVersionRequired = errors.New("cache: invalidation version required")
+)
+
+const (
+	envelopeValue    byte = 1    // envelopeValue is the byte value used to indicate a positive cache hit.
+	envelopeNegative byte = 2    // envelopeNegative is the byte value used to indicate a negative cache hit.
+	mutationStripes       = 256  // mutationStripes is the number of stripes used for cache mutation.
+	maxCacheKeyBytes      = 1024 // maxCacheKeyBytes is the maximum number of bytes allowed in a cache key.
+)
+
+// Backend is the minimal binary cache storage contract.
+type Backend interface {
+	// Get retrieves the value associated with the given key from the cache.
+	Get(context.Context, string) ([]byte, error)
+	// Set stores the value associated with the given key in the cache.
+	Set(context.Context, string, []byte, time.Duration) error
+	// Delete removes the value associated with the given key from the cache.
+	Delete(context.Context, ...string) (int64, error)
+}
+
+// InvalidationState reports an atomic versioned backend decision.
+type InvalidationState uint8
+
+const (
+	// InvalidationApplied means a newer version replaced the watermark and
+	// deleted the cached value.
+	InvalidationApplied InvalidationState = iota + 1
+	// InvalidationCurrent means the same version was already applied.
+	InvalidationCurrent
+	// InvalidationStale means a newer version had already been observed.
+	InvalidationStale
+)
+
+// VersionedBackend prevents a loader from writing after another replica has
+// atomically advanced a key's invalidation watermark.
+type VersionedBackend interface {
+	Backend // Backend is the minimal binary cache storage contract.
+	// CurrentVersion returns the current version of the given key.
+	CurrentVersion(context.Context, string) (uint64, error)
+	// SetIfVersion stores the value associated with the given key in the cache if the version matches.
+	SetIfVersion(context.Context, string, []byte, time.Duration, uint64) (bool, error)
+	// ApplyInvalidation applies an invalidation state to the given key.
+	ApplyInvalidation(context.Context, string, uint64) (InvalidationState, error)
+}
+
+// Loader obtains a value when no valid cache entry exists.
+type Loader[T any] func(context.Context, string) (T, error)
+
+// Random supplies cache TTL jitter values in [0, 1).
+type Random interface {
+	// Float64 returns a random float64 value in [0, 1).
+	Float64() float64
+}
+
+// Cache is a typed read-through cache with request coalescing.
+type Cache[T any] struct {
+	backend Backend            // backend is the backend used to store cache values.
+	version VersionedBackend   // version is the versioned backend used to store cache values.
+	codec   Codec[T]           // codec is the codec used to serialize/deserialize values.
+	loader  Loader[T]          // loader is the function used to load cache values.
+	policy  Policy             // policy is the cache policy.
+	random  Random             // random is used to generate random values.
+	group   singleflight.Group // group is used to coalesce cache load requests.
+
+	mutations              [mutationStripes]mutationStripe // mutationStripes is the number of stripes used for cache mutation.
+	staleWritesSuppressed  atomic.Uint64                   // number of stale writes suppressed
+	invalidations          atomic.Uint64                   // number of invalidations
+	observedInvalidations  atomic.Uint64                   // number of observed invalidations
+	versionedInvalidations atomic.Uint64                   // number of versioned invalidations
+	currentInvalidations   atomic.Uint64                   // number of current invalidations
+	staleInvalidations     atomic.Uint64                   // number of stale invalidations
+	versionFailures        atomic.Uint64                   // number of version failures
+}
+
+type loadResult[T any] struct {
+	value T
+}
+
+type mutationStripe struct {
+	mu         sync.Mutex
+	generation atomic.Uint64
+}
+
+// Description is a value-free cache consistency snapshot.
+type Description struct {
+	StaleWritesSuppressed  uint64 // number of stale writes suppressed
+	Invalidations          uint64 // number of invalidations
+	ObservedInvalidations  uint64 // number of observed invalidations
+	VersionedInvalidations uint64 // number of versioned invalidations
+	CurrentInvalidations   uint64 // number of current invalidations
+	StaleInvalidations     uint64 // number of stale invalidations
+	VersionFailures        uint64 // number of version failures
+}
+
+// New creates a typed read-through cache.
+func New[T any](backend Backend, codec Codec[T], loader Loader[T], policy Policy, options ...Option) (*Cache[T], error) {
+	if isNil(backend) || isNil(codec) || loader == nil {
+		return nil, fmt.Errorf("%w: backend, codec, and loader are required", ErrInvalidOption)
+	}
+	if err := validatePolicy(policy); err != nil {
+		return nil, err
+	}
+	settings := settings{random: packageRandom{}}
+	for index, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+
+	result := &Cache[T]{
+		backend: backend,
+		codec:   codec,
+		loader:  loader,
+		policy:  policy,
+		random:  settings.random,
+	}
+	if settings.versioning {
+		versioned, ok := backend.(VersionedBackend)
+		if !ok || isNil(versioned) {
+			return nil, ErrVersioningUnsupported
+		}
+		result.version = versioned
+	}
+	return result, nil
+}
+
+// Get returns a cached value or coalesces concurrent loads for key.
+func (c *Cache[T]) Get(ctx context.Context, key string) (T, error) {
+	var zero T
+	if c == nil {
+		return zero, fmt.Errorf("%w: cache is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return zero, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if err := validateKey(key); err != nil {
+		return zero, err
+	}
+	value, hit, err := c.read(ctx, key)
+	if hit {
+		return value, err
+	}
+	if err != nil && !c.policy.FailOpen {
+		return zero, err
+	}
+
+	resultChannel := c.group.DoChan(key, func() (any, error) {
+		generation := c.generation(key)
+		// Recheck after becoming the singleflight leader. Another request may
+		// have populated the key between the first read and this point.
+		cached, cachedHit, cachedErr := c.read(ctx, key)
+		if cachedHit {
+			return loadResult[T]{value: cached}, cachedErr
+		}
+		if cachedErr != nil && !c.policy.FailOpen {
+			return loadResult[T]{}, cachedErr
+		}
+		version, versionKnown, versionErr := c.currentVersion(ctx, key)
+		if versionErr != nil && !c.policy.FailOpen {
+			return loadResult[T]{}, versionErr
+		}
+
+		loaded, loadErr := c.loader(ctx, key)
+		if loadErr != nil {
+			if c.policy.IsNegative != nil && c.policy.IsNegative(loadErr) && c.policy.NegativeTTL > 0 {
+				writeErr := c.storeNegativeIfCurrent(ctx, key, generation, version, versionKnown)
+				if writeErr != nil && !c.policy.FailOpen {
+					return loadResult[T]{}, errors.Join(loadErr, writeErr)
+				}
+			}
+			return loadResult[T]{}, loadErr
+		}
+		if writeErr := c.storeIfCurrent(ctx, key, loaded, generation, version, versionKnown); writeErr != nil &&
+			!c.policy.FailOpen {
+			return loadResult[T]{}, writeErr
+		}
+		return loadResult[T]{value: loaded}, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return zero, context.Cause(ctx)
+	case result := <-resultChannel:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+		loaded, ok := result.Val.(loadResult[T])
+		if !ok {
+			return zero, fmt.Errorf("%w: invalid coalesced result", ErrCorrupt)
+		}
+		return loaded.value, nil
+	}
+}
+
+// InvalidateVersion applies a monotonic invalidation watermark and suppresses
+// local in-flight loaders. Equal versions are locally observed but do not
+// delete a freshly repopulated backend value; stale versions are ignored.
+func (c *Cache[T]) InvalidateVersion(ctx context.Context, key string, version uint64) (InvalidationState, error) {
+	if c == nil {
+		return 0, fmt.Errorf("%w: cache is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return 0, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if err := validateKey(key); err != nil {
+		return 0, err
+	}
+	if version == 0 {
+		return 0, fmt.Errorf("%w: version is zero", ErrInvalidOption)
+	}
+	if c.version == nil {
+		return 0, ErrVersioningUnsupported
+	}
+	state, err := c.version.ApplyInvalidation(ctx, key, version)
+	if err != nil {
+		c.versionFailures.Add(1)
+		return 0, err
+	}
+	switch state {
+	case InvalidationApplied:
+		c.versionedInvalidations.Add(1)
+	case InvalidationCurrent:
+		c.currentInvalidations.Add(1)
+	case InvalidationStale:
+		c.staleInvalidations.Add(1)
+		return state, nil
+	default:
+		c.versionFailures.Add(1)
+		return 0, fmt.Errorf("%w: invalid backend invalidation state", ErrInvalidOption)
+	}
+	stripe := c.stripe(key)
+	stripe.mu.Lock()
+	stripe.generation.Add(1)
+	c.group.Forget(key)
+	stripe.mu.Unlock()
+	return state, nil
+}
+
+// Set stores one value using the configured positive TTL.
+func (c *Cache[T]) Set(ctx context.Context, key string, value T) error {
+	if c == nil {
+		return fmt.Errorf("%w: cache is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if err := validateKey(key); err != nil {
+		return err
+	}
+	stripe := c.stripe(key)
+	stripe.mu.Lock()
+	defer stripe.mu.Unlock()
+	stripe.generation.Add(1)
+	c.group.Forget(key)
+	return c.store(ctx, key, value)
+}
+
+// Invalidate deletes one or more keys.
+func (c *Cache[T]) Invalidate(ctx context.Context, keys ...string) (int64, error) {
+	if c == nil {
+		return 0, fmt.Errorf("%w: cache is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return 0, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if len(keys) == 0 {
+		return 0, fmt.Errorf("%w: no keys", ErrInvalidOption)
+	}
+	if c.version != nil {
+		return 0, ErrVersionRequired
+	}
+	for _, key := range keys {
+		if err := validateKey(key); err != nil {
+			return 0, err
+		}
+	}
+	stripes := c.lockStripes(keys)
+	defer unlockStripes(stripes)
+	for _, stripe := range stripes {
+		stripe.generation.Add(1)
+	}
+	for _, key := range keys {
+		c.group.Forget(key)
+	}
+	count, err := c.backend.Delete(ctx, keys...)
+	c.invalidations.Add(uint64(len(keys)))
+	return count, err
+}
+
+// ObserveInvalidation applies an invalidation event already committed by
+// another replica. It does not delete the shared backend again or publish a
+// new event.
+//
+// Publishers must delete the backend before broadcasting the event.
+func (c *Cache[T]) ObserveInvalidation(keys ...string) error {
+	if c == nil {
+		return fmt.Errorf("%w: cache is nil", ErrInvalidOption)
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("%w: no keys", ErrInvalidOption)
+	}
+	for _, key := range keys {
+		if err := validateKey(key); err != nil {
+			return err
+		}
+	}
+	stripes := c.lockStripes(keys)
+	defer unlockStripes(stripes)
+	for _, stripe := range stripes {
+		stripe.generation.Add(1)
+	}
+	for _, key := range keys {
+		c.group.Forget(key)
+	}
+	c.observedInvalidations.Add(uint64(len(keys)))
+	return nil
+}
+
+// Description returns consistency counters without cache keys or values.
+func (c *Cache[T]) Description() Description {
+	if c == nil {
+		return Description{}
+	}
+
+	return Description{
+		StaleWritesSuppressed:  c.staleWritesSuppressed.Load(),
+		Invalidations:          c.invalidations.Load(),
+		ObservedInvalidations:  c.observedInvalidations.Load(),
+		VersionedInvalidations: c.versionedInvalidations.Load(),
+		CurrentInvalidations:   c.currentInvalidations.Load(),
+		StaleInvalidations:     c.staleInvalidations.Load(),
+		VersionFailures:        c.versionFailures.Load(),
+	}
+}
+
+func (c *Cache[T]) read(ctx context.Context, key string) (T, bool, error) {
+	var zero T
+	payload, err := c.backend.Get(ctx, key)
+	if errors.Is(err, ErrMiss) {
+		return zero, false, nil
+	}
+	if err != nil {
+		return zero, false, err
+	}
+	if len(payload) == 0 {
+		return zero, false, fmt.Errorf("%w: empty envelope", ErrCorrupt)
+	}
+	switch payload[0] {
+	case envelopeNegative:
+		return zero, true, c.policy.NegativeError
+	case envelopeValue:
+		value, decodeErr := c.codec.Decode(payload[1:])
+		if decodeErr != nil {
+			return zero, false, fmt.Errorf("%w: decode: %w", ErrCorrupt, decodeErr)
+		}
+		return value, true, nil
+	default:
+		return zero, false, fmt.Errorf("%w: unknown envelope %d", ErrCorrupt, payload[0])
+	}
+}
+
+func (c *Cache[T]) store(ctx context.Context, key string, value T) error {
+	payload, err := c.codec.Encode(value)
+	if err != nil {
+		return fmt.Errorf("cache: encode: %w", err)
+	}
+	envelope := make([]byte, len(payload)+1)
+	envelope[0] = envelopeValue
+	copy(envelope[1:], payload)
+	ttl := c.jitter(c.policy.TTL)
+	if c.version == nil {
+		if err := c.backend.Set(ctx, key, envelope, ttl); err != nil {
+			return fmt.Errorf("cache: set: %w", err)
+		}
+		return nil
+	}
+	version, err := c.version.CurrentVersion(ctx, key)
+	if err != nil {
+		c.versionFailures.Add(1)
+		return fmt.Errorf("cache: current version: %w", err)
+	}
+	stored, err := c.version.SetIfVersion(
+		ctx,
+		key,
+		envelope,
+		ttl,
+		version,
+	)
+	if err != nil {
+		return fmt.Errorf("cache: set: %w", err)
+	}
+	if !stored {
+		c.staleWritesSuppressed.Add(1)
+		return ErrStaleWrite
+	}
+
+	return nil
+}
+
+func (c *Cache[T]) storeIfCurrent(ctx context.Context, key string, value T, generation uint64, version uint64, versionKnown bool) error {
+	stripe := c.stripe(key)
+	stripe.mu.Lock()
+	defer stripe.mu.Unlock()
+	if stripe.generation.Load() != generation {
+		c.staleWritesSuppressed.Add(1)
+		return nil
+	}
+	payload, err := c.codec.Encode(value)
+	if err != nil {
+		return fmt.Errorf("cache: encode: %w", err)
+	}
+	envelope := make([]byte, len(payload)+1)
+	envelope[0] = envelopeValue
+	copy(envelope[1:], payload)
+
+	return c.storeEnvelopeIfVersion(
+		ctx,
+		key,
+		envelope,
+		c.jitter(c.policy.TTL),
+		version,
+		versionKnown,
+	)
+}
+
+func (c *Cache[T]) storeNegativeIfCurrent(ctx context.Context, key string, generation uint64, version uint64, versionKnown bool) error {
+	stripe := c.stripe(key)
+	stripe.mu.Lock()
+	defer stripe.mu.Unlock()
+	if stripe.generation.Load() != generation {
+		c.staleWritesSuppressed.Add(1)
+		return nil
+	}
+
+	return c.storeEnvelopeIfVersion(
+		ctx,
+		key,
+		[]byte{envelopeNegative},
+		c.jitter(c.policy.NegativeTTL),
+		version,
+		versionKnown,
+	)
+}
+
+func (c *Cache[T]) currentVersion(ctx context.Context, key string) (uint64, bool, error) {
+	if c.version == nil {
+		return 0, false, nil
+	}
+	version, err := c.version.CurrentVersion(ctx, key)
+	if err != nil {
+		c.versionFailures.Add(1)
+		return 0, false, fmt.Errorf("cache: current version: %w", err)
+	}
+	return version, true, nil
+}
+
+func (c *Cache[T]) storeEnvelopeIfVersion(ctx context.Context, key string, envelope []byte, ttl time.Duration, version uint64, versionKnown bool) error {
+	if c.version == nil {
+		return c.backend.Set(ctx, key, envelope, ttl)
+	}
+	if !versionKnown {
+		// A fail-open read may still return the loader value, but writing
+		// without a known watermark could resurrect data deleted remotely.
+		return nil
+	}
+	stored, err := c.version.SetIfVersion(ctx, key, envelope, ttl, version)
+	if err != nil {
+		return err
+	}
+	if !stored {
+		c.staleWritesSuppressed.Add(1)
+	}
+
+	return nil
+}
+
+// generation returns the generation of the mutation stripe for the given key.
+func (c *Cache[T]) generation(key string) uint64 {
+	return c.stripe(key).generation.Load()
+}
+
+// stripe returns the mutation stripe for the given key.
+func (c *Cache[T]) stripe(key string) *mutationStripe {
+	return &c.mutations[mutationStripeIndex(key)]
+}
+
+// lockStripes locks the mutation stripes for the given keys and returns them in order.
+func (c *Cache[T]) lockStripes(keys []string) []*mutationStripe {
+	indexSet := make(map[int]struct{}, len(keys))
+	for _, key := range keys {
+		indexSet[mutationStripeIndex(key)] = struct{}{}
+	}
+	indices := make([]int, 0, len(indexSet))
+	for index := range indexSet {
+		indices = append(indices, index)
+	}
+	sort.Ints(indices)
+	stripes := make([]*mutationStripe, len(indices))
+	for position, index := range indices {
+		stripe := &c.mutations[index]
+		stripe.mu.Lock()
+		stripes[position] = stripe
+	}
+	return stripes
+}
+
+// unlockStripes unlocks the given stripes in reverse order.
+func unlockStripes(stripes []*mutationStripe) {
+	for index := len(stripes) - 1; index >= 0; index-- {
+		stripes[index].mu.Unlock()
+	}
+}
+
+// mutationStripeIndex returns the index of the mutation stripe for the given key.
+func mutationStripeIndex(key string) int {
+	var hash uint32 = 2166136261
+	for index := range len(key) {
+		hash ^= uint32(key[index])
+		hash *= 16777619
+	}
+	return int(hash % mutationStripes)
+}
+
+func (c *Cache[T]) jitter(ttl time.Duration) time.Duration {
+	if c.policy.JitterRatio == 0 {
+		return ttl
+	}
+	ratio := c.random.Float64()
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio >= 1 {
+		ratio = 0.999999999999
+	}
+	return ttl - time.Duration(
+		float64(ttl)*c.policy.JitterRatio*ratio,
+	)
+}
+
+func validatePolicy(policy Policy) error {
+	if policy.TTL <= 0 {
+		return fmt.Errorf("%w: TTL must be positive", ErrInvalidOption)
+	}
+	if policy.NegativeTTL < 0 {
+		return fmt.Errorf("%w: negative TTL is negative", ErrInvalidOption)
+	}
+	if policy.JitterRatio < 0 || policy.JitterRatio >= 1 {
+		return fmt.Errorf("%w: jitter ratio must be in [0, 1)", ErrInvalidOption)
+	}
+	if policy.NegativeTTL > 0 {
+		if policy.IsNegative == nil || policy.NegativeError == nil {
+			return fmt.Errorf("%w: negative caching requires classifier and stable error", ErrInvalidOption)
+		}
+	}
+	return nil
+}
+
+func validateKey(key string) error {
+	if key == "" || len(key) > maxCacheKeyBytes || strings.TrimSpace(key) != key || !utf8.ValidString(key) {
+		return fmt.Errorf("%w: cache key is invalid", ErrInvalidOption)
+	}
+	for _, character := range key {
+		if unicode.IsControl(character) {
+			return fmt.Errorf("%w: cache key is invalid", ErrInvalidOption)
+		}
+	}
+	return nil
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+type packageRandom struct{}
+
+func (packageRandom) Float64() float64 {
+	return rand.Float64()
+}

--- a/cache/codec.go
+++ b/cache/codec.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"encoding/json"
+
+	"github.com/pelletier/go-toml/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// Codec maps application values to backend payloads.
+type Codec[T any] interface {
+	// Encode serializes value into a backend payload.
+	Encode(T) ([]byte, error)
+	// Decode deserializes a backend payload into value.
+	Decode([]byte) (T, error)
+}
+
+// TOMLCodec encodes cache values with github.com/pelletier/go-toml/v2.
+type TOMLCodec[T any] struct{}
+
+// Encode serializes value as TOML.
+func (TOMLCodec[T]) Encode(value T) ([]byte, error) {
+	return toml.Marshal(value)
+}
+
+// Decode deserializes a TOML value.
+func (TOMLCodec[T]) Decode(payload []byte) (T, error) {
+	var value T
+	err := toml.Unmarshal(payload, &value)
+	return value, err
+}
+
+// JSONCodec encodes cache values with encoding/json.
+type JSONCodec[T any] struct{}
+
+// Encode serializes value as JSON.
+func (JSONCodec[T]) Encode(value T) ([]byte, error) {
+	return json.Marshal(value)
+}
+
+// Decode deserializes a JSON value.
+func (JSONCodec[T]) Decode(payload []byte) (T, error) {
+	var value T
+	err := json.Unmarshal(payload, &value)
+	return value, err
+}
+
+// YAMLCodec encodes cache values with gopkg.in/yaml.v3.
+type YAMLCodec[T any] struct{}
+
+// Encode serializes value as YAML.
+func (YAMLCodec[T]) Encode(value T) ([]byte, error) {
+	return yaml.Marshal(value)
+}
+
+// Decode deserializes a YAML value.
+func (YAMLCodec[T]) Decode(payload []byte) (T, error) {
+	var value T
+	err := yaml.Unmarshal(payload, &value)
+	return value, err
+}

--- a/cache/memory/memory.go
+++ b/cache/memory/memory.go
@@ -1,0 +1,164 @@
+// Package memory provides an in-process implementation of cache.Backend.
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/cache"
+)
+
+var _ cache.VersionedBackend = (*Store)(nil)
+
+// Clock supplies deterministic expiration time.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+}
+
+type entry struct {
+	value     []byte // value is a defensive copy of the cached value.
+	expiresAt time.Time
+}
+
+// Store is a concurrency-safe in-memory cache backend.
+type Store struct {
+	clock Clock
+
+	mu       sync.Mutex
+	entries  map[string]entry  // entries is the map of cached values.
+	versions map[string]uint64 // versions is the map of version numbers.
+}
+
+// New creates an in-memory backend using the system clock.
+func New() *Store {
+	return NewWithClock(systemClock{})
+}
+
+// NewWithClock creates an in-memory backend with an injected clock.
+func NewWithClock(clock Clock) *Store {
+	if clock == nil {
+		clock = systemClock{}
+	}
+	return &Store{
+		clock:    clock,
+		entries:  make(map[string]entry),
+		versions: make(map[string]uint64),
+	}
+}
+
+// Get returns a defensive value copy or cache.ErrMiss.
+func (store *Store) Get(ctx context.Context, key string) ([]byte, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	now := store.clock.Now()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	entry, ok := store.entries[key]
+	if !ok {
+		return nil, cache.ErrMiss
+	}
+	if !entry.expiresAt.IsZero() && !now.Before(entry.expiresAt) {
+		delete(store.entries, key)
+		return nil, cache.ErrMiss
+	}
+	return append([]byte(nil), entry.value...), nil
+}
+
+// Set stores a defensive copy. A zero TTL means no expiration.
+func (store *Store) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	expiresAt := time.Time{}
+	if ttl > 0 {
+		expiresAt = store.clock.Now().Add(ttl)
+	}
+	store.mu.Lock()
+	store.entries[key] = entry{
+		value:     append([]byte(nil), value...),
+		expiresAt: expiresAt,
+	}
+	store.mu.Unlock()
+	return nil
+}
+
+// Delete removes keys and reports how many existed.
+func (store *Store) Delete(ctx context.Context, keys ...string) (int64, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return 0, cause
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	var deleted int64
+	for _, key := range keys {
+		if _, ok := store.entries[key]; ok {
+			delete(store.entries, key)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// CurrentVersion returns the in-process invalidation watermark for key.
+func (store *Store) CurrentVersion(ctx context.Context, key string) (uint64, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return 0, cause
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return store.versions[key], nil
+}
+
+// SetIfVersion stores only while the invalidation watermark is unchanged.
+func (store *Store) SetIfVersion(ctx context.Context, key string, value []byte, ttl time.Duration, expected uint64) (bool, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return false, cause
+	}
+	expiresAt := time.Time{}
+	if ttl > 0 {
+		expiresAt = store.clock.Now().Add(ttl)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.versions[key] != expected {
+		return false, nil
+	}
+	store.entries[key] = entry{
+		value:     append([]byte(nil), value...),
+		expiresAt: expiresAt,
+	}
+	return true, nil
+}
+
+// ApplyInvalidation advances a key watermark and atomically deletes its value.
+func (store *Store) ApplyInvalidation(ctx context.Context, key string, version uint64) (cache.InvalidationState, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return 0, cause
+	}
+	if version == 0 {
+		return 0, fmt.Errorf("%w: version is zero", cache.ErrInvalidOption)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	current := store.versions[key]
+	switch {
+	case version > current:
+		store.versions[key] = version
+		delete(store.entries, key)
+		return cache.InvalidationApplied, nil
+	case version == current:
+		return cache.InvalidationCurrent, nil
+	default:
+		return cache.InvalidationStale, nil
+	}
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}

--- a/cache/options.go
+++ b/cache/options.go
@@ -1,0 +1,40 @@
+package cache
+
+import "fmt"
+
+// Option configures Cache internals.
+type Option interface {
+	// apply applies the option to the given settings.
+	apply(*settings) error
+}
+
+type optionFunc func(*settings) error
+
+func (f optionFunc) apply(settings *settings) error {
+	return f(settings)
+}
+
+type settings struct {
+	random     Random // random source for TTL jitter
+	versioning bool   // enable atomic backend invalidation watermarks
+}
+
+// WithRandom replaces the default TTL jitter source.
+func WithRandom(random Random) Option {
+	return optionFunc(func(settings *settings) error {
+		if isNil(random) {
+			return fmt.Errorf("random source is nil")
+		}
+		settings.random = random
+		return nil
+	})
+}
+
+// WithVersioning requires atomic backend invalidation watermarks. Redis keys
+// using this option must follow the adapter's cluster-safe key rules.
+func WithVersioning() Option {
+	return optionFunc(func(settings *settings) error {
+		settings.versioning = true
+		return nil
+	})
+}

--- a/cache/policy.go
+++ b/cache/policy.go
@@ -1,0 +1,33 @@
+package cache
+
+import (
+	"errors"
+	"time"
+)
+
+// NegativeClassifier identifies safe-to-cache absent results.
+type NegativeClassifier func(error) bool
+
+// Policy defines read-through and expiration behavior.
+type Policy struct {
+	TTL           time.Duration      // TTL is the time-to-live for cache entries.
+	NegativeTTL   time.Duration      // NegativeTTL is the time-to-live for negative cache entries.
+	JitterRatio   float64            // JitterRatio is the ratio of TTL jitter to apply.
+	FailOpen      bool               // FailOpen indicates whether to fail open on cache errors.
+	IsNegative    NegativeClassifier // IsNegative is the negative classifier function.
+	NegativeError error              // NegativeError is the error to return for negative cache entries.
+}
+
+// DefaultPolicy returns a safe read-through baseline.
+func DefaultPolicy() Policy {
+	return Policy{
+		TTL:         5 * time.Minute,
+		NegativeTTL: 30 * time.Second,
+		JitterRatio: 0.1,
+		FailOpen:    true,
+		IsNegative: func(err error) bool {
+			return errors.Is(err, ErrNotFound)
+		},
+		NegativeError: ErrNotFound,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/keelab/keelith
 
 go 1.26.3
+
+require (
+	github.com/pelletier/go-toml/v2 v2.2.4
+	golang.org/x/sync v0.22.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## 变更概述

- 添加类型化读穿缓存包及内存缓存实现，支持负缓存、TTL、singleflight、统计与版本化失效保护
- 添加显式应用生命周期编排与组件依赖管理
- 支持服务器启动/退出监控、优雅停止、生命周期状态与健康状态同步
- 增强组件图校验，覆盖空组件、重复名称、非法依赖、自依赖与循环依赖

## 提交

- feat: 添加类型化的读穿缓存包
- feat: 添加显式应用生命周期编排

## Testing

Not run (not requested)