### PR TITLE
feat: add background runtime primitives

### DIFF
--- a/cache/invalidation/event.go
+++ b/cache/invalidation/event.go
@@ -1,0 +1,120 @@
+// Package invalidation defines versioned cache invalidation events and a
+// Worker-compatible processor.
+package invalidation
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// SchemaVersion is the current JSON invalidation event schema.
+	SchemaVersion = 1
+
+	maxNamespaceBytes = 256
+	maxKeyBytes       = 1024
+	maxEntries        = 128
+	maxPayloadBytes   = 256 * 1024
+)
+
+var (
+	// ErrInvalidEvent reports an unknown schema or malformed event.
+	ErrInvalidEvent = errors.New("cache invalidation: invalid event")
+	// ErrPayloadTooLarge reports an event beyond the decoder budget.
+	ErrPayloadTooLarge = errors.New("cache invalidation: payload too large")
+)
+
+// Entry advances one cache key to a datastore-derived monotonic version.
+type Entry struct {
+	Key     string `json:"key"`
+	Version uint64 `json:"version"`
+}
+
+// Event groups a bounded set of keys for one cache namespace.
+type Event struct {
+	Schema    int     `json:"schema"`
+	Namespace string  `json:"namespace"`
+	Entries   []Entry `json:"entries"`
+}
+
+// Validate rejects ambiguous namespaces, duplicate keys, and zero versions.
+func (e Event) Validate() error {
+	if e.Schema != SchemaVersion || !validIdentity(e.Namespace, maxNamespaceBytes) || len(e.Entries) == 0 || len(e.Entries) > maxEntries {
+		return fmt.Errorf("%w: event envelope", ErrInvalidEvent)
+	}
+	seen := make(map[string]struct{}, len(e.Entries))
+	for _, entry := range e.Entries {
+		if !validIdentity(entry.Key, maxKeyBytes) || entry.Version == 0 {
+			return fmt.Errorf("%w: entry", ErrInvalidEvent)
+		}
+		if _, exists := seen[entry.Key]; exists {
+			return fmt.Errorf("%w: duplicate key", ErrInvalidEvent)
+		}
+		seen[entry.Key] = struct{}{}
+	}
+	return nil
+}
+
+// Encode validates and serializes one event.
+func Encode(event Event) ([]byte, error) {
+	if err := event.Validate(); err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return nil, fmt.Errorf("cache invalidation: encode: %w", err)
+	}
+	if len(payload) > maxPayloadBytes {
+		return nil, ErrPayloadTooLarge
+	}
+	return payload, nil
+}
+
+// Decode strictly parses one bounded event and rejects unknown fields.
+func Decode(payload []byte) (Event, error) {
+	if len(payload) == 0 {
+		return Event{}, fmt.Errorf("%w: empty payload", ErrInvalidEvent)
+	}
+	if len(payload) > maxPayloadBytes {
+		return Event{}, ErrPayloadTooLarge
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var event Event
+	if err := decoder.Decode(&event); err != nil {
+		return Event{}, fmt.Errorf("cache invalidation: decode: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = ErrInvalidEvent
+		}
+		return Event{}, fmt.Errorf("cache invalidation: trailing data: %w", err)
+	}
+	if err := event.Validate(); err != nil {
+		return Event{}, err
+	}
+	event.Entries = append([]Entry(nil), event.Entries...)
+	return event, nil
+}
+
+func validIdentity(value string, maxBytes int) bool {
+	if value == "" ||
+		len(value) > maxBytes ||
+		strings.TrimSpace(value) != value ||
+		!utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}

--- a/cache/invalidation/processor.go
+++ b/cache/invalidation/processor.go
@@ -1,0 +1,154 @@
+package invalidation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"time"
+
+	"github.com/keelab/keelith/cache"
+	"github.com/keelab/keelith/worker"
+)
+
+const defaultRetryAfter = time.Second
+
+var (
+	// ErrInvalidOption reports an incomplete Processor configuration.
+	ErrInvalidOption = errors.New("cache invalidation: invalid option")
+	errTargetPanic   = errors.New("cache invalidation: target panicked")
+)
+
+// Target atomically applies versioned invalidation entries.
+type Target interface {
+	InvalidateVersion(context.Context, string, uint64) (cache.InvalidationState, error)
+}
+
+// Config constructs one namespace-bound Processor.
+type Config struct {
+	Namespace  string
+	Target     Target
+	RetryAfter time.Duration
+}
+
+// Description is a key- and payload-free processing snapshot.
+type Description struct {
+	Applied  uint64
+	Current  uint64
+	Stale    uint64
+	Failures uint64
+	Invalid  uint64
+	Panics   uint64
+}
+
+// Processor decodes invalidation events into a worker disposition.
+type Processor struct {
+	namespace  string
+	target     Target
+	retryAfter time.Duration
+
+	applied  atomic.Uint64
+	current  atomic.Uint64
+	stale    atomic.Uint64
+	failures atomic.Uint64
+	invalid  atomic.Uint64
+	panics   atomic.Uint64
+}
+
+// New constructs a Processor for exactly one cache namespace.
+func New(config Config) (*Processor, error) {
+	if !validIdentity(config.Namespace, maxNamespaceBytes) || isNil(config.Target) {
+		return nil, fmt.Errorf("%w: namespace or target", ErrInvalidOption)
+	}
+	if config.RetryAfter == 0 {
+		config.RetryAfter = defaultRetryAfter
+	}
+	if config.RetryAfter < 0 {
+		return nil, fmt.Errorf("%w: retry delay", ErrInvalidOption)
+	}
+	return &Processor{
+		namespace:  config.Namespace,
+		target:     config.Target,
+		retryAfter: config.RetryAfter,
+	}, nil
+}
+
+// Handle applies every entry. A partial backend failure is safe to retry:
+// already-applied versions become Current on the next delivery.
+func (processor *Processor) Handle(ctx context.Context, message worker.Message) worker.Result {
+	if processor == nil || ctx == nil {
+		return worker.Nack(fmt.Errorf("%w: processor or context", ErrInvalidOption))
+	}
+	event, err := Decode(message.Payload())
+	if err != nil || event.Namespace != processor.namespace {
+		processor.invalid.Add(1)
+		if err == nil {
+			err = fmt.Errorf("%w: namespace mismatch", ErrInvalidEvent)
+		}
+		return worker.DeadLetter(err)
+	}
+	for _, entry := range event.Entries {
+		state, applyErr := processor.apply(
+			ctx,
+			entry.Key,
+			entry.Version,
+		)
+		if applyErr != nil {
+			processor.failures.Add(1)
+			return worker.Retry(fmt.Errorf("cache invalidation: apply: %w", applyErr), processor.retryAfter)
+		}
+		switch state {
+		case cache.InvalidationApplied:
+			processor.applied.Add(1)
+		case cache.InvalidationCurrent:
+			processor.current.Add(1)
+		case cache.InvalidationStale:
+			processor.stale.Add(1)
+		default:
+			processor.failures.Add(1)
+			return worker.Nack(fmt.Errorf("%w: target state", ErrInvalidOption))
+		}
+	}
+	return worker.Ack()
+}
+
+// Description returns bounded result counters.
+func (processor *Processor) Description() Description {
+	if processor == nil {
+		return Description{}
+	}
+	return Description{
+		Applied:  processor.applied.Load(),
+		Current:  processor.current.Load(),
+		Stale:    processor.stale.Load(),
+		Failures: processor.failures.Load(),
+		Invalid:  processor.invalid.Load(),
+		Panics:   processor.panics.Load(),
+	}
+}
+
+func (processor *Processor) apply(ctx context.Context, key string, version uint64) (state cache.InvalidationState, err error) {
+	defer func() {
+		if recover() != nil {
+			processor.panics.Add(1)
+			state = 0
+			err = errTargetPanic
+		}
+	}()
+	return processor.target.InvalidateVersion(ctx, key, version)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/coordination/coordination.go
+++ b/coordination/coordination.go
@@ -1,0 +1,57 @@
+package coordination
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrInvalidOption reports an invalid coordinator, key, or lease budget.
+	ErrInvalidOption = errors.New("coordination: invalid option")
+	// ErrLeaseLost reports that ownership ended before explicit Release.
+	ErrLeaseLost = errors.New("coordination: lease lost")
+)
+
+// Lease represents actively maintained ownership of one stable key.
+//
+// Done closes when ownership is lost or the lease is explicitly released.
+// Err returns nil after a successful Release and a stable cause after loss.
+type Lease interface {
+	// Fence is a positive, monotonically increasing ownership generation for
+	// this key. Downstream writes can reject a generation older than the last
+	// accepted value.
+	Fence() uint64
+	Done() <-chan struct{}
+	Err() error
+	Release(context.Context) error
+}
+
+// Coordinator attempts to acquire one auto-maintained lease.
+//
+// acquired=false is normal contention and returns a nil Lease and nil error.
+// ttl is the maximum backend outage window before ownership must be considered
+// lost; implementations renew an acquired lease until Release.
+type Coordinator interface {
+	TryAcquire(context.Context, string, time.Duration) (lease Lease, acquired bool, err error)
+}
+
+type fenceContextKey struct{}
+
+// WithFence adds one positive ownership generation to a Handler context.
+func WithFence(ctx context.Context, fence uint64) context.Context {
+	if ctx == nil || fence == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, fenceContextKey{}, fence)
+}
+
+// FenceFromContext obtains an ownership generation without exposing a
+// coordinator implementation to business code.
+func FenceFromContext(ctx context.Context) (uint64, bool) {
+	if ctx == nil {
+		return 0, false
+	}
+	fence, ok := ctx.Value(fenceContextKey{}).(uint64)
+	return fence, ok && fence > 0
+}

