### PR TITLE
fix: wrap request info errors

### DIFF
--- a/operation/request_info.go
+++ b/operation/request_info.go
@@ -107,7 +107,7 @@ func NewRequestInfo(target Operation, optionList ...RequestInfoOption) (RequestI
 			return RequestInfo{}, fmt.Errorf("%w: request info option %d is nil", ErrInvalid, index)
 		}
 		if err := option.applyRequestInfo(&options); err != nil {
-			return RequestInfo{}, fmt.Errorf("%w: request info option %d: %v", ErrInvalid, index, err)
+			return RequestInfo{}, fmt.Errorf("%w: request info option %d: %w", ErrInvalid, index, err)
 		}
 	}
 	return RequestInfo{

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -251,7 +251,7 @@ func (w *Worker) dispatch(ctx context.Context, request any) (any, error) {
 	defer cancel()
 	requestInfo, err := operation.NewRequestInfo(w.target)
 	if err != nil {
-		return nil, fmt.Errorf("%w: request info: %v", ErrInvalidOption, err)
+		return nil, fmt.Errorf("%w: request info: %w", ErrInvalidOption, err)
 	}
 	invocationCtx = operation.WithRequestInfo(invocationCtx, requestInfo)
 


### PR DESCRIPTION
## Summary
- wrap request-info option errors with %w so errorlint accepts the error chain
- wrap worker request-info construction errors with %w

## Testing
- golangci-lint run --timeout=5m ./...
- go test ./...