--- a/coordination/doc.go
+++ b/coordination/doc.go
@@ -1,0 +1,10 @@
+// Package coordination defines small distributed ownership contracts:
+// try to acquire an auto-maintained lease for a stable key, observe loss via
+// Done/Err, and carry a fencing token on Handler contexts.
+//
+// The coordination/memory subpackage is a process-local stand-in for
+// development and contract tests. It simulates mutual exclusion inside one
+// process only; it is not a cross-process or cluster-wide lease service, does
+// not renew or expire leases by TTL, and must not be used as production
+// distributed ownership.
+package coordination

--- a/coordination/memory/memory.go
+++ b/coordination/memory/memory.go
@@ -1,0 +1,162 @@
+// Package memory provides process-local coordination for development and
+// contract verification. It is not a distributed ownership implementation.
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/keelab/keelith/coordination"
+)
+
+// Description is a value-free coordinator snapshot.
+type Description struct {
+	Active   int
+	Acquired uint64
+	Rejected uint64
+	Released uint64
+}
+
+// Coordinator owns in-process lease keys.
+type Coordinator struct {
+	mu       sync.Mutex
+	leases   map[string]*lease
+	fences   map[string]uint64
+	acquired uint64
+	rejected uint64
+	released uint64
+}
+
+// New constructs an empty process-local Coordinator.
+func New() *Coordinator {
+	return &Coordinator{
+		leases: make(map[string]*lease),
+		fences: make(map[string]uint64),
+	}
+}
+
+// TryAcquire atomically acquires key when no local owner exists.
+func (c *Coordinator) TryAcquire(ctx context.Context, key string, ttl time.Duration) (coordination.Lease, bool, error) {
+	if c == nil {
+		return nil, false, fmt.Errorf("%w: coordinator is nil", coordination.ErrInvalidOption)
+	}
+	if ctx == nil || ttl <= 0 || !validKey(key) {
+		return nil, false, fmt.Errorf("%w: context, key, or TTL", coordination.ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, false, cause
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.leases[key]; exists {
+		c.rejected++
+		return nil, false, nil
+	}
+	c.fences[key]++
+	acquired := &lease{
+		coordinator: c,
+		key:         key,
+		fence:       c.fences[key],
+		done:        make(chan struct{}),
+	}
+	c.leases[key] = acquired
+	c.acquired++
+	return acquired, true, nil
+}
+
+// Description returns bounded aggregate counters.
+func (c *Coordinator) Description() Description {
+	if c == nil {
+		return Description{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return Description{
+		Active:   len(c.leases),
+		Acquired: c.acquired,
+		Rejected: c.rejected,
+		Released: c.released,
+	}
+}
+
+type lease struct {
+	coordinator *Coordinator
+	key         string
+	fence       uint64
+	done        chan struct{}
+
+	mu      sync.Mutex
+	err     error
+	release sync.Once
+}
+
+func (lease *lease) Fence() uint64 {
+	if lease == nil {
+		return 0
+	}
+	return lease.fence
+}
+
+func (lease *lease) Done() <-chan struct{} {
+	if lease == nil {
+		return closed()
+	}
+	return lease.done
+}
+
+func (lease *lease) Err() error {
+	if lease == nil {
+		return coordination.ErrLeaseLost
+	}
+	lease.mu.Lock()
+	defer lease.mu.Unlock()
+	return lease.err
+}
+
+func (lease *lease) Release(ctx context.Context) error {
+	if lease == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", coordination.ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	lease.release.Do(func() {
+		lease.coordinator.mu.Lock()
+		if lease.coordinator.leases[lease.key] == lease {
+			delete(lease.coordinator.leases, lease.key)
+			lease.coordinator.released++
+		}
+		lease.coordinator.mu.Unlock()
+		close(lease.done)
+	})
+
+	return lease.Err()
+}
+
+func validKey(value string) bool {
+	if value == "" || len(value) > 512 || strings.TrimSpace(value) != value || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func closed() <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}

--- a/metadata/carrier.go
+++ b/metadata/carrier.go
@@ -1,0 +1,236 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+)
+
+type inboundContextKey struct{}
+type outboundContextKey struct{}
+type localContextKey struct{}
+
+// WithInbound attaches immutable inbound Metadata to ctx.
+func WithInbound(ctx context.Context, metadata Metadata) context.Context {
+	return context.WithValue(ctx, inboundContextKey{}, metadata.Clone())
+}
+
+// Inbound returns an independent copy of inbound Metadata.
+func Inbound(ctx context.Context) (Metadata, bool) {
+	metadata, ok := ctx.Value(inboundContextKey{}).(Metadata)
+	if !ok {
+		return Metadata{}, false
+	}
+	return metadata.Clone(), true
+}
+
+// WithOutbound attaches immutable outbound Metadata to ctx.
+func WithOutbound(ctx context.Context, metadata Metadata) context.Context {
+	return context.WithValue(ctx, outboundContextKey{}, metadata.Clone())
+}
+
+// Outbound returns an independent copy of outbound Metadata.
+func Outbound(ctx context.Context) (Metadata, bool) {
+	metadata, ok := ctx.Value(outboundContextKey{}).(Metadata)
+	if !ok {
+		return Metadata{}, false
+	}
+	return metadata.Clone(), true
+}
+
+// WithLocal attaches local-only Metadata to ctx.
+func WithLocal(ctx context.Context, metadata Metadata) context.Context {
+	return context.WithValue(ctx, localContextKey{}, metadata.Clone())
+}
+
+// Local returns an independent copy of local-only Metadata.
+func Local(ctx context.Context) (Metadata, bool) {
+	metadata, ok := ctx.Value(localContextKey{}).(Metadata)
+	if !ok {
+		return Metadata{}, false
+	}
+	return metadata.Clone(), true
+}
+
+// Carrier is the minimal multi-value transport carrier used by Policy.
+type Carrier interface {
+	Values(string) []string
+	Set(string, []string)
+}
+
+// MapCarrier adapts a normalized map to Carrier.
+//
+// Callers that inject metadata must initialize the map.
+type MapCarrier map[string][]string
+
+// Values returns a defensive copy of a normalized carrier value.
+func (c MapCarrier) Values(key string) []string {
+	normalized, err := normalizeKey(key)
+	if err != nil {
+		return nil
+	}
+	values, exists := c[normalized]
+	if !exists {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+// Set writes a defensive copy under a normalized key.
+func (c MapCarrier) Set(key string, values []string) {
+	normalized, err := normalizeKey(key)
+	if err != nil || c == nil {
+		return
+	}
+	c[normalized] = append([]string(nil), values...)
+}
+
+// Policy is an immutable allowlist and byte budget for transport propagation.
+type Policy struct {
+	allowed   []string
+	sensitive map[string]struct{}
+	maxBytes  int
+}
+
+// PolicyOption configures a propagation Policy.
+type PolicyOption interface {
+	applyPolicy(*policyOptions) error
+}
+
+type policyOptionFunc func(*policyOptions) error
+
+func (function policyOptionFunc) applyPolicy(options *policyOptions) error {
+	return function(options)
+}
+
+type policyOptions struct {
+	sensitive map[string]struct{}
+	maxBytes  int
+}
+
+// WithSensitiveKeys marks allowed propagation keys as sensitive.
+func WithSensitiveKeys(keys ...string) PolicyOption {
+	snapshot := append([]string(nil), keys...)
+	return policyOptionFunc(func(options *policyOptions) error {
+		for _, key := range snapshot {
+			normalized, err := normalizeKey(key)
+			if err != nil {
+				return err
+			}
+			options.sensitive[normalized] = struct{}{}
+		}
+		return nil
+	})
+}
+
+// WithPolicyMaxBytes sets the maximum propagated key/value bytes.
+func WithPolicyMaxBytes(maxBytes int) PolicyOption {
+	return policyOptionFunc(func(options *policyOptions) error {
+		if maxBytes < 0 {
+			return fmt.Errorf("%w: policy max bytes must not be negative", ErrInvalidOption)
+		}
+		options.maxBytes = maxBytes
+		return nil
+	})
+}
+
+// NewPolicy constructs an immutable default-deny propagation policy.
+func NewPolicy(allowed []string, options ...PolicyOption) (Policy, error) {
+	settings := policyOptions{
+		sensitive: make(map[string]struct{}),
+		maxBytes:  DefaultMaxBytes,
+	}
+	for index, option := range options {
+		if option == nil {
+			return Policy{}, fmt.Errorf("%w: policy option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyPolicy(&settings); err != nil {
+			return Policy{}, fmt.Errorf("metadata policy option %d: %w", index, err)
+		}
+	}
+
+	normalizedAllowed := make([]string, 0, len(allowed))
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		normalized, err := normalizeKey(key)
+		if err != nil {
+			return Policy{}, err
+		}
+		if _, duplicate := allowedSet[normalized]; duplicate {
+			return Policy{}, fmt.Errorf("%w: duplicate normalized allowlist key %q", ErrInvalidKey, normalized)
+		}
+		allowedSet[normalized] = struct{}{}
+		normalizedAllowed = append(normalizedAllowed, normalized)
+	}
+	for key := range settings.sensitive {
+		if _, allowed := allowedSet[key]; !allowed {
+			return Policy{}, fmt.Errorf("%w: sensitive key %q is not allowlisted", ErrInvalidOption, key)
+		}
+	}
+
+	return Policy{
+		allowed:   normalizedAllowed,
+		sensitive: cloneSet(settings.sensitive),
+		maxBytes:  settings.maxBytes,
+	}, nil
+}
+
+// Extract copies only allowlisted fields from carrier.
+func (p Policy) Extract(carrier Carrier) (Metadata, error) {
+	if isNilCarrier(carrier) {
+		return Metadata{}, ErrNilCarrier
+	}
+	values := make(map[string][]string, len(p.allowed))
+	for _, key := range p.allowed {
+		if extracted := carrier.Values(key); extracted != nil {
+			values[key] = extracted
+		}
+	}
+	return New(
+		values,
+		WithMaxBytes(p.maxBytes),
+		WithSensitive(setValues(p.sensitive)...),
+	)
+}
+
+// Inject copies only allowlisted fields into carrier.
+func (p Policy) Inject(metadata Metadata, carrier Carrier) error {
+	if isNilCarrier(carrier) {
+		return ErrNilCarrier
+	}
+	values := make(map[string][]string, len(p.allowed))
+	for _, key := range p.allowed {
+		if propagated := metadata.Values(key); propagated != nil {
+			values[key] = propagated
+		}
+	}
+	validated, err := New(values, WithMaxBytes(p.maxBytes))
+	if err != nil {
+		return err
+	}
+	for _, key := range validated.Keys() {
+		carrier.Set(key, validated.Values(key))
+	}
+	return nil
+}
+
+func setValues(set map[string]struct{}) []string {
+	values := make([]string, 0, len(set))
+	for value := range set {
+		values = append(values, value)
+	}
+	return values
+}
+
+func isNilCarrier(carrier Carrier) bool {
+	if carrier == nil {
+		return true
+	}
+	value := reflect.ValueOf(carrier)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/metadata/metadatea.go
+++ b/metadata/metadatea.go
@@ -1,0 +1,223 @@
+// Package metadata provides immutable request metadata and explicit
+// propagation policies.
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// DefaultMaxBytes is the default metadata key/value budget.
+	DefaultMaxBytes = 8 * 1024
+)
+
+var (
+	// ErrInvalidKey means a metadata key cannot be normalized safely.
+	ErrInvalidKey = errors.New("metadata: invalid key")
+	// ErrTooLarge means metadata exceeds its configured byte budget.
+	ErrTooLarge = errors.New("metadata: size limit exceeded")
+	// ErrInvalidOption means a metadata option is invalid.
+	ErrInvalidOption = errors.New("metadata: invalid option")
+	// ErrNilCarrier means a propagation Carrier is nil.
+	ErrNilCarrier = errors.New("metadata: nil carrier")
+)
+
+// Metadata is an immutable collection of normalized multi-value metadata.
+type Metadata struct {
+	values    map[string][]string
+	sensitive map[string]struct{}
+}
+
+// Option configures Metadata construction.
+type Option interface {
+	apply(*metadataOptions) error
+}
+
+type optionFunc func(*metadataOptions) error
+
+func (function optionFunc) apply(options *metadataOptions) error {
+	return function(options)
+}
+
+type metadataOptions struct {
+	maxBytes  int
+	sensitive map[string]struct{}
+}
+
+// WithMaxBytes sets the maximum combined key/value bytes.
+func WithMaxBytes(maxBytes int) Option {
+	return optionFunc(func(options *metadataOptions) error {
+		if maxBytes < 0 {
+			return fmt.Errorf("%w: max bytes must not be negative", ErrInvalidOption)
+		}
+		options.maxBytes = maxBytes
+		return nil
+	})
+}
+
+// WithSensitive marks keys for redaction without granting propagation rights.
+func WithSensitive(keys ...string) Option {
+	snapshot := append([]string(nil), keys...)
+	return optionFunc(func(options *metadataOptions) error {
+		for _, key := range snapshot {
+			normalized, err := normalizeKey(key)
+			if err != nil {
+				return err
+			}
+			options.sensitive[normalized] = struct{}{}
+		}
+		return nil
+	})
+}
+
+// New constructs immutable Metadata and enforces its byte budget.
+func New(values map[string][]string, options ...Option) (Metadata, error) {
+	settings := metadataOptions{
+		maxBytes:  DefaultMaxBytes,
+		sensitive: make(map[string]struct{}),
+	}
+	for index, option := range options {
+		if option == nil {
+			return Metadata{}, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return Metadata{}, fmt.Errorf("metadata option %d: %w", index, err)
+		}
+	}
+
+	result := Metadata{
+		values:    make(map[string][]string, len(values)),
+		sensitive: cloneSet(settings.sensitive),
+	}
+	size := 0
+	for key, sourceValues := range values {
+		normalized, err := normalizeKey(key)
+		if err != nil {
+			return Metadata{}, err
+		}
+		if _, exists := result.values[normalized]; exists {
+			return Metadata{}, fmt.Errorf("%w: duplicate normalized key %q", ErrInvalidKey, normalized)
+		}
+
+		size, err = addSize(size, len(normalized), settings.maxBytes)
+		if err != nil {
+			return Metadata{}, err
+		}
+		clonedValues := make([]string, len(sourceValues))
+		for index, value := range sourceValues {
+			size, err = addSize(size, len(value), settings.maxBytes)
+			if err != nil {
+				return Metadata{}, err
+			}
+			clonedValues[index] = value
+		}
+		result.values[normalized] = clonedValues
+	}
+	return result, nil
+}
+
+// Values returns an independent copy of every value for key.
+func (m Metadata) Values(key string) []string {
+	normalized, err := normalizeKey(key)
+	if err != nil {
+		return nil
+	}
+	values, exists := m.values[normalized]
+	if !exists {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+// Keys returns normalized keys in lexical order.
+func (m Metadata) Keys() []string {
+	keys := make([]string, 0, len(m.values))
+	for key := range m.values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Clone returns a deep immutable copy.
+func (m Metadata) Clone() Metadata {
+	return Metadata{
+		values:    cloneValues(m.values),
+		sensitive: cloneSet(m.sensitive),
+	}
+}
+
+// IsSensitive reports whether key must be redacted in diagnostic output.
+func (m Metadata) IsSensitive(key string) bool {
+	normalized, err := normalizeKey(key)
+	if err != nil {
+		return false
+	}
+	_, exists := m.sensitive[normalized]
+	return exists
+}
+
+// Redacted returns an independent map with sensitive values replaced.
+func (m Metadata) Redacted(replacement string) map[string][]string {
+	result := cloneValues(m.values)
+	for key := range m.sensitive {
+		values, exists := result[key]
+		if !exists {
+			continue
+		}
+		for index := range values {
+			values[index] = replacement
+		}
+	}
+	return result
+}
+
+func normalizeKey(key string) (string, error) {
+	if key == "" {
+		return "", fmt.Errorf("%w: key is empty", ErrInvalidKey)
+	}
+	normalized := strings.ToLower(key)
+	for _, character := range normalized {
+		valid := character >= 'a' && character <= 'z' ||
+			character >= '0' && character <= '9' ||
+			character == '-' ||
+			character == '_' ||
+			character == '.'
+		if !valid {
+			return "", fmt.Errorf("%w: %q", ErrInvalidKey, key)
+		}
+	}
+	return normalized, nil
+}
+
+func addSize(current, additional, limit int) (int, error) {
+	if additional > limit-current {
+		return 0, fmt.Errorf("%w: at least %d bytes exceeds %d", ErrTooLarge, current+additional, limit)
+	}
+	return current + additional, nil
+}
+
+func cloneValues(source map[string][]string) map[string][]string {
+	if len(source) == 0 {
+		return nil
+	}
+	clone := make(map[string][]string, len(source))
+	for key, values := range source {
+		clone[key] = append([]string(nil), values...)
+	}
+	return clone
+}
+
+func cloneSet(source map[string]struct{}) map[string]struct{} {
+	if len(source) == 0 {
+		return nil
+	}
+	clone := make(map[string]struct{}, len(source))
+	for value := range source {
+		clone[value] = struct{}{}
+	}
+	return clone
+}

--- a/middleware/bundle.go
+++ b/middleware/bundle.go
@@ -1,0 +1,156 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/keelab/keelith/operation"
+)
+
+const explicitSource = "explicit"
+
+var (
+	// ErrInvalidEntry means a Bundle entry is incomplete or ambiguous.
+	ErrInvalidEntry = errors.New("middleware: invalid bundle entry")
+)
+
+// Entry names a Middleware and records the configuration source that enabled
+// it.
+type Entry struct {
+	Name       string
+	Source     string
+	Middleware Middleware
+}
+
+// ScopeToService returns a namespaced Bundle whose entries execute only when
+// the current Operation belongs to service. The original Bundle is unchanged
+// and can be reused by multiple generated service bindings.
+func ScopeToService(service string, bundle *Bundle) (*Bundle, error) {
+	return ScopeToServiceWithNamespace(service, service, bundle)
+}
+
+// ScopeToServiceWithNamespace behaves like ScopeToService and uses namespace
+// as the diagnostic Entry prefix. It allows higher-level immutable groups to
+// distinguish inherited policy from Binding-specific policy.
+func ScopeToServiceWithNamespace(namespace string, service string, bundle *Bundle) (*Bundle, error) {
+	if strings.TrimSpace(namespace) != namespace || namespace == "" {
+		return nil, fmt.Errorf("%w: namespace is empty or not normalized", ErrInvalidEntry)
+	}
+	if strings.TrimSpace(service) != service || service == "" {
+		return nil, fmt.Errorf("%w: service scope is empty or not normalized", ErrInvalidEntry)
+	}
+	if bundle == nil {
+		return nil, nil
+	}
+	entries := make([]Entry, len(bundle.entries))
+
+	for index, entry := range bundle.entries {
+		entries[index] = Entry{
+			Name:       namespace + "/" + entry.Name,
+			Source:     entry.Source,
+			Middleware: scopeMiddlewareToService(service, entry.Middleware),
+		}
+	}
+	return NewBundle(entries...)
+}
+
+func scopeMiddlewareToService(service string, scoped Middleware) Middleware {
+	return func(next Handler) Handler {
+		handler := scoped(next)
+		return func(ctx context.Context, request any) (any, error) {
+			target, ok := operation.FromContext(ctx)
+			if !ok || target.Service() != service {
+				return next(ctx, request)
+			}
+			return handler(ctx, request)
+		}
+	}
+}
+
+// Description is an immutable diagnostic projection of one Bundle entry.
+type Description struct {
+	Position int
+	Name     string
+	Source   string
+}
+
+// Bundle is an immutable, inspectable middleware chain.
+type Bundle struct {
+	entries []Entry
+}
+
+// NewBundle validates and copies entries.
+func NewBundle(entries ...Entry) (*Bundle, error) {
+	snapshot := make([]Entry, 0, len(entries))
+	names := make(map[string]struct{}, len(entries))
+
+	for index, entry := range entries {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			return nil, fmt.Errorf("%w: entry %d has an empty name", ErrInvalidEntry, index)
+		}
+		if entry.Middleware == nil {
+			return nil, fmt.Errorf("%w: entry %q has a nil middleware", ErrInvalidEntry, name)
+		}
+		if _, duplicate := names[name]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate name %q", ErrInvalidEntry, name)
+		}
+		names[name] = struct{}{}
+
+		source := strings.TrimSpace(entry.Source)
+		if source == "" {
+			source = explicitSource
+		}
+		snapshot = append(snapshot, Entry{
+			Name:       name,
+			Source:     source,
+			Middleware: entry.Middleware,
+		})
+	}
+	return &Bundle{entries: snapshot}, nil
+}
+
+// CombineBundles creates one auditable Bundle by concatenating entries in
+// argument order. Nil bundles are ignored and duplicate names are rejected.
+func CombineBundles(bundles ...*Bundle) (*Bundle, error) {
+	entries := make([]Entry, 0)
+
+	for _, bundle := range bundles {
+		if bundle == nil {
+			continue
+		}
+		entries = append(entries, bundle.entries...)
+	}
+	return NewBundle(entries...)
+}
+
+// Chain returns this Bundle as a composable Middleware.
+func (b *Bundle) Chain() Middleware {
+	if b == nil {
+		return Chain()
+	}
+	middlewares := make([]Middleware, len(b.entries))
+
+	for index, entry := range b.entries {
+		middlewares[index] = entry.Middleware
+	}
+	return Chain(middlewares...)
+}
+
+// Describe returns entries in final execution order.
+func (b *Bundle) Describe() []Description {
+	if b == nil {
+		return nil
+	}
+	description := make([]Description, len(b.entries))
+	for index, entry := range b.entries {
+		description[index] = Description{
+			Position: index,
+			Name:     entry.Name,
+			Source:   entry.Source,
+		}
+	}
+	return description
+}

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -1,0 +1,16 @@
+package middleware
+
+// Chain composes middleware in declaration order.
+//
+// The first middleware is the outermost invocation. Chain deliberately does
+// not recover panics; recovery is an explicit middleware.
+func Chain(middlewares ...Middleware) Middleware {
+	snapshot := append([]Middleware(nil), middlewares...)
+	return func(final Handler) Handler {
+		handler := final
+		for index := len(snapshot) - 1; index >= 0; index-- {
+			handler = snapshot[index](handler)
+		}
+		return handler
+	}
+}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,0 +1,10 @@
+// Package middleware defines Keelith's transport-neutral invocation model.
+package middleware
+
+import "context"
+
+// Handler executes one transport-neutral request.
+type Handler func(context.Context, any) (any, error)
+
+// Middleware wraps a Handler.
+type Middleware func(Handler) Handler

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -1,0 +1,155 @@
+// Package operation defines stable identities for transport-neutral calls.
+package operation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var (
+	// ErrInvalid means an Operation component is missing or malformed.
+	ErrInvalid = errors.New("operation: invalid operation")
+)
+
+// Kind identifies an invocation shape.
+type Kind string
+
+const (
+	// KindUnary is a single request and single response.
+	KindUnary Kind = "unary"
+	// KindClientStream is a streamed request and single response.
+	KindClientStream Kind = "client-stream"
+	// KindServerStream is a single request and streamed response.
+	KindServerStream Kind = "server-stream"
+	// KindBidiStream is a bidirectional stream.
+	KindBidiStream Kind = "bidi-stream"
+	// KindConsumer is a message consumer invocation.
+	KindConsumer Kind = "consumer"
+	// KindJob is a scheduled or ad hoc job invocation.
+	KindJob Kind = "job"
+)
+
+// Operation is an immutable, low-cardinality call identity.
+type Operation struct {
+	transport string
+	service   string
+	method    string
+	kind      Kind
+}
+
+// New validates and constructs an Operation.
+func New(transport, service, method string, kind Kind) (Operation, error) {
+	normalizedTransport := strings.ToLower(transport)
+	if !validTransport(normalizedTransport) {
+		return Operation{}, fmt.Errorf("%w: transport %q", ErrInvalid, transport)
+	}
+	if !validComponent(service) {
+		return Operation{}, fmt.Errorf("%w: service %q", ErrInvalid, service)
+	}
+	if !validComponent(method) {
+		return Operation{}, fmt.Errorf("%w: method %q", ErrInvalid, method)
+	}
+	if !validKind(kind) {
+		return Operation{}, fmt.Errorf("%w: kind %q", ErrInvalid, kind)
+	}
+	return Operation{
+		transport: normalizedTransport,
+		service:   service,
+		method:    method,
+		kind:      kind,
+	}, nil
+}
+
+// Transport returns the normalized transport identifier.
+func (o Operation) Transport() string {
+	return o.transport
+}
+
+// Service returns the logical service identifier.
+func (o Operation) Service() string {
+	return o.service
+}
+
+// Method returns the logical method identifier.
+func (o Operation) Method() string {
+	return o.method
+}
+
+// Kind returns the invocation shape.
+func (o Operation) Kind() Kind {
+	return o.kind
+}
+
+// PolicyKey returns a stable, collision-free, human-readable policy key.
+func (o Operation) PolicyKey() string {
+	return url.PathEscape(o.transport) + "/" +
+		url.PathEscape(o.service) + "/" +
+		url.PathEscape(o.method) + "/" +
+		url.PathEscape(string(o.kind))
+}
+
+// String returns the stable policy key.
+func (o Operation) String() string {
+	return o.PolicyKey()
+}
+
+// WithContext attaches an Operation through the canonical RequestInfo context
+// value. Prefer WithRequestInfo when transport peer facts are available.
+func WithContext(ctx context.Context, operation Operation) context.Context {
+	return context.WithValue(ctx, requestInfoContextKey{}, RequestInfo{
+		operation: operation,
+		attempt:   1,
+	})
+}
+
+// FromContext returns the Operation projected from the canonical RequestInfo.
+func FromContext(ctx context.Context) (Operation, bool) {
+	info, ok := RequestInfoFromContext(ctx)
+	if !ok {
+		return Operation{}, false
+	}
+	return info.Operation(), true
+}
+
+func validTransport(transport string) bool {
+	if transport == "" || transport[0] < 'a' || transport[0] > 'z' {
+		return false
+	}
+	for index := 1; index < len(transport); index++ {
+		character := transport[index]
+		if character >= 'a' && character <= 'z' || character >= '0' && character <= '9' || character == '+' || character == '-' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validComponent(component string) bool {
+	if component == "" || !utf8.ValidString(component) {
+		return false
+	}
+	if strings.TrimSpace(component) != component {
+		return false
+	}
+	for _, character := range component {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validKind(kind Kind) bool {
+	switch kind {
+	case KindUnary, KindClientStream, KindServerStream, KindBidiStream, KindConsumer, KindJob:
+		return true
+	default:
+		return false
+	}
+}

--- a/operation/request_info.go
+++ b/operation/request_info.go
@@ -1,0 +1,185 @@
+package operation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const maxPeerAddressBytes = 2 * 1024
+
+// Peer is an immutable transport peer identity. Address is intentionally not
+// used as a metric label by the operation package because it is high
+// cardinality and may contain tenant data.
+type Peer struct {
+	network string
+	address string
+}
+
+// NewPeer validates and constructs a peer from a transport-provided address.
+func NewPeer(network, address string) (Peer, error) {
+	normalizedNetwork := strings.ToLower(strings.TrimSpace(network))
+	if !validTransport(normalizedNetwork) {
+		return Peer{}, fmt.Errorf("%w: peer network %q", ErrInvalid, network)
+	}
+	normalizedAddress := strings.TrimSpace(address)
+	if normalizedAddress == "" ||
+		len(normalizedAddress) > maxPeerAddressBytes ||
+		!utf8.ValidString(normalizedAddress) {
+		return Peer{}, fmt.Errorf("%w: peer address is empty, oversized, or malformed", ErrInvalid)
+	}
+
+	for _, character := range normalizedAddress {
+		if unicode.IsControl(character) {
+			return Peer{}, fmt.Errorf("%w: peer address contains a control character", ErrInvalid)
+		}
+	}
+	return Peer{
+		network: normalizedNetwork,
+		address: normalizedAddress,
+	}, nil
+}
+
+// Network returns the normalized network or application transport name.
+func (peer Peer) Network() string {
+	return peer.network
+}
+
+// Address returns the transport-provided peer address.
+func (peer Peer) Address() string {
+	return peer.address
+}
+
+// RequestInfoOption configures immutable request facts known before dispatch.
+type RequestInfoOption interface {
+	applyRequestInfo(*requestInfoOptions) error
+}
+
+type requestInfoOptionFunc func(*requestInfoOptions) error
+
+func (f requestInfoOptionFunc) applyRequestInfo(
+	options *requestInfoOptions,
+) error {
+	return f(options)
+}
+
+type requestInfoOptions struct {
+	peer    Peer
+	hasPeer bool
+}
+
+// WithPeer records a peer selected or accepted by a transport.
+func WithPeer(peer Peer) RequestInfoOption {
+	return requestInfoOptionFunc(func(options *requestInfoOptions) error {
+		if peer.network == "" || peer.address == "" {
+			return fmt.Errorf("%w: peer is invalid", ErrInvalid)
+		}
+		options.peer = peer
+		options.hasPeer = true
+		return nil
+	})
+}
+
+// RequestInfo is an immutable snapshot of transport-neutral request facts.
+// Deadline and attempt are refreshed from the current context when the value is
+// retrieved so inner timeout/retry middleware remains visible.
+type RequestInfo struct {
+	operation   Operation
+	peer        Peer
+	hasPeer     bool
+	attempt     int
+	deadline    time.Time
+	hasDeadline bool
+}
+
+// NewRequestInfo validates and constructs request facts for an Operation.
+func NewRequestInfo(target Operation, optionList ...RequestInfoOption) (RequestInfo, error) {
+	if target.transport == "" || target.service == "" || target.method == "" || !validKind(target.kind) {
+		return RequestInfo{}, fmt.Errorf("%w: request operation is invalid", ErrInvalid)
+	}
+	options := requestInfoOptions{}
+
+	for index, option := range optionList {
+		if option == nil {
+			return RequestInfo{}, fmt.Errorf("%w: request info option %d is nil", ErrInvalid, index)
+		}
+		if err := option.applyRequestInfo(&options); err != nil {
+			return RequestInfo{}, fmt.Errorf("%w: request info option %d: %v", ErrInvalid, index, err)
+		}
+	}
+	return RequestInfo{
+		operation: target,
+		peer:      options.peer,
+		hasPeer:   options.hasPeer,
+		attempt:   1,
+	}, nil
+}
+
+// Operation returns the stable request operation.
+func (i RequestInfo) Operation() Operation {
+	return i.operation
+}
+
+// Peer returns the request peer when the transport knows it.
+func (i RequestInfo) Peer() (Peer, bool) {
+	return i.peer, i.hasPeer
+}
+
+// Attempt returns the one-based invocation attempt.
+func (i RequestInfo) Attempt() int {
+	if i.attempt < 1 {
+		return 1
+	}
+	return i.attempt
+}
+
+// Deadline returns the effective deadline when one exists.
+func (i RequestInfo) Deadline() (time.Time, bool) {
+	return i.deadline, i.hasDeadline
+}
+
+type requestInfoContextKey struct{}
+type attemptContextKey struct{}
+
+// WithRequestInfo attaches the canonical request facts to ctx.
+func WithRequestInfo(ctx context.Context, info RequestInfo) context.Context {
+	return context.WithValue(ctx, requestInfoContextKey{}, info)
+}
+
+// RequestInfoFromContext returns a snapshot refreshed with the effective
+// attempt and deadline at the current middleware depth.
+func RequestInfoFromContext(ctx context.Context) (RequestInfo, bool) {
+	if ctx == nil {
+		return RequestInfo{}, false
+	}
+	info, ok := ctx.Value(requestInfoContextKey{}).(RequestInfo)
+	if !ok || info.operation.transport == "" {
+		return RequestInfo{}, false
+	}
+	info.attempt = AttemptFromContext(ctx)
+	info.deadline, info.hasDeadline = ctx.Deadline()
+	return info, true
+}
+
+// WithAttempt records a one-based invocation attempt.
+func WithAttempt(ctx context.Context, number int) context.Context {
+	if number < 1 {
+		number = 1
+	}
+	return context.WithValue(ctx, attemptContextKey{}, number)
+}
+
+// AttemptFromContext returns a one-based attempt and defaults to one.
+func AttemptFromContext(ctx context.Context) int {
+	if ctx == nil {
+		return 1
+	}
+	number, ok := ctx.Value(attemptContextKey{}).(int)
+	if !ok || number < 1 {
+		return 1
+	}
+	return number
+}

--- a/worker/consumer.go
+++ b/worker/consumer.go
@@ -1,0 +1,230 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/keelab/keelith/health"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// Action is the broker-neutral disposition of one message or job execution.
+type Action string
+
+const (
+	// ActionAck accepts and commits successful work.
+	ActionAck Action = "ack"
+	// ActionNack rejects work without asking Keelith to schedule a retry.
+	ActionNack Action = "nack"
+	// ActionRetry asks the adapter to redeliver after a bounded delay.
+	ActionRetry Action = "retry"
+	// ActionDeadLetter asks the adapter to quarantine the work.
+	ActionDeadLetter Action = "dead-letter"
+)
+
+var (
+	// ErrNacked is used when Nack is constructed without a cause.
+	ErrNacked = errors.New("worker: message was negatively acknowledged")
+	// ErrRetryRequested is used when Retry is constructed without a cause.
+	ErrRetryRequested = errors.New("worker: retry requested")
+	// ErrDeadLettered is used when DeadLetter is constructed without a cause.
+	ErrDeadLettered = errors.New("worker: dead letter requested")
+	// ErrInvalidResult reports a handler or middleware response with no valid
+	// disposition.
+	ErrInvalidResult = errors.New("worker: invalid result")
+)
+
+// Result is an immutable broker-neutral handling disposition.
+type Result struct {
+	action     Action
+	cause      error
+	retryAfter time.Duration
+}
+
+// Ack creates a successful disposition.
+func Ack() Result {
+	return Result{action: ActionAck}
+}
+
+// Nack creates a negative acknowledgement.
+func Nack(cause error) Result {
+	if cause == nil {
+		cause = ErrNacked
+	}
+	return Result{action: ActionNack, cause: cause}
+}
+
+// Retry creates a retry disposition. Negative delays are normalized to zero.
+func Retry(cause error, after time.Duration) Result {
+	if cause == nil {
+		cause = ErrRetryRequested
+	}
+	if after < 0 {
+		after = 0
+	}
+	return Result{
+		action:     ActionRetry,
+		cause:      cause,
+		retryAfter: after,
+	}
+}
+
+// DeadLetter creates a quarantine disposition.
+func DeadLetter(cause error) Result {
+	if cause == nil {
+		cause = ErrDeadLettered
+	}
+	return Result{action: ActionDeadLetter, cause: cause}
+}
+
+// Action returns the stable disposition.
+func (r Result) Action() Action {
+	return r.action
+}
+
+// Cause returns the handler or policy failure associated with the disposition.
+func (r Result) Cause() error {
+	return r.cause
+}
+
+// RetryAfter returns the requested redelivery delay.
+func (r Result) RetryAfter() time.Duration {
+	return r.retryAfter
+}
+
+func (r Result) valid() bool {
+	switch r.action {
+	case ActionAck:
+		return r.cause == nil && r.retryAfter == 0
+	case ActionNack, ActionDeadLetter:
+		return r.cause != nil && r.retryAfter == 0
+	case ActionRetry:
+		return r.cause != nil && r.retryAfter >= 0
+	default:
+		return false
+	}
+}
+
+// Message is an immutable broker-neutral delivery envelope.
+type Message struct {
+	id       string
+	payload  []byte
+	metadata metadata.Metadata
+}
+
+// NewMessage defensively copies a delivery payload and metadata.
+func NewMessage(id string, payload []byte, inbound metadata.Metadata) Message {
+	return Message{
+		id:       strings.TrimSpace(id),
+		payload:  append([]byte(nil), payload...),
+		metadata: inbound.Clone(),
+	}
+}
+
+// ID returns the adapter-provided message identity.
+func (message Message) ID() string {
+	return message.id
+}
+
+// Payload returns a defensive copy of the delivery body.
+func (message Message) Payload() []byte {
+	return append([]byte(nil), message.payload...)
+}
+
+// Metadata returns an immutable clone of inbound delivery metadata.
+func (message Message) Metadata() metadata.Metadata {
+	return message.metadata.Clone()
+}
+
+// ConsumerHandler maps one delivery to an explicit disposition.
+type ConsumerHandler func(context.Context, Message) Result
+
+// Consumer is implemented by broker adapters.
+//
+// Subscribe returns only after the broker subscription is ready. StopPulling
+// prevents new callbacks, Drain waits for adapter-side commit/rollback, Close
+// releases connections, and Wait reports runtime termination.
+type Consumer interface {
+	Subscribe(context.Context, ConsumerHandler) error
+	StopPulling(context.Context) error
+	Drain(context.Context) error
+	Close(context.Context) error
+	Wait() error
+}
+
+// ConsumerConfig constructs a broker-neutral Worker.
+type ConsumerConfig struct {
+	Name       string
+	Operation  operation.Operation
+	Consumer   Consumer
+	Handler    ConsumerHandler
+	Middleware *middleware.Bundle
+	Health     *health.Registry
+}
+
+// NewConsumer constructs a Worker around a broker adapter.
+func NewConsumer(config ConsumerConfig) (*Worker, error) {
+	if isNil(config.Consumer) {
+		return nil, invalidOption("consumer is nil")
+	}
+	if config.Handler == nil {
+		return nil, invalidOption("consumer handler is nil")
+	}
+	source := runtimeSource{
+		start: func(ctx context.Context, dispatch middleware.Handler) error {
+			return config.Consumer.Subscribe(
+				ctx,
+				func(ctx context.Context, message Message) Result {
+					ctx = metadata.WithInbound(ctx, message.Metadata())
+					response, err := dispatch(ctx, message)
+					return normalizeResult(response, err)
+				},
+			)
+		},
+		stopPulling: config.Consumer.StopPulling,
+		drain:       config.Consumer.Drain,
+		close:       config.Consumer.Close,
+		wait:        config.Consumer.Wait,
+	}
+	final := middleware.Handler(func(ctx context.Context, request any) (any, error) {
+		message, ok := request.(Message)
+		if !ok {
+			return nil, ErrInvalidResult
+		}
+		result := config.Handler(ctx, message)
+		return result, result.Cause()
+	})
+	return newWorker(
+		config.Name,
+		config.Operation,
+		operation.KindConsumer,
+		source,
+		final,
+		config.Middleware,
+		config.Health,
+	)
+}
+
+func normalizeResult(response any, err error) Result {
+	result, ok := response.(Result)
+	if !ok || !result.valid() {
+		if err == nil {
+			err = ErrInvalidResult
+		}
+		return Nack(err)
+	}
+	if err == nil {
+		return result
+	}
+	switch result.action {
+	case ActionNack, ActionRetry, ActionDeadLetter:
+		result.cause = err
+		return result
+	default:
+		return Nack(err)
+	}
+}

--- a/worker/group.go
+++ b/worker/group.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"context"
+	"sync"
+)
+
+type inflightGroup struct {
+	mu        sync.Mutex
+	accepting bool
+	inflight  int
+	drained   chan struct{}
+	closeOnce sync.Once
+}
+
+func newInflightGroup() *inflightGroup {
+	return &inflightGroup{drained: make(chan struct{})}
+}
+
+func (g *inflightGroup) open() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.accepting = true
+}
+
+func (g *inflightGroup) begin() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if !g.accepting {
+		return false
+	}
+	g.inflight++
+	return true
+}
+
+func (g *inflightGroup) done() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.inflight == 0 {
+		return
+	}
+	g.inflight--
+	g.signalDrainedLocked()
+}
+
+func (g *inflightGroup) stopAndWait(ctx context.Context) error {
+	g.mu.Lock()
+	g.accepting = false
+	g.signalDrainedLocked()
+	drained := g.drained
+	g.mu.Unlock()
+
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (g *inflightGroup) signalDrainedLocked() {
+	if g.accepting || g.inflight != 0 {
+		return
+	}
+	g.closeOnce.Do(func() {
+		close(g.drained)
+	})
+}

--- a/worker/job.go
+++ b/worker/job.go
@@ -1,0 +1,176 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/keelab/keelith/health"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// Execution is an immutable scheduled or ad-hoc job input.
+type Execution struct {
+	id          string
+	scheduledAt time.Time
+	payload     []byte
+	metadata    metadata.Metadata
+}
+
+// NewExecution defensively copies a job input.
+func NewExecution(id string, scheduledAt time.Time, payload []byte, inbound metadata.Metadata) Execution {
+	return Execution{
+		id:          strings.TrimSpace(id),
+		scheduledAt: scheduledAt,
+		payload:     append([]byte(nil), payload...),
+		metadata:    inbound.Clone(),
+	}
+}
+
+// ID returns the scheduler-provided execution identity.
+func (e Execution) ID() string {
+	return e.id
+}
+
+// ScheduledAt returns the planned execution time.
+func (e Execution) ScheduledAt() time.Time {
+	return e.scheduledAt
+}
+
+// Payload returns a defensive copy of job input.
+func (e Execution) Payload() []byte {
+	return append([]byte(nil), e.payload...)
+}
+
+// Metadata returns an immutable clone of execution metadata.
+func (e Execution) Metadata() metadata.Metadata {
+	return e.metadata.Clone()
+}
+
+// JobHandler maps one execution to the same explicit disposition used by
+// Consumer. Scheduler adapters decide how Retry and DeadLetter are realized.
+type JobHandler func(context.Context, Execution) Result
+
+// Scheduler is implemented by Cron, platform, and remote job adapters.
+type Scheduler interface {
+	Schedule(context.Context, JobHandler) error
+	StopPulling(context.Context) error
+	Drain(context.Context) error
+	Close(context.Context) error
+	Wait() error
+}
+
+// TriggerAuthority identifies who decides when a job execution exists.
+type TriggerAuthority string
+
+const (
+	// TriggerAuthorityUnknown is used by third-party schedulers without a
+	// capability declaration.
+	TriggerAuthorityUnknown TriggerAuthority = ""
+	// TriggerAuthorityLocal means this process owns the schedule clock.
+	TriggerAuthorityLocal TriggerAuthority = "local"
+	// TriggerAuthorityExternal means a remote platform dispatches executions.
+	TriggerAuthorityExternal TriggerAuthority = "external"
+)
+
+// OwnershipMode describes how executions are coordinated across replicas.
+type OwnershipMode string
+
+const (
+	// OwnershipUnknown means no capability declaration is available.
+	OwnershipUnknown OwnershipMode = ""
+	// OwnershipPerReplica means every process may execute the same schedule.
+	OwnershipPerReplica OwnershipMode = "per-replica"
+	// OwnershipExternal means a remote scheduler owns coordination/sharding.
+	OwnershipExternal OwnershipMode = "external"
+	// OwnershipLease means a Keelith renewable lease admits each execution.
+	OwnershipLease OwnershipMode = "lease"
+)
+
+// SchedulerCapabilities prevents invalid ownership composition and gives Ops
+// a stable, vendor-neutral description.
+type SchedulerCapabilities struct {
+	TriggerAuthority TriggerAuthority
+	Ownership        OwnershipMode
+	Fencing          bool
+	Sharding         bool
+	RemoteKill       bool
+}
+
+// SchedulerCapabilitiesProvider is implemented by schedulers and decorators
+// that can declare ownership semantics.
+type SchedulerCapabilitiesProvider interface {
+	SchedulerCapabilities() SchedulerCapabilities
+}
+
+// CapabilitiesOf returns a safe unknown description for third-party adapters.
+func CapabilitiesOf(scheduler Scheduler) SchedulerCapabilities {
+	if scheduler == nil {
+		return SchedulerCapabilities{}
+	}
+	provider, ok := scheduler.(SchedulerCapabilitiesProvider)
+	if !ok {
+		return SchedulerCapabilities{}
+	}
+	return provider.SchedulerCapabilities()
+}
+
+// JobConfig constructs a scheduled Worker.
+type JobConfig struct {
+	Name       string
+	Operation  operation.Operation
+	Scheduler  Scheduler
+	Handler    JobHandler
+	Middleware *middleware.Bundle
+	Health     *health.Registry
+}
+
+// Job exposes a scheduler as a Server-compatible runtime component.
+type Job struct {
+	*Worker
+}
+
+// NewJob constructs a Job around a scheduler adapter.
+func NewJob(config JobConfig) (*Job, error) {
+	if isNil(config.Scheduler) {
+		return nil, invalidOption("scheduler is nil")
+	}
+	if config.Handler == nil {
+		return nil, invalidOption("job handler is nil")
+	}
+
+	source := runtimeSource{
+		start: func(ctx context.Context, dispatch middleware.Handler) error {
+			return config.Scheduler.Schedule(
+				ctx,
+				func(ctx context.Context, execution Execution) Result {
+					ctx = metadata.WithInbound(ctx, execution.Metadata())
+					response, err := dispatch(ctx, execution)
+					return normalizeResult(response, err)
+				},
+			)
+		},
+		stopPulling: config.Scheduler.StopPulling,
+		drain:       config.Scheduler.Drain,
+		close:       config.Scheduler.Close,
+		wait:        config.Scheduler.Wait,
+	}
+
+	final := middleware.Handler(func(ctx context.Context, request any) (any, error) {
+		execution, ok := request.(Execution)
+		if !ok {
+			return nil, ErrInvalidResult
+		}
+		result := config.Handler(ctx, execution)
+		return result, result.Cause()
+	})
+
+	runtime, err := newWorker(config.Name, config.Operation, operation.KindJob, source, final, config.Middleware, config.Health)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Job{Worker: runtime}, nil
+}

--- a/worker/owned/scheduler.go
+++ b/worker/owned/scheduler.go
@@ -1,0 +1,294 @@
+// Package owned decorates a worker Scheduler with distributed lease
+// ownership.
+package owned
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/keelab/keelith/coordination"
+	"github.com/keelab/keelith/worker"
+)
+
+const defaultReleaseTimeout = 5 * time.Second
+
+var (
+	// ErrInvalidOption reports invalid ownership configuration.
+	ErrInvalidOption = errors.New("owned scheduler: invalid option")
+	// ErrOwnershipConflict reports a remote or already leased scheduler.
+	ErrOwnershipConflict = errors.New("owned scheduler: ownership conflict")
+)
+
+// Config controls cluster ownership around one Scheduler.
+type Config struct {
+	Key            string
+	TTL            time.Duration
+	ReleaseTimeout time.Duration
+	Coordinator    coordination.Coordinator
+	Scheduler      worker.Scheduler
+}
+
+// Description is a value-free ownership snapshot.
+type Description struct {
+	Active          int
+	Acquired        uint64
+	Contended       uint64
+	AcquireFailures uint64
+	LeaseLosses     uint64
+	ReleaseFailures uint64
+	Capabilities    worker.SchedulerCapabilities
+}
+
+// Scheduler admits an execution only while this replica owns its lease.
+type Scheduler struct {
+	key            string
+	ttl            time.Duration
+	releaseTimeout time.Duration
+	coordinator    coordination.Coordinator
+	scheduler      worker.Scheduler
+
+	mu           sync.Mutex
+	description  Description
+	capabilities worker.SchedulerCapabilities
+}
+
+// New creates a cluster-ownership Scheduler decorator.
+func New(config Config) (*Scheduler, error) {
+	if !validKey(config.Key) ||
+		config.TTL <= 0 ||
+		isNil(config.Coordinator) ||
+		isNil(config.Scheduler) {
+		return nil, fmt.Errorf(
+			"%w: key, TTL, coordinator, or scheduler",
+			ErrInvalidOption,
+		)
+	}
+	releaseTimeout := config.ReleaseTimeout
+	if releaseTimeout == 0 {
+		releaseTimeout = defaultReleaseTimeout
+		if config.TTL < releaseTimeout {
+			releaseTimeout = config.TTL
+		}
+	}
+	if releaseTimeout < 0 || releaseTimeout > config.TTL {
+		return nil, fmt.Errorf(
+			"%w: release timeout must be positive and not exceed TTL",
+			ErrInvalidOption,
+		)
+	}
+	wrapped := worker.CapabilitiesOf(config.Scheduler)
+	if wrapped.TriggerAuthority == worker.TriggerAuthorityExternal ||
+		wrapped.Ownership == worker.OwnershipExternal ||
+		wrapped.Ownership == worker.OwnershipLease ||
+		wrapped.Sharding {
+		return nil, fmt.Errorf(
+			"%w: scheduler is external, sharded, or already coordinated",
+			ErrOwnershipConflict,
+		)
+	}
+	capabilities := worker.SchedulerCapabilities{
+		TriggerAuthority: wrapped.TriggerAuthority,
+		Ownership:        worker.OwnershipLease,
+		Fencing:          true,
+		Sharding:         false,
+		RemoteKill:       wrapped.RemoteKill,
+	}
+	return &Scheduler{
+		key:            config.Key,
+		ttl:            config.TTL,
+		releaseTimeout: releaseTimeout,
+		coordinator:    config.Coordinator,
+		scheduler:      config.Scheduler,
+		capabilities:   capabilities,
+		description: Description{
+			Capabilities: capabilities,
+		},
+	}, nil
+}
+
+// SchedulerCapabilities declares renewable lease ownership and fencing.
+func (s *Scheduler) SchedulerCapabilities() worker.SchedulerCapabilities {
+	if s == nil {
+		return worker.SchedulerCapabilities{}
+	}
+	return s.capabilities
+}
+
+// Schedule starts the wrapped Scheduler with ownership admission.
+func (s *Scheduler) Schedule(ctx context.Context, handler worker.JobHandler) error {
+	if s == nil || handler == nil {
+		return fmt.Errorf("%w: scheduler or handler is nil", ErrInvalidOption)
+	}
+
+	return s.scheduler.Schedule(ctx, func(ctx context.Context, execution worker.Execution) worker.Result {
+		return s.runOwned(ctx, execution, handler)
+	})
+}
+
+// StopPulling delegates to the wrapped Scheduler.
+func (s *Scheduler) StopPulling(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+
+	return s.scheduler.StopPulling(ctx)
+}
+
+// Drain delegates to the wrapped Scheduler. Active leases are part of wrapped
+// Handler completion and therefore drain before this returns.
+func (s *Scheduler) Drain(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	return s.scheduler.Drain(ctx)
+}
+
+// Close delegates to the wrapped Scheduler.
+func (s *Scheduler) Close(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	return s.scheduler.Close(ctx)
+}
+
+// Wait delegates to the wrapped Scheduler.
+func (s *Scheduler) Wait() error {
+	if s == nil {
+		return nil
+	}
+	return s.scheduler.Wait()
+}
+
+// Description returns aggregate ownership state without lease keys or errors.
+func (s *Scheduler) Description() Description {
+	if s == nil {
+		return Description{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.description
+}
+
+func (s *Scheduler) runOwned(ctx context.Context, execution worker.Execution, handler worker.JobHandler) (result worker.Result) {
+	lease, acquired, err := s.coordinator.TryAcquire(ctx, s.key, s.ttl)
+
+	if err != nil {
+		s.record(func(description *Description) {
+			description.AcquireFailures++
+		})
+		return worker.Nack(err)
+	}
+	if !acquired {
+		s.record(func(description *Description) {
+			description.Contended++
+		})
+		return worker.Ack()
+	}
+	if isNil(lease) {
+		s.record(func(description *Description) {
+			description.AcquireFailures++
+		})
+		return worker.Nack(fmt.Errorf("%w: acquired lease is nil", ErrInvalidOption))
+	}
+	if lease.Fence() == 0 {
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.releaseTimeout)
+		releaseErr := lease.Release(releaseCtx)
+		cancel()
+		s.record(func(description *Description) {
+			description.AcquireFailures++
+			if releaseErr != nil {
+				description.ReleaseFailures++
+			}
+		})
+		return worker.Nack(fmt.Errorf("%w: acquired lease has no fencing token", ErrInvalidOption))
+	}
+	s.record(func(description *Description) {
+		description.Acquired++
+		description.Active++
+	})
+
+	ownedCtx, cancel := context.WithCancelCause(coordination.WithFence(ctx, lease.Fence()))
+	handlerDone := make(chan struct{})
+
+	go func() {
+		select {
+		case <-lease.Done():
+			if lease.Err() != nil {
+				cancel(coordination.ErrLeaseLost)
+			}
+		case <-handlerDone:
+		}
+	}()
+
+	defer func() {
+		close(handlerDone)
+		cancel(nil)
+		recovered := recover()
+		lost := lease.Err()
+		releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), s.releaseTimeout)
+		releaseErr := lease.Release(releaseCtx)
+		releaseCancel()
+		if lost == nil && errors.Is(releaseErr, coordination.ErrLeaseLost) {
+			lost = releaseErr
+		}
+		s.record(func(description *Description) {
+			description.Active--
+			if lost != nil {
+				description.LeaseLosses++
+			}
+			if releaseErr != nil {
+				description.ReleaseFailures++
+			}
+		})
+		if recovered != nil {
+			panic(recovered)
+		}
+		if lost != nil {
+			result = worker.Nack(errors.Join(coordination.ErrLeaseLost, lost))
+		}
+	}()
+
+	return handler(ownedCtx, execution)
+}
+
+func (s *Scheduler) record(update func(*Description)) {
+	s.mu.Lock()
+	update(&s.description)
+	s.mu.Unlock()
+}
+
+func validKey(value string) bool {
+	if value == "" ||
+		len(value) > 512 ||
+		strings.TrimSpace(value) != value ||
+		!utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,0 +1,363 @@
+// Package worker provides broker- and scheduler-neutral background runtimes.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/health"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+const forcedShutdownTimeout = 100 * time.Millisecond
+
+var (
+	// ErrInvalidOption reports an invalid Worker dependency or operation.
+	ErrInvalidOption = errors.New("worker: invalid option")
+	// ErrAlreadyStarted reports a second Start call.
+	ErrAlreadyStarted = errors.New("worker: already started")
+	// ErrNilContext reports a nil lifecycle or delivery context.
+	ErrNilContext = errors.New("worker: nil context")
+	// ErrNotAccepting reports a delivery after draining began.
+	ErrNotAccepting = errors.New("worker: not accepting work")
+	// ErrNotStarted reports Wait before Start.
+	ErrNotStarted = errors.New("worker: not started")
+)
+
+type workerState uint8
+
+const (
+	workerStateNew workerState = iota
+	workerStateStarting
+	workerStateRunning
+	workerStateStopping
+	workerStateStopped
+)
+
+type runtimeSource struct {
+	start       func(context.Context, middleware.Handler) error
+	stopPulling func(context.Context) error
+	drain       func(context.Context) error
+	close       func(context.Context) error
+	wait        func() error
+}
+
+// Worker is a Server-compatible owner of one Consumer or Scheduler.
+type Worker struct {
+	name      string
+	target    operation.Operation
+	source    runtimeSource
+	invoke    middleware.Handler
+	inflight  *inflightGroup
+	readiness *health.Registry
+
+	mu            sync.Mutex
+	state         workerState
+	runtimeCtx    context.Context
+	runtimeCancel context.CancelCauseFunc
+	startErr      error
+	stopErr       error
+
+	startDone chan struct{}
+	stopDone  chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+func newWorker(name string, target operation.Operation, wantKind operation.Kind, source runtimeSource, final middleware.Handler, bundle *middleware.Bundle, registry *health.Registry) (*Worker, error) {
+	normalizedName := strings.TrimSpace(name)
+	if normalizedName == "" {
+		return nil, invalidOption("name is empty")
+	}
+	if target.Transport() == "" || target.Kind() != wantKind {
+		return nil, invalidOption(fmt.Sprintf("operation kind is %q, want %q", target.Kind(), wantKind))
+	}
+	if final == nil || source.start == nil || source.stopPulling == nil || source.drain == nil || source.close == nil || source.wait == nil {
+		return nil, invalidOption("runtime source is incomplete")
+	}
+	invoke := final
+	if bundle != nil {
+		invoke = bundle.Chain()(final)
+	}
+	result := &Worker{
+		name:      normalizedName,
+		target:    target,
+		source:    source,
+		invoke:    invoke,
+		inflight:  newInflightGroup(),
+		readiness: registry,
+		state:     workerStateNew,
+		startDone: make(chan struct{}),
+		stopDone:  make(chan struct{}),
+	}
+	if registry != nil {
+		if err := registry.Register(health.KindReadiness, normalizedName, result.healthCheck); err != nil {
+			return nil, fmt.Errorf("%w: register health: %w", ErrInvalidOption, err)
+		}
+	}
+	return result, nil
+}
+
+// Name returns the stable diagnostic and health contributor name.
+func (w *Worker) Name() string {
+	return w.name
+}
+
+// Ready reports whether subscription or scheduling is accepting work.
+func (w *Worker) Ready() bool {
+	if w == nil {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.state == workerStateRunning
+}
+
+// Start subscribes or schedules and returns only after the source is ready.
+func (w *Worker) Start(ctx context.Context) error {
+	if w == nil {
+		return fmt.Errorf("%w: worker is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	w.mu.Lock()
+	if w.state != workerStateNew {
+		w.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	w.state = workerStateStarting
+	w.runtimeCtx, w.runtimeCancel = context.WithCancelCause(
+		context.WithoutCancel(ctx),
+	)
+	w.mu.Unlock()
+	defer w.startOnce.Do(func() { close(w.startDone) })
+
+	w.inflight.open()
+	err := w.source.start(ctx, w.dispatch)
+	if err == nil {
+		err = context.Cause(ctx)
+	}
+	if err != nil {
+		cleanupErr := w.rollback(err)
+		result := errors.Join(err, cleanupErr)
+		w.mu.Lock()
+		w.startErr = result
+		w.state = workerStateStopped
+		w.mu.Unlock()
+		w.stopOnce.Do(func() { close(w.stopDone) })
+		return result
+	}
+
+	w.mu.Lock()
+	w.state = workerStateRunning
+	w.mu.Unlock()
+	return nil
+}
+
+// Stop stops new work, drains handlers and adapter commits, then closes the
+// source. Stop is safe to call repeatedly and concurrently.
+func (w *Worker) Stop(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	for {
+		w.mu.Lock()
+		switch w.state {
+		case workerStateNew:
+			w.state = workerStateStopped
+			w.startOnce.Do(func() { close(w.startDone) })
+			w.stopOnce.Do(func() { close(w.stopDone) })
+			w.mu.Unlock()
+			return nil
+		case workerStateStarting:
+			startDone := w.startDone
+			w.mu.Unlock()
+			select {
+			case <-startDone:
+				continue
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		case workerStateRunning:
+			w.state = workerStateStopping
+			w.mu.Unlock()
+			err := w.shutdown(ctx)
+			w.complete(err)
+			return err
+		case workerStateStopping:
+			stopDone := w.stopDone
+			w.mu.Unlock()
+			return w.waitStop(ctx, stopDone)
+		case workerStateStopped:
+			err := errors.Join(w.startErr, w.stopErr)
+			w.mu.Unlock()
+			return err
+		default:
+			w.mu.Unlock()
+			return fmt.Errorf("%w: unknown state", ErrInvalidOption)
+		}
+	}
+}
+
+// Wait reports source termination and returns after Close during normal Stop.
+func (w *Worker) Wait() error {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	state := w.state
+	startErr := w.startErr
+	w.mu.Unlock()
+	switch state {
+	case workerStateNew, workerStateStarting:
+		return ErrNotStarted
+	case workerStateStopped:
+		w.mu.Lock()
+		stopErr := w.stopErr
+		w.mu.Unlock()
+		return errors.Join(startErr, stopErr)
+	}
+
+	return w.source.wait()
+}
+
+func (w *Worker) dispatch(ctx context.Context, request any) (any, error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	if !w.inflight.begin() {
+		return nil, ErrNotAccepting
+	}
+	defer w.inflight.done()
+
+	w.mu.Lock()
+	runtimeCtx := w.runtimeCtx
+	w.mu.Unlock()
+	if runtimeCtx == nil {
+		return nil, ErrNotAccepting
+	}
+	invocationCtx, cancel := mergeContexts(ctx, runtimeCtx)
+	defer cancel()
+	requestInfo, err := operation.NewRequestInfo(w.target)
+	if err != nil {
+		return nil, fmt.Errorf("%w: request info: %v", ErrInvalidOption, err)
+	}
+	invocationCtx = operation.WithRequestInfo(invocationCtx, requestInfo)
+
+	return w.invoke(invocationCtx, request)
+}
+
+func (w *Worker) shutdown(ctx context.Context) error {
+	stopPullingErr := w.source.stopPulling(ctx)
+	drainHandlersErr := w.inflight.stopAndWait(ctx)
+	if drainHandlersErr != nil {
+		w.cancelRuntime(drainHandlersErr)
+		forced, cancel := context.WithTimeout(context.Background(), forcedShutdownTimeout)
+		drainHandlersErr = errors.Join(drainHandlersErr, w.inflight.stopAndWait(forced))
+		cancel()
+	}
+	w.cancelRuntime(context.Canceled)
+
+	cleanupCtx, cleanupCancel := cleanupContext(ctx)
+	defer cleanupCancel()
+	adapterDrainErr := w.source.drain(cleanupCtx)
+	closeErr := w.source.close(cleanupCtx)
+
+	return errors.Join(stopPullingErr, drainHandlersErr, adapterDrainErr, closeErr)
+}
+
+func (w *Worker) rollback(primary error) error {
+	w.cancelRuntime(primary)
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), forcedShutdownTimeout)
+	defer cancel()
+
+	return errors.Join(w.source.stopPulling(cleanupCtx), w.inflight.stopAndWait(cleanupCtx), w.source.drain(cleanupCtx), w.source.close(cleanupCtx))
+}
+
+func (w *Worker) complete(err error) {
+	w.mu.Lock()
+	w.stopErr = err
+	w.state = workerStateStopped
+	w.mu.Unlock()
+	w.stopOnce.Do(func() { close(w.stopDone) })
+}
+
+func (w *Worker) waitStop(
+	ctx context.Context,
+	stopDone <-chan struct{},
+) error {
+	select {
+	case <-stopDone:
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		return w.stopErr
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (w *Worker) cancelRuntime(cause error) {
+	w.mu.Lock()
+	cancel := w.runtimeCancel
+	w.mu.Unlock()
+	if cancel != nil {
+		cancel(cause)
+	}
+}
+
+func (w *Worker) healthCheck(context.Context) health.Result {
+	if w.Ready() {
+		return health.Pass("worker subscription is accepting work")
+	}
+	return health.Fail("worker subscription is not accepting work")
+}
+
+func mergeContexts(message context.Context, runtime context.Context) (context.Context, func()) {
+	merged, cancel := context.WithCancelCause(message)
+
+	stop := context.AfterFunc(runtime, func() {
+		cancel(context.Cause(runtime))
+	})
+
+	return merged, func() {
+		stop()
+		cancel(nil)
+	}
+}
+
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if context.Cause(ctx) == nil {
+		return context.WithCancel(ctx)
+	}
+
+	return context.WithTimeout(context.Background(), forcedShutdownTimeout)
+}
+
+func invalidOption(message string) error {
+	return fmt.Errorf("%w: %s", ErrInvalidOption, message)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- add bounded cache invalidation events and worker-compatible processor
- add coordination lease abstractions with in-memory coordinator support
- add metadata propagation, middleware composition, operation descriptors, and worker runtime primitives

## Testing
- gofmt -w cache/invalidation coordination metadata middleware operation worker
- go test ./...