### PR TITLE
feat: add runtime contracts and governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ coverage.*
 !.env.example
 tmp/
 temp/
+
+
+AGENTS.md

--- a/client/node_change.go
+++ b/client/node_change.go
@@ -1,0 +1,260 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/keelab/keelith/registry"
+)
+
+var (
+	// ErrNodeChangeWatcherClosed reports a closed Router node-change watcher.
+	ErrNodeChangeWatcherClosed = errors.New("client: node change watcher closed")
+)
+
+// NodeUpdate describes one instance whose endpoints or metadata changed.
+//
+// Previous and Current return immutable registry values.
+type NodeUpdate struct {
+	previous registry.Instance
+	current  registry.Instance
+}
+
+// Previous returns the instance before the accepted snapshot.
+func (update NodeUpdate) Previous() registry.Instance {
+	return update.previous.Clone()
+}
+
+// Current returns the instance in the accepted snapshot.
+func (update NodeUpdate) Current() registry.Instance {
+	return update.current.Clone()
+}
+
+// NodeChange is an immutable, revisioned Router topology update.
+//
+// Current always contains the complete accepted instance set. Consumers may
+// therefore coalesce pending updates without losing the final topology.
+type NodeChange struct {
+	service          string
+	previousRevision string
+	revision         string
+	current          []registry.Instance
+	added            []registry.Instance
+	updated          []NodeUpdate
+	removed          []registry.Instance
+}
+
+// NewNodeChange validates two snapshots and derives one immutable topology
+// change. A zero-valued previous snapshot represents an initial full state.
+func NewNodeChange(previous registry.Snapshot, current registry.Snapshot) (NodeChange, error) {
+	if err := current.Validate(); err != nil {
+		return NodeChange{}, fmt.Errorf("client: current snapshot: %w", err)
+	}
+	previousIsZero := previous.Service() == "" &&
+		previous.Revision() == "" &&
+		len(previous.Instances()) == 0
+	if !previousIsZero {
+		if err := previous.Validate(); err != nil {
+			return NodeChange{}, fmt.Errorf("client: previous snapshot: %w", err)
+		}
+		if previous.Service() != current.Service() {
+			return NodeChange{}, fmt.Errorf("%w: snapshot services differ", ErrInvalidOption)
+		}
+	}
+	return newNodeChange(previous, current), nil
+}
+
+// Service returns the logical service whose topology changed.
+func (n NodeChange) Service() string {
+	return n.service
+}
+
+// PreviousRevision returns the previously accepted discovery revision.
+func (n NodeChange) PreviousRevision() string {
+	return n.previousRevision
+}
+
+// Revision returns the newly accepted discovery revision.
+func (n NodeChange) Revision() string {
+	return n.revision
+}
+
+// Current returns the complete accepted instance set.
+func (n NodeChange) Current() []registry.Instance {
+	return cloneInstances(n.current)
+}
+
+// Added returns instances absent from the previous accepted snapshot.
+func (n NodeChange) Added() []registry.Instance {
+	return cloneInstances(n.added)
+}
+
+// Updated returns instances whose endpoints or metadata changed.
+func (n NodeChange) Updated() []NodeUpdate {
+	result := make([]NodeUpdate, len(n.updated))
+	for index, update := range n.updated {
+		result[index] = NodeUpdate{
+			previous: update.previous.Clone(),
+			current:  update.current.Clone(),
+		}
+	}
+	return result
+}
+
+// Removed returns instances absent from the newly accepted snapshot.
+func (n NodeChange) Removed() []registry.Instance {
+	return cloneInstances(n.removed)
+}
+
+// NodeChangeSource creates service-scoped topology watchers.
+type NodeChangeSource interface {
+	WatchNodeChanges(context.Context) (NodeChangeWatcher, error)
+}
+
+// NodeChangeWatcher returns latest-wins full-state topology changes.
+type NodeChangeWatcher interface {
+	Next(context.Context) (NodeChange, error)
+	Close() error
+}
+
+type routerNodeChangeWatcher struct {
+	router   *Router
+	parent   context.Context
+	updates  chan NodeChange
+	done     chan struct{}
+	stopMu   sync.Mutex
+	stop     func() bool
+	closeOne sync.Once
+}
+
+func (w *routerNodeChangeWatcher) Next(ctx context.Context) (NodeChange, error) {
+	if ctx == nil {
+		return NodeChange{}, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	select {
+	case change := <-w.updates:
+		return change.clone(), nil
+	case <-w.done:
+		return NodeChange{}, ErrNodeChangeWatcherClosed
+	case <-w.parent.Done():
+		return NodeChange{}, context.Cause(w.parent)
+	case <-ctx.Done():
+		return NodeChange{}, context.Cause(ctx)
+	}
+}
+
+func (w *routerNodeChangeWatcher) Close() error {
+	if w == nil {
+		return nil
+	}
+	w.closeOne.Do(func() {
+		w.stopMu.Lock()
+		stop := w.stop
+		w.stopMu.Unlock()
+		if stop != nil {
+			stop()
+		}
+		if w.router != nil {
+			w.router.removeNodeChangeWatcher(w)
+		}
+		close(w.done)
+	})
+	return nil
+}
+
+func (w *routerNodeChangeWatcher) setStop(stop func() bool) {
+	w.stopMu.Lock()
+	w.stop = stop
+	w.stopMu.Unlock()
+	select {
+	case <-w.done:
+		stop()
+	default:
+	}
+}
+
+func (w *routerNodeChangeWatcher) publish(change NodeChange) {
+	select {
+	case <-w.done:
+		return
+	default:
+	}
+	select {
+	case <-w.updates:
+	default:
+	}
+	select {
+	case w.updates <- change.clone():
+	case <-w.done:
+	default:
+	}
+}
+
+func (n NodeChange) clone() NodeChange {
+	return NodeChange{
+		service:          n.service,
+		previousRevision: n.previousRevision,
+		revision:         n.revision,
+		current:          cloneInstances(n.current),
+		added:            cloneInstances(n.added),
+		updated:          n.Updated(),
+		removed:          cloneInstances(n.removed),
+	}
+}
+
+func newNodeChange(previous registry.Snapshot, current registry.Snapshot) NodeChange {
+	previousByID := make(map[string]registry.Instance)
+	for _, instance := range previous.Instances() {
+		previousByID[instance.ID()] = instance
+	}
+	currentInstances := current.Instances()
+	currentByID := make(map[string]registry.Instance, len(currentInstances))
+	added := make([]registry.Instance, 0)
+	updated := make([]NodeUpdate, 0)
+
+	for _, instance := range currentInstances {
+		currentByID[instance.ID()] = instance
+		former, exists := previousByID[instance.ID()]
+		switch {
+		case !exists:
+			added = append(added, instance)
+		case !former.Equal(instance):
+			updated = append(updated, NodeUpdate{
+				previous: former,
+				current:  instance,
+			})
+		}
+	}
+	removed := make([]registry.Instance, 0)
+
+	for _, instance := range previous.Instances() {
+		if _, exists := currentByID[instance.ID()]; !exists {
+			removed = append(removed, instance)
+		}
+	}
+
+	return NodeChange{
+		service:          current.Service(),
+		previousRevision: previous.Revision(),
+		revision:         current.Revision(),
+		current:          currentInstances,
+		added:            added,
+		updated:          updated,
+		removed:          removed,
+	}
+}
+
+func cloneInstances(source []registry.Instance) []registry.Instance {
+	result := make([]registry.Instance, len(source))
+	for index, instance := range source {
+		result[index] = instance.Clone()
+	}
+	return result
+}
+
+var (
+	_ NodeChangeSource  = (*Router)(nil)
+	_ NodeChangeWatcher = (*routerNodeChangeWatcher)(nil)
+)

--- a/client/outbound.go
+++ b/client/outbound.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/keelab/keelith/governance/dependency"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/selector"
+)
+
+// OutboundConfig defines one instance-scoped outbound invocation runtime.
+//
+// Dependency supplies the coherent policy, timeout, bulkhead, breaker,
+// retry/hedging, and instance-outlier layers. Middleware and StreamMiddleware
+// add application-owned stages such as telemetry after the governance chain.
+type OutboundConfig struct {
+	Dependency       dependency.Config
+	Middleware       *middleware.Bundle
+	StreamMiddleware *middleware.StreamBundle
+}
+
+// OutboundDescription is an immutable diagnostic view of an Outbound.
+type OutboundDescription struct {
+	Middleware       []middleware.Description
+	StreamMiddleware []middleware.StreamDescription
+	Dependency       dependency.Description
+}
+
+// Outbound is the standard composition point for Keelith client transports.
+//
+// It owns no goroutines or network resources. Routers and transport
+// connections remain explicit App components, while every HTTP/gRPC client
+// created from this object shares one coherent governance state.
+type Outbound struct {
+	dependency       *dependency.Runtime
+	middleware       *middleware.Bundle
+	streamMiddleware *middleware.StreamBundle
+}
+
+// NewOutbound assembles the standard outbound governance and extension chain.
+func NewOutbound(config OutboundConfig) (*Outbound, error) {
+	governance, err := dependency.New(config.Dependency)
+	if err != nil {
+		return nil, fmt.Errorf("%w: dependency runtime: %w", ErrInvalidOption, err)
+	}
+	unary, err := middleware.CombineBundles(
+		governance.Middleware(),
+		config.Middleware,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: combine middleware: %w", ErrInvalidOption, err)
+	}
+	stream, err := middleware.CombineStreamBundles(
+		config.StreamMiddleware,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: combine stream middleware: %w", ErrInvalidOption, err)
+	}
+	return &Outbound{
+		dependency:       governance,
+		middleware:       unary,
+		streamMiddleware: stream,
+	}, nil
+}
+
+// Middleware returns the complete unary/client-creation middleware chain.
+func (o *Outbound) Middleware() *middleware.Bundle {
+	if o == nil {
+		return nil
+	}
+	return o.middleware
+}
+
+// StreamMiddleware returns the per-stream lifecycle middleware chain.
+func (o *Outbound) StreamMiddleware() *middleware.StreamBundle {
+	if o == nil {
+		return nil
+	}
+	return o.streamMiddleware
+}
+
+// InstanceObserver returns the passive instance-health observer shared by
+// selectors created for this Outbound.
+func (o *Outbound) InstanceObserver() selector.Observer {
+	if o == nil || o.dependency == nil {
+		return nil
+	}
+	return o.dependency.InstanceObserver()
+}
+
+// SelectorOptions returns the selector options required for per-attempt
+// instance health feedback.
+func (o *Outbound) SelectorOptions() []selector.Option {
+	if o == nil || o.dependency == nil {
+		return nil
+	}
+	return o.dependency.SelectorOptions()
+}
+
+// Describe returns an immutable snapshot of middleware and governance state.
+func (o *Outbound) Describe() OutboundDescription {
+	if o == nil {
+		return OutboundDescription{}
+	}
+	return OutboundDescription{
+		Middleware:       o.middleware.Describe(),
+		StreamMiddleware: o.streamMiddleware.Describe(),
+		Dependency:       o.dependency.Describe(),
+	}
+}

--- a/client/router.go
+++ b/client/router.go
@@ -1,0 +1,595 @@
+// Package client connects service discovery snapshots to feedback-aware
+// selectors without owning transport connections.
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/registry"
+	"github.com/keelab/keelith/selector"
+)
+
+const (
+	defaultMinReconnectDelay = 100 * time.Millisecond
+	defaultMaxReconnectDelay = 5 * time.Second
+	defaultMaxStale          = 30 * time.Second
+)
+
+var (
+	// ErrInvalidOption reports an incomplete or unsafe Router configuration.
+	ErrInvalidOption = errors.New("client: invalid router option")
+	// ErrAlreadyStarted reports a second Router Start call.
+	ErrAlreadyStarted = errors.New("client: router already started")
+	// ErrNotRunning reports a Pick outside the running lifecycle.
+	ErrNotRunning = errors.New("client: router not running")
+	// ErrStale reports a disconnected last-good snapshot beyond MaxStale.
+	ErrStale = errors.New("client: discovery snapshot is stale")
+)
+
+// Picker selects one node and returns its idempotent completion callback.
+type Picker interface {
+	Pick(context.Context, operation.Operation) (selector.Node, selector.Done, error)
+}
+
+// State is the observable Router lifecycle.
+type State string
+
+const (
+	// StateNew means Start has not been called.
+	StateNew State = "new"
+	// StateStarting means the initial complete snapshot is loading.
+	StateStarting State = "starting"
+	// StateRunning means Pick can select from the current snapshot.
+	StateRunning State = "running"
+	// StateStopping means new Pick calls are rejected while Watch exits.
+	StateStopping State = "stopping"
+	// StateStopped means all Router resources have been released.
+	StateStopped State = "stopped"
+)
+
+// RouterConfig defines one service-scoped discovery and selection pipeline.
+type RouterConfig struct {
+	Name         string
+	Service      string
+	Discovery    registry.Discovery
+	Selector     selector.Selector
+	ReconnectMin time.Duration
+	ReconnectMax time.Duration
+	MaxStale     time.Duration
+}
+
+// Description is an immutable operational Router snapshot.
+type Description struct {
+	Name           string
+	Service        string
+	State          State
+	Connected      bool
+	Stale          bool
+	Revision       string
+	Instances      int
+	Subscribers    int
+	Reconnects     uint64
+	UpdatedAt      time.Time
+	DisconnectedAt time.Time
+	LastError      string
+}
+
+// Router owns one service Watcher and updates an injected Selector.
+//
+// Router implements app.Component structurally.
+type Router struct {
+	name         string
+	service      string
+	discovery    registry.Discovery
+	selector     selector.Selector
+	reconnectMin time.Duration
+	reconnectMax time.Duration
+	maxStale     time.Duration
+
+	mu             sync.Mutex
+	state          State
+	connected      bool
+	revision       string
+	reconnects     uint64
+	updatedAt      time.Time
+	disconnectedAt time.Time
+	lastError      string
+	watcher        registry.Watcher
+	snapshot       registry.Snapshot
+	changeWatchers map[*routerNodeChangeWatcher]struct{}
+	cancel         context.CancelFunc
+
+	startDone     chan struct{}
+	done          chan struct{}
+	startDoneOnce sync.Once
+	doneOnce      sync.Once
+}
+
+// NewRouter validates configuration without starting discovery goroutines.
+func NewRouter(config RouterConfig) (*Router, error) {
+	name := strings.TrimSpace(config.Name)
+	if !validName(name) {
+		return nil, fmt.Errorf("%w: name is malformed", ErrInvalidOption)
+	}
+	service := strings.TrimSpace(config.Service)
+	if !validName(service) {
+		return nil, fmt.Errorf("%w: service is malformed", ErrInvalidOption)
+	}
+	if isNil(config.Discovery) {
+		return nil, fmt.Errorf("%w: discovery is nil", ErrInvalidOption)
+	}
+	if isNil(config.Selector) {
+		return nil, fmt.Errorf("%w: selector is nil", ErrInvalidOption)
+	}
+	reconnectMin := config.ReconnectMin
+	if reconnectMin == 0 {
+		reconnectMin = defaultMinReconnectDelay
+	}
+	reconnectMax := config.ReconnectMax
+	if reconnectMax == 0 {
+		reconnectMax = defaultMaxReconnectDelay
+	}
+	maxStale := config.MaxStale
+	if maxStale == 0 {
+		maxStale = defaultMaxStale
+	}
+	if reconnectMin <= 0 ||
+		reconnectMax < reconnectMin ||
+		maxStale <= 0 {
+		return nil, fmt.Errorf("%w: reconnect and stale durations are invalid", ErrInvalidOption)
+	}
+	return &Router{
+		name:           name,
+		service:        service,
+		discovery:      config.Discovery,
+		selector:       config.Selector,
+		reconnectMin:   reconnectMin,
+		reconnectMax:   reconnectMax,
+		maxStale:       maxStale,
+		state:          StateNew,
+		changeWatchers: make(map[*routerNodeChangeWatcher]struct{}),
+		startDone:      make(chan struct{}),
+		done:           make(chan struct{}),
+	}, nil
+}
+
+// Name returns the stable App component name.
+func (r *Router) Name() string {
+	if r == nil {
+		return ""
+	}
+	return r.name
+}
+
+// Start obtains and applies the initial complete snapshot before returning.
+func (r *Router) Start(ctx context.Context) error {
+	if r == nil {
+		return fmt.Errorf("%w: router is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+
+	runtimeCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	r.mu.Lock()
+	if r.state != StateNew {
+		r.mu.Unlock()
+		cancel()
+		return ErrAlreadyStarted
+	}
+	r.state = StateStarting
+	r.cancel = cancel
+	r.mu.Unlock()
+	defer r.startDoneOnce.Do(func() { close(r.startDone) })
+
+	watcher, err := r.discovery.Watch(runtimeCtx, r.service)
+	if err != nil {
+		r.failStart(cancel, nil, err)
+		return fmt.Errorf("client: watch %q: %w", r.service, err)
+	}
+	if isNil(watcher) {
+		err = fmt.Errorf("client: discovery returned a nil watcher")
+		r.failStart(cancel, nil, err)
+		return err
+	}
+	initialContext, cancelInitial := mergeContexts(ctx, runtimeCtx)
+	snapshot, err := watcher.Next(initialContext)
+	cancelInitial()
+	if err != nil {
+		r.failStart(cancel, watcher, err)
+		return fmt.Errorf("client: initial snapshot %q: %w", r.service, err)
+	}
+	if err := r.selector.Update(snapshot); err != nil {
+		r.failStart(cancel, watcher, err)
+		return fmt.Errorf("client: apply initial snapshot: %w", err)
+	}
+
+	now := time.Now()
+	r.mu.Lock()
+	if r.state != StateStarting || context.Cause(runtimeCtx) != nil {
+		r.mu.Unlock()
+		r.failStart(cancel, watcher, context.Canceled)
+		return context.Canceled
+	}
+	r.state = StateRunning
+	r.connected = true
+	r.revision = snapshot.Revision()
+	r.updatedAt = now
+	r.disconnectedAt = time.Time{}
+	r.lastError = ""
+	r.watcher = watcher
+	r.snapshot = snapshot.Clone()
+	r.mu.Unlock()
+
+	go r.watch(runtimeCtx, watcher)
+	return nil
+}
+
+// Stop cancels Watch/Backoff, closes the current Watcher, and waits for exit.
+func (r *Router) Stop(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+
+	for {
+		r.mu.Lock()
+		switch r.state {
+		case StateNew:
+			r.state = StateStopped
+			r.connected = false
+			r.startDoneOnce.Do(func() { close(r.startDone) })
+			r.doneOnce.Do(func() { close(r.done) })
+			r.mu.Unlock()
+			return nil
+		case StateStarting:
+			cancel := r.cancel
+			startDone := r.startDone
+			r.mu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
+			select {
+			case <-startDone:
+				continue
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		case StateRunning:
+			r.state = StateStopping
+			r.connected = false
+			cancel := r.cancel
+			watcher := r.watcher
+			done := r.done
+			r.mu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
+			if !isNil(watcher) {
+				_ = watcher.Close()
+			}
+			return wait(ctx, done)
+		case StateStopping:
+			done := r.done
+			r.mu.Unlock()
+			return wait(ctx, done)
+		case StateStopped:
+			r.mu.Unlock()
+			return nil
+		default:
+			r.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// WatchNodeChanges subscribes to accepted full-state topology changes.
+//
+// A new watcher receives the current snapshot first. Pending updates are
+// latest-wins because every NodeChange includes the complete current topology.
+func (r *Router) WatchNodeChanges(ctx context.Context) (NodeChangeWatcher, error) {
+	if r == nil {
+		return nil, ErrNotRunning
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	r.mu.Lock()
+	if r.state != StateRunning {
+		r.mu.Unlock()
+		return nil, ErrNotRunning
+	}
+	watcher := &routerNodeChangeWatcher{
+		router:  r,
+		parent:  ctx,
+		updates: make(chan NodeChange, 1),
+		done:    make(chan struct{}),
+	}
+	r.changeWatchers[watcher] = struct{}{}
+	current := r.snapshot.Clone()
+	watcher.updates <- newNodeChange(registry.Snapshot{}, current)
+	r.mu.Unlock()
+	watcher.setStop(context.AfterFunc(ctx, func() {
+		_ = watcher.Close()
+	}))
+	return watcher, nil
+}
+
+// Pick selects from the current or bounded last-good snapshot.
+func (r *Router) Pick(ctx context.Context, target operation.Operation) (selector.Node, selector.Done, error) {
+	if r == nil {
+		return selector.Node{}, nil, ErrNotRunning
+	}
+	if ctx == nil {
+		return selector.Node{}, nil, fmt.Errorf(
+			"%w: context is nil",
+			ErrInvalidOption,
+		)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return selector.Node{}, nil, cause
+	}
+	r.mu.Lock()
+	state := r.state
+	connected := r.connected
+	disconnectedAt := r.disconnectedAt
+	maxStale := r.maxStale
+	r.mu.Unlock()
+	if state != StateRunning {
+		return selector.Node{}, nil, ErrNotRunning
+	}
+	if !connected &&
+		!disconnectedAt.IsZero() &&
+		time.Since(disconnectedAt) >= maxStale {
+		return selector.Node{}, nil, ErrStale
+	}
+	return r.selector.Select(ctx, target)
+}
+
+// Describe returns lifecycle, connection, revision, and reconnect diagnostics.
+func (r *Router) Describe() Description {
+	if r == nil {
+		return Description{State: StateStopped, LastError: "router is nil"}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	stale := r.state == StateRunning && !r.connected && !r.disconnectedAt.IsZero() && time.Since(r.disconnectedAt) >= r.maxStale
+	return Description{
+		Name:           r.name,
+		Service:        r.service,
+		State:          r.state,
+		Connected:      r.connected,
+		Stale:          stale,
+		Revision:       r.revision,
+		Instances:      len(r.snapshot.Instances()),
+		Subscribers:    len(r.changeWatchers),
+		Reconnects:     r.reconnects,
+		UpdatedAt:      r.updatedAt,
+		DisconnectedAt: r.disconnectedAt,
+		LastError:      r.lastError,
+	}
+}
+
+func (r *Router) watch(ctx context.Context, initial registry.Watcher) {
+	defer r.finish()
+	watcher := initial
+	backoff := r.reconnectMin
+	for {
+		snapshot, err := watcher.Next(ctx)
+		if err == nil {
+			r.applySnapshot(snapshot)
+			continue
+		}
+		_ = watcher.Close()
+		if context.Cause(ctx) != nil {
+			return
+		}
+		r.disconnected(err)
+
+		for {
+			if !waitBackoff(ctx, backoff) {
+				return
+			}
+			next, watchErr := r.discovery.Watch(ctx, r.service)
+			if watchErr != nil || isNil(next) {
+				if watchErr == nil {
+					watchErr = errors.New("discovery returned a nil watcher")
+				}
+				r.recordError(watchErr)
+				backoff = nextBackoff(backoff, r.reconnectMax)
+				continue
+			}
+			snapshot, nextErr := next.Next(ctx)
+			if nextErr != nil {
+				_ = next.Close()
+				if context.Cause(ctx) != nil {
+					return
+				}
+				r.recordError(nextErr)
+				backoff = nextBackoff(backoff, r.reconnectMax)
+				continue
+			}
+			r.reconnected(next)
+			r.applySnapshot(snapshot)
+			watcher = next
+			backoff = r.reconnectMin
+			break
+		}
+	}
+}
+
+func (r *Router) applySnapshot(snapshot registry.Snapshot) {
+	if err := r.selector.Update(snapshot); err != nil {
+		r.recordError(err)
+		return
+	}
+	r.mu.Lock()
+	change := newNodeChange(r.snapshot, snapshot)
+	watchers := make([]*routerNodeChangeWatcher, 0, len(r.changeWatchers))
+	for watcher := range r.changeWatchers {
+		watchers = append(watchers, watcher)
+	}
+	r.snapshot = snapshot.Clone()
+	r.revision = snapshot.Revision()
+	r.updatedAt = time.Now()
+	r.lastError = ""
+	r.mu.Unlock()
+	for _, watcher := range watchers {
+		watcher.publish(change)
+	}
+}
+
+func (r *Router) removeNodeChangeWatcher(watcher *routerNodeChangeWatcher) {
+	r.mu.Lock()
+	delete(r.changeWatchers, watcher)
+	r.mu.Unlock()
+}
+
+func (r *Router) disconnected(err error) {
+	r.mu.Lock()
+	r.connected = false
+	r.watcher = nil
+	r.disconnectedAt = time.Now()
+	if err != nil {
+		r.lastError = err.Error()
+	}
+	r.mu.Unlock()
+}
+
+func (r *Router) reconnected(watcher registry.Watcher) {
+	r.mu.Lock()
+	r.connected = true
+	r.disconnectedAt = time.Time{}
+	r.watcher = watcher
+	r.reconnects++
+	r.mu.Unlock()
+}
+
+func (r *Router) recordError(err error) {
+	if err == nil {
+		return
+	}
+	r.mu.Lock()
+	r.lastError = err.Error()
+	r.mu.Unlock()
+}
+
+func (r *Router) failStart(cancel context.CancelFunc, watcher registry.Watcher, err error) {
+	cancel()
+	if !isNil(watcher) {
+		_ = watcher.Close()
+	}
+	r.mu.Lock()
+	r.state = StateStopped
+	r.connected = false
+	r.watcher = nil
+	if err != nil {
+		r.lastError = err.Error()
+	}
+	r.doneOnce.Do(func() { close(r.done) })
+	r.mu.Unlock()
+}
+
+func (r *Router) finish() {
+	r.mu.Lock()
+	r.state = StateStopped
+	r.connected = false
+	r.watcher = nil
+	watchers := make([]*routerNodeChangeWatcher, 0, len(r.changeWatchers))
+	for watcher := range r.changeWatchers {
+		watchers = append(watchers, watcher)
+	}
+	r.changeWatchers = make(map[*routerNodeChangeWatcher]struct{})
+	r.doneOnce.Do(func() { close(r.done) })
+	r.mu.Unlock()
+	for _, watcher := range watchers {
+		_ = watcher.Close()
+	}
+}
+
+func wait(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func waitBackoff(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func nextBackoff(current, maximum time.Duration) time.Duration {
+	if current >= maximum/2 {
+		return maximum
+	}
+	return current * 2
+}
+
+func mergeContexts(primary context.Context, secondary context.Context) (context.Context, func()) {
+	merged, cancel := context.WithCancelCause(primary)
+	stop := context.AfterFunc(secondary, func() {
+		cancel(context.Cause(secondary))
+	})
+	return merged, func() {
+		stop()
+		cancel(nil)
+	}
+}
+
+func validName(value string) bool {
+	if value == "" || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/config/codec.go
+++ b/config/codec.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+const snapshotEncodingVersion = 1
+
+type encodedSnapshot struct {
+	Version  int                  `json:"version"`
+	Revision string               `json:"revision"`
+	Values   map[string]wireValue `json:"values"`
+}
+
+type wireValue struct {
+	Kind   string               `json:"kind"`
+	Scalar string               `json:"scalar,omitempty"`
+	Array  []wireValue          `json:"array,omitempty"`
+	Object map[string]wireValue `json:"object,omitempty"`
+}
+
+// MarshalSnapshot encodes an immutable Snapshot without losing scalar types.
+//
+// The format is versioned for durable last-good configuration caches. It is
+// not intended as a human-authored configuration format.
+func MarshalSnapshot(snapshot Snapshot) ([]byte, error) {
+	if err := snapshot.validate(); err != nil {
+		return nil, err
+	}
+	values := make(map[string]wireValue, len(snapshot.values))
+	for key, value := range snapshot.values {
+		encoded, err := encodeValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("config: encode key %q: %w", key, err)
+		}
+		values[key] = encoded
+	}
+	payload, err := json.Marshal(encodedSnapshot{
+		Version:  snapshotEncodingVersion,
+		Revision: snapshot.revision,
+		Values:   values,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("config: encode snapshot: %w", err)
+	}
+	return payload, nil
+}
+
+// UnmarshalSnapshot decodes the durable versioned Snapshot representation.
+func UnmarshalSnapshot(payload []byte) (Snapshot, error) {
+	var encoded encodedSnapshot
+	if err := json.Unmarshal(payload, &encoded); err != nil {
+		return Snapshot{}, fmt.Errorf("%w: decode snapshot: %w", ErrInvalidSnapshot, err)
+	}
+	if encoded.Version != snapshotEncodingVersion {
+		return Snapshot{}, fmt.Errorf("%w: unsupported encoding version %d", ErrInvalidSnapshot, encoded.Version)
+	}
+	values := make(map[string]any, len(encoded.Values))
+	for key, value := range encoded.Values {
+		decoded, err := decodeValue(value)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("%w: decode key %q: %w", ErrInvalidSnapshot, key, err)
+		}
+		values[key] = decoded
+	}
+	return NewSnapshot(encoded.Revision, values)
+}
+
+func encodeValue(value any) (wireValue, error) {
+	if value == nil {
+		return wireValue{Kind: "nil"}, nil
+	}
+	if _, ok := value.(deleteValue); ok {
+		return wireValue{Kind: "delete"}, nil
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Bool:
+		return wireValue{
+			Kind:   "bool",
+			Scalar: strconv.FormatBool(reflected.Bool()),
+		}, nil
+	case reflect.String:
+		return wireValue{
+			Kind:   "string",
+			Scalar: reflected.String(),
+		}, nil
+	case reflect.Int:
+		return integerValue("int", reflected.Int()), nil
+	case reflect.Int8:
+		return integerValue("int8", reflected.Int()), nil
+	case reflect.Int16:
+		return integerValue("int16", reflected.Int()), nil
+	case reflect.Int32:
+		return integerValue("int32", reflected.Int()), nil
+	case reflect.Int64:
+		return integerValue("int64", reflected.Int()), nil
+	case reflect.Uint:
+		return unsignedValue("uint", reflected.Uint()), nil
+	case reflect.Uint8:
+		return unsignedValue("uint8", reflected.Uint()), nil
+	case reflect.Uint16:
+		return unsignedValue("uint16", reflected.Uint()), nil
+	case reflect.Uint32:
+		return unsignedValue("uint32", reflected.Uint()), nil
+	case reflect.Uint64:
+		return unsignedValue("uint64", reflected.Uint()), nil
+	case reflect.Float32:
+		return wireValue{
+			Kind:   "float32",
+			Scalar: strconv.FormatFloat(reflected.Float(), 'g', -1, 32),
+		}, nil
+	case reflect.Float64:
+		return wireValue{
+			Kind:   "float64",
+			Scalar: strconv.FormatFloat(reflected.Float(), 'g', -1, 64),
+		}, nil
+	case reflect.Array, reflect.Slice:
+		result := make([]wireValue, reflected.Len())
+		for index := range reflected.Len() {
+			encoded, err := encodeValue(reflected.Index(index).Interface())
+			if err != nil {
+				return wireValue{}, err
+			}
+			result[index] = encoded
+		}
+		return wireValue{Kind: "array", Array: result}, nil
+	case reflect.Map:
+		if reflected.Type().Key().Kind() != reflect.String {
+			return wireValue{}, fmt.Errorf("map key type %s is not string", reflected.Type().Key())
+		}
+		result := make(map[string]wireValue, reflected.Len())
+		iterator := reflected.MapRange()
+		for iterator.Next() {
+			encoded, err := encodeValue(iterator.Value().Interface())
+			if err != nil {
+				return wireValue{}, err
+			}
+			result[iterator.Key().String()] = encoded
+		}
+		return wireValue{Kind: "object", Object: result}, nil
+	default:
+		return wireValue{}, fmt.Errorf("unsupported value type %T", value)
+	}
+}
+
+func decodeValue(value wireValue) (any, error) {
+	switch value.Kind {
+	case "nil":
+		return nil, nil
+	case "delete":
+		return Delete(), nil
+	case "bool":
+		return strconv.ParseBool(value.Scalar)
+	case "string":
+		return value.Scalar, nil
+	case "int":
+		parsed, err := strconv.ParseInt(value.Scalar, 10, 0)
+		return int(parsed), err
+	case "int8":
+		parsed, err := strconv.ParseInt(value.Scalar, 10, 8)
+		return int8(parsed), err
+	case "int16":
+		parsed, err := strconv.ParseInt(value.Scalar, 10, 16)
+		return int16(parsed), err
+	case "int32":
+		parsed, err := strconv.ParseInt(value.Scalar, 10, 32)
+		return int32(parsed), err
+	case "int64":
+		return strconv.ParseInt(value.Scalar, 10, 64)
+	case "uint":
+		parsed, err := strconv.ParseUint(value.Scalar, 10, 0)
+		return uint(parsed), err
+	case "uint8":
+		parsed, err := strconv.ParseUint(value.Scalar, 10, 8)
+		return uint8(parsed), err
+	case "uint16":
+		parsed, err := strconv.ParseUint(value.Scalar, 10, 16)
+		return uint16(parsed), err
+	case "uint32":
+		parsed, err := strconv.ParseUint(value.Scalar, 10, 32)
+		return uint32(parsed), err
+	case "uint64":
+		return strconv.ParseUint(value.Scalar, 10, 64)
+	case "float32":
+		parsed, err := strconv.ParseFloat(value.Scalar, 32)
+		return float32(parsed), err
+	case "float64":
+		return strconv.ParseFloat(value.Scalar, 64)
+	case "array":
+		result := make([]any, len(value.Array))
+		for index, item := range value.Array {
+			decoded, err := decodeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = decoded
+		}
+		return result, nil
+	case "object":
+		result := make(map[string]any, len(value.Object))
+		for key, item := range value.Object {
+			decoded, err := decodeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = decoded
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unknown value kind %q", value.Kind)
+	}
+}
+
+func integerValue(kind string, value int64) wireValue {
+	return wireValue{Kind: kind, Scalar: strconv.FormatInt(value, 10)}
+}
+
+func unsignedValue(kind string, value uint64) wireValue {
+	return wireValue{Kind: kind, Scalar: strconv.FormatUint(value, 10)}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,548 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Option configures a Manager.
+type Option interface {
+	apply(*managerOptions) error
+}
+
+type optionFunc func(*managerOptions) error
+
+func (function optionFunc) apply(options *managerOptions) error {
+	return function(options)
+}
+
+type managerOptions struct {
+	sources       []Source
+	validators    []Validator
+	bindings      []Binding
+	unknownPolicy UnknownFieldPolicy
+	knownFields   []string
+}
+
+// WithSources registers Sources from low to high priority.
+func WithSources(sources ...Source) Option {
+	snapshot := append([]Source(nil), sources...)
+	return optionFunc(func(options *managerOptions) error {
+		for index, source := range snapshot {
+			if isNil(source) {
+				return fmt.Errorf("source %d is nil", index)
+			}
+		}
+		options.sources = append(options.sources, snapshot...)
+		return nil
+	})
+}
+
+// WithValidator registers a merged-snapshot Validator.
+func WithValidator(validator Validator) Option {
+	return optionFunc(func(options *managerOptions) error {
+		if validator == nil {
+			return fmt.Errorf("validator is nil")
+		}
+		options.validators = append(options.validators, validator)
+		return nil
+	})
+}
+
+// WithBindings registers typed component configuration as both pre-publish
+// validators and post-publish named subscribers.
+func WithBindings(bindings ...Binding) Option {
+	snapshot := append([]Binding(nil), bindings...)
+	return optionFunc(func(options *managerOptions) error {
+		for index, binding := range snapshot {
+			if isNil(binding) {
+				return fmt.Errorf("binding %d is nil", index)
+			}
+		}
+		options.bindings = append(options.bindings, snapshot...)
+		return nil
+	})
+}
+
+// WithUnknownFieldPolicy selects allow or reject behavior.
+func WithUnknownFieldPolicy(policy UnknownFieldPolicy) Option {
+	return optionFunc(func(options *managerOptions) error {
+		if policy != UnknownAllow && policy != UnknownReject {
+			return fmt.Errorf("unknown field policy %d is invalid", policy)
+		}
+		options.unknownPolicy = policy
+		return nil
+	})
+}
+
+// WithKnownFields adds dot-separated known paths. A final * allows one
+// arbitrary child subtree.
+func WithKnownFields(paths ...string) Option {
+	snapshot := append([]string(nil), paths...)
+	return optionFunc(func(options *managerOptions) error {
+		for _, path := range snapshot {
+			if strings.TrimSpace(path) == "" {
+				return fmt.Errorf("known field path is empty")
+			}
+		}
+		options.knownFields = append(options.knownFields, snapshot...)
+		return nil
+	})
+}
+
+type publishedSnapshot struct {
+	snapshot Snapshot
+}
+
+// Manager loads, validates, watches, and atomically publishes configuration.
+type Manager struct {
+	sources       []Source
+	validators    []Validator
+	unknownPolicy UnknownFieldPolicy
+	schema        *schemaNode
+
+	current atomic.Pointer[publishedSnapshot]
+
+	updateMu sync.Mutex
+
+	subscriberMu sync.Mutex
+	subscribers  map[string]Subscriber
+	statuses     map[string]SubscriberStatus
+
+	rejectedMu   sync.Mutex
+	lastRejected string
+
+	watchMu  sync.Mutex
+	watching bool
+}
+
+// New validates options and constructs an isolated Manager.
+func New(optionList ...Option) (*Manager, error) {
+	settings := managerOptions{unknownPolicy: UnknownAllow}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	if len(settings.sources) == 0 {
+		return nil, fmt.Errorf("%w: at least one Source is required", ErrInvalidOption)
+	}
+	if settings.unknownPolicy == UnknownReject && len(settings.knownFields) == 0 {
+		return nil, fmt.Errorf("%w: reject policy requires known fields", ErrInvalidOption)
+	}
+	schema, err := buildSchema(settings.knownFields)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidOption, err)
+	}
+
+	validators := append([]Validator(nil), settings.validators...)
+	subscribers := make(map[string]Subscriber, len(settings.bindings))
+	for index, binding := range settings.bindings {
+		name := strings.TrimSpace(binding.Name())
+		if name == "" {
+			return nil, fmt.Errorf("%w: binding %d has an empty name", ErrInvalidOption, index)
+		}
+		if _, duplicate := subscribers[name]; duplicate {
+			return nil, fmt.Errorf("%w: binding %q", ErrDuplicateSubscriber, name)
+		}
+		subject := binding
+		validators = append(validators, subject.Validate)
+		subscribers[name] = subject.Apply
+	}
+
+	return &Manager{
+		sources:       append([]Source(nil), settings.sources...),
+		validators:    validators,
+		unknownPolicy: settings.unknownPolicy,
+		schema:        schema,
+		subscribers:   subscribers,
+		statuses:      make(map[string]SubscriberStatus),
+	}, nil
+}
+
+// Load reads every Source, merges them, and atomically publishes a valid
+// Snapshot.
+func (manager *Manager) Load(ctx context.Context) (Snapshot, error) {
+	if ctx == nil {
+		return Snapshot{}, fmt.Errorf("%w: nil context", ErrInvalidOption)
+	}
+	snapshots, err := manager.loadSources(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	merged, err := Merge(snapshots...)
+	if err != nil {
+		manager.recordRejected(err)
+		return Snapshot{}, err
+	}
+	published, _, err := manager.publish(ctx, merged)
+	return published, err
+}
+
+// Watch establishes all Source watchers before loading and then processes
+// complete snapshot updates until ctx ends or a watcher fails.
+func (manager *Manager) Watch(ctx context.Context) error {
+	return manager.watch(ctx, nil)
+}
+
+func (manager *Manager) watch(ctx context.Context, ready chan<- error) (result error) {
+	readySent := false
+	notifyReady := func(err error) {
+		if readySent {
+			return
+		}
+		readySent = true
+		if ready != nil {
+			ready <- err
+		}
+	}
+	defer func() {
+		if !readySent {
+			notifyReady(result)
+		}
+	}()
+	if ctx == nil {
+		return fmt.Errorf("%w: nil context", ErrInvalidOption)
+	}
+	if !manager.beginWatch() {
+		return ErrAlreadyWatching
+	}
+	defer manager.endWatch()
+
+	watchContext, cancel := context.WithCancel(ctx)
+	watchers := make([]Watcher, 0, len(manager.sources))
+	for index, source := range manager.sources {
+		watcher, err := source.Watch(watchContext)
+		if err != nil {
+			cancel()
+			closeWatchers(watchers)
+			return fmt.Errorf("config: watch source %d: %w", index, err)
+		}
+		if isNil(watcher) {
+			cancel()
+			closeWatchers(watchers)
+			return fmt.Errorf("config: watch source %d returned nil", index)
+		}
+		watchers = append(watchers, watcher)
+	}
+
+	events := make(chan watchEvent, len(watchers)*2)
+	var readers sync.WaitGroup
+	readers.Add(len(watchers))
+	for index, watcher := range watchers {
+		go readWatcher(watchContext, &readers, events, index, watcher)
+	}
+	defer func() {
+		cancel()
+		closeWatchers(watchers)
+		readers.Wait()
+	}()
+
+	sourceSnapshots, err := manager.loadSources(watchContext)
+	if err != nil {
+		return err
+	}
+	merged, err := Merge(sourceSnapshots...)
+	if err != nil {
+		manager.recordRejected(err)
+		return err
+	}
+	if _, _, err := manager.publish(watchContext, merged); err != nil {
+		return err
+	}
+	notifyReady(nil)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case event := <-events:
+			if event.err != nil {
+				if cause := context.Cause(watchContext); cause != nil {
+					return cause
+				}
+				return fmt.Errorf("config: watch source %d: %w", event.index, event.err)
+			}
+
+			candidateSources := append([]Snapshot(nil), sourceSnapshots...)
+			candidateSources[event.index] = event.snapshot
+			candidate, mergeErr := Merge(candidateSources...)
+			if mergeErr != nil {
+				manager.recordRejected(mergeErr)
+				continue
+			}
+			_, changed, publishErr := manager.publish(watchContext, candidate)
+			if publishErr != nil {
+				continue
+			}
+			if changed {
+				sourceSnapshots = candidateSources
+			}
+		}
+	}
+}
+
+// Current returns a deep copy of the current complete Snapshot.
+func (manager *Manager) Current() (Snapshot, bool) {
+	published := manager.current.Load()
+	if published == nil {
+		return Snapshot{}, false
+	}
+	return published.snapshot.Clone(), true
+}
+
+// Subscribe registers a uniquely named Subscriber.
+func (manager *Manager) Subscribe(name string, subscriber Subscriber) error {
+	normalizedName := strings.TrimSpace(name)
+	if normalizedName == "" || subscriber == nil {
+		return fmt.Errorf("%w: subscriber name or function is empty", ErrInvalidOption)
+	}
+	manager.subscriberMu.Lock()
+	defer manager.subscriberMu.Unlock()
+	if _, duplicate := manager.subscribers[normalizedName]; duplicate {
+		return fmt.Errorf("%w: %s", ErrDuplicateSubscriber, normalizedName)
+	}
+	manager.subscribers[normalizedName] = subscriber
+	return nil
+}
+
+// Unsubscribe removes a Subscriber and its status.
+func (manager *Manager) Unsubscribe(name string) {
+	manager.subscriberMu.Lock()
+	defer manager.subscriberMu.Unlock()
+	delete(manager.subscribers, strings.TrimSpace(name))
+	delete(manager.statuses, strings.TrimSpace(name))
+}
+
+// SubscriberStatuses returns statuses in lexical name order.
+func (manager *Manager) SubscriberStatuses() []SubscriberStatus {
+	manager.subscriberMu.Lock()
+	defer manager.subscriberMu.Unlock()
+	statuses := make([]SubscriberStatus, 0, len(manager.statuses))
+	for _, status := range manager.statuses {
+		statuses = append(statuses, status)
+	}
+	sort.Slice(statuses, func(first, second int) bool {
+		return statuses[first].Name < statuses[second].Name
+	})
+	return statuses
+}
+
+// LastRejected returns the latest rejected snapshot error for diagnostics.
+func (manager *Manager) LastRejected() string {
+	manager.rejectedMu.Lock()
+	defer manager.rejectedMu.Unlock()
+	return manager.lastRejected
+}
+
+func (manager *Manager) loadSources(ctx context.Context) ([]Snapshot, error) {
+	snapshots := make([]Snapshot, len(manager.sources))
+	for index, source := range manager.sources {
+		if cause := context.Cause(ctx); cause != nil {
+			return nil, cause
+		}
+		snapshot, err := source.Load(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("config: load source %d: %w", index, err)
+		}
+		if err := snapshot.validate(); err != nil {
+			return nil, fmt.Errorf("config: load source %d: %w", index, err)
+		}
+		snapshots[index] = snapshot
+	}
+	return snapshots, nil
+}
+
+func (manager *Manager) publish(
+	ctx context.Context,
+	candidate Snapshot,
+) (Snapshot, bool, error) {
+	manager.updateMu.Lock()
+	defer manager.updateMu.Unlock()
+
+	if current := manager.current.Load(); current != nil &&
+		current.snapshot.revision == candidate.revision {
+		return current.snapshot.Clone(), false, nil
+	}
+	if manager.unknownPolicy == UnknownReject {
+		if err := manager.schema.validate(candidate.values); err != nil {
+			manager.recordRejected(err)
+			return Snapshot{}, false, err
+		}
+	}
+	for index, validator := range manager.validators {
+		if err := validator(candidate.Clone()); err != nil {
+			wrapped := fmt.Errorf("%w: validator %d: %w", ErrValidation, index, err)
+			manager.recordRejected(wrapped)
+			return Snapshot{}, false, wrapped
+		}
+	}
+
+	stored := candidate.Clone()
+	manager.current.Store(&publishedSnapshot{snapshot: stored})
+	manager.notifySubscribers(ctx, stored)
+	return stored.Clone(), true, nil
+}
+
+func (manager *Manager) notifySubscribers(ctx context.Context, snapshot Snapshot) {
+	manager.subscriberMu.Lock()
+	names := make([]string, 0, len(manager.subscribers))
+	subscribers := make(map[string]Subscriber, len(manager.subscribers))
+	for name, subscriber := range manager.subscribers {
+		names = append(names, name)
+		subscribers[name] = subscriber
+	}
+	manager.subscriberMu.Unlock()
+	sort.Strings(names)
+
+	for _, name := range names {
+		err := subscribers[name](ctx, snapshot.Clone())
+		status := SubscriberStatus{
+			Name:      name,
+			Revision:  snapshot.revision,
+			AppliedAt: time.Now().UTC(),
+		}
+		if err != nil {
+			status.RestartRequired = errors.Is(err, ErrRestartRequired)
+			status.LastError = err.Error()
+		}
+		manager.subscriberMu.Lock()
+		if manager.subscribers[name] != nil {
+			manager.statuses[name] = status
+		}
+		manager.subscriberMu.Unlock()
+	}
+}
+
+func (manager *Manager) recordRejected(err error) {
+	if err == nil {
+		return
+	}
+	manager.rejectedMu.Lock()
+	manager.lastRejected = err.Error()
+	manager.rejectedMu.Unlock()
+}
+
+func (manager *Manager) beginWatch() bool {
+	manager.watchMu.Lock()
+	defer manager.watchMu.Unlock()
+	if manager.watching {
+		return false
+	}
+	manager.watching = true
+	return true
+}
+
+func (manager *Manager) endWatch() {
+	manager.watchMu.Lock()
+	manager.watching = false
+	manager.watchMu.Unlock()
+}
+
+type watchEvent struct {
+	index    int
+	snapshot Snapshot
+	err      error
+}
+
+func readWatcher(ctx context.Context, readers *sync.WaitGroup, events chan<- watchEvent, index int, watcher Watcher) {
+	defer readers.Done()
+	for {
+		snapshot, err := watcher.Next(ctx)
+		event := watchEvent{index: index, snapshot: snapshot, err: err}
+		select {
+		case events <- event:
+		case <-ctx.Done():
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func closeWatchers(watchers []Watcher) {
+	for _, watcher := range watchers {
+		_ = watcher.Close()
+	}
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+type schemaNode struct {
+	children map[string]*schemaNode
+	terminal bool
+}
+
+func buildSchema(paths []string) (*schemaNode, error) {
+	root := &schemaNode{children: make(map[string]*schemaNode)}
+	for _, path := range paths {
+		segments := strings.Split(path, ".")
+		current := root
+		for index, segment := range segments {
+			if segment == "" || segment == "*" && index != len(segments)-1 {
+				return nil, fmt.Errorf("config: invalid known field path %q", path)
+			}
+			next := current.children[segment]
+			if next == nil {
+				next = &schemaNode{children: make(map[string]*schemaNode)}
+				current.children[segment] = next
+			}
+			current = next
+		}
+		current.terminal = true
+	}
+	return root, nil
+}
+
+func (schema *schemaNode) validate(values map[string]any) error {
+	return schema.validateAt(values, nil)
+}
+
+func (schema *schemaNode) validateAt(values map[string]any, path []string) error {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		child := schema.children[key]
+		if child == nil {
+			child = schema.children["*"]
+		}
+		currentPath := append(append([]string(nil), path...), key)
+		if child == nil {
+			return fmt.Errorf("%w: %s", ErrUnknownField, strings.Join(currentPath, "."))
+		}
+		if child.terminal {
+			continue
+		}
+		if nested, ok := values[key].(map[string]any); ok {
+			if err := child.validateAt(nested, currentPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/config/env/json.go
+++ b/config/env/json.go
@@ -1,0 +1,42 @@
+package env
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	jsonValuePrefix   = "json:"
+	maxJSONValueBytes = 1 * 1024 * 1024
+)
+
+// JSONValueParser preserves ordinary environment strings and strictly
+// decodes values prefixed with "json:".
+//
+// The explicit prefix prevents service versions, numeric-looking identifiers,
+// durations, and boolean-looking strings from changing type accidentally.
+func JSONValueParser(_ []string, value string) (any, error) {
+	if !strings.HasPrefix(value, jsonValuePrefix) {
+		return value, nil
+	}
+	payload := strings.TrimPrefix(value, jsonValuePrefix)
+	if payload == "" || len(payload) > maxJSONValueBytes {
+		return nil, fmt.Errorf("%w: json value is empty or exceeds %d bytes", ErrInvalidOption, maxJSONValueBytes)
+	}
+	decoder := json.NewDecoder(strings.NewReader(payload))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("%w: invalid json value", ErrInvalidOption)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, fmt.Errorf(
+			"%w: json value contains trailing data",
+			ErrInvalidOption,
+		)
+	}
+	return decoded, nil
+}

--- a/config/env/os.go
+++ b/config/env/os.go
@@ -1,0 +1,7 @@
+package env
+
+import "os"
+
+func defaultEnviron() []string {
+	return os.Environ()
+}

--- a/config/env/source.go
+++ b/config/env/source.go
@@ -1,0 +1,282 @@
+// Package env provides prefix-scoped environment configuration snapshots.
+package env
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/config"
+)
+
+const defaultPollInterval = time.Second
+
+var (
+	// ErrInvalidOption reports an invalid environment source option.
+	ErrInvalidOption = errors.New("config/env: invalid option")
+	// ErrDuplicatePath reports environment keys that normalize to one path.
+	ErrDuplicatePath = errors.New("config/env: duplicate normalized path")
+	// ErrPathConflict reports a scalar key that is also used as a parent path.
+	ErrPathConflict = errors.New("config/env: conflicting normalized path")
+)
+
+// Parser converts one environment string into a configuration value.
+type Parser func(path []string, value string) (any, error)
+
+// Option configures a Source.
+type Option interface {
+	apply(*options) error
+}
+
+type optionFunc func(*options) error
+
+func (function optionFunc) apply(options *options) error {
+	return function(options)
+}
+
+type options struct {
+	separator    string
+	pollInterval time.Duration
+	environ      func() []string
+	parser       Parser
+}
+
+// WithSeparator sets the nested-key separator. The default is "__".
+func WithSeparator(separator string) Option {
+	return optionFunc(func(options *options) error {
+		if separator == "" || strings.Contains(separator, "=") {
+			return fmt.Errorf("%w: separator is invalid", ErrInvalidOption)
+		}
+		options.separator = separator
+		return nil
+	})
+}
+
+// WithPollInterval sets the interval used by Watch.
+func WithPollInterval(interval time.Duration) Option {
+	return optionFunc(func(options *options) error {
+		if interval <= 0 {
+			return fmt.Errorf("%w: poll interval must be positive", ErrInvalidOption)
+		}
+		options.pollInterval = interval
+		return nil
+	})
+}
+
+// WithEnviron replaces os.Environ, primarily for deterministic hosts and
+// tests.
+func WithEnviron(environ func() []string) Option {
+	return optionFunc(func(options *options) error {
+		if environ == nil {
+			return fmt.Errorf("%w: environ function is nil", ErrInvalidOption)
+		}
+		options.environ = environ
+		return nil
+	})
+}
+
+// WithParser converts selected values instead of retaining strings.
+func WithParser(parser Parser) Option {
+	return optionFunc(func(options *options) error {
+		if parser == nil {
+			return fmt.Errorf("%w: parser is nil", ErrInvalidOption)
+		}
+		options.parser = parser
+		return nil
+	})
+}
+
+// Source maps PREFIX_FOO__BAR to the path foo.bar.
+type Source struct {
+	prefix       string
+	separator    string
+	pollInterval time.Duration
+	environ      func() []string
+	parser       Parser
+}
+
+// New constructs a prefix-scoped environment Source.
+func New(prefix string, optionList ...Option) (*Source, error) {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" || strings.Contains(prefix, "=") {
+		return nil, fmt.Errorf("%w: prefix is invalid", ErrInvalidOption)
+	}
+	settings := options{
+		separator:    "__",
+		pollInterval: defaultPollInterval,
+		environ:      defaultEnviron,
+		parser: func(_ []string, value string) (any, error) {
+			return value, nil
+		},
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("config/env: option %d: %w", index, err)
+		}
+	}
+	return &Source{
+		prefix:       prefix,
+		separator:    settings.separator,
+		pollInterval: settings.pollInterval,
+		environ:      settings.environ,
+		parser:       settings.parser,
+	}, nil
+}
+
+// Load captures a complete deterministic snapshot of selected variables.
+func (source *Source) Load(ctx context.Context) (config.Snapshot, error) {
+	if ctx == nil {
+		return config.Snapshot{}, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if err := context.Cause(ctx); err != nil {
+		return config.Snapshot{}, err
+	}
+	type entry struct {
+		key   string
+		value string
+	}
+	entries := make([]entry, 0)
+	for _, raw := range source.environ() {
+		key, value, found := strings.Cut(raw, "=")
+		if !found || !strings.HasPrefix(key, source.prefix) {
+			continue
+		}
+		entries = append(entries, entry{key: key, value: value})
+	}
+	sort.Slice(entries, func(left, right int) bool {
+		return entries[left].key < entries[right].key
+	})
+
+	values := make(map[string]any)
+	seen := make(map[string]string, len(entries))
+	hasher := sha256.New()
+	for _, entry := range entries {
+		path, err := source.path(entry.key)
+		if err != nil {
+			return config.Snapshot{}, err
+		}
+		normalized := strings.Join(path, ".")
+		if previous, duplicate := seen[normalized]; duplicate {
+			return config.Snapshot{}, fmt.Errorf("%w: %s and %s become %s", ErrDuplicatePath, previous, entry.key, normalized)
+		}
+		for existing, previous := range seen {
+			if strings.HasPrefix(existing, normalized+".") ||
+				strings.HasPrefix(normalized, existing+".") {
+				return config.Snapshot{}, fmt.Errorf("%w: %s and %s conflict at %s/%s", ErrPathConflict, previous, entry.key, existing, normalized)
+			}
+		}
+		seen[normalized] = entry.key
+		parsed, err := source.parser(append([]string(nil), path...), entry.value)
+		if err != nil {
+			return config.Snapshot{}, fmt.Errorf(
+				"config/env: parse %s: %w",
+				entry.key,
+				err,
+			)
+		}
+		set(values, path, parsed)
+		_, _ = hasher.Write([]byte(entry.key))
+		_, _ = hasher.Write([]byte{0})
+		_, _ = hasher.Write([]byte(entry.value))
+		_, _ = hasher.Write([]byte{0})
+	}
+	revision := "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+	return config.NewSnapshot(revision, values)
+}
+
+// Watch polls the selected environment snapshot and emits revisions.
+func (source *Source) Watch(ctx context.Context) (config.Watcher, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	initial, err := source.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &watcher{
+		source:       source,
+		lastRevision: initial.Revision(),
+		closed:       make(chan struct{}),
+	}, nil
+}
+
+func (source *Source) path(key string) ([]string, error) {
+	relative := strings.TrimPrefix(key, source.prefix)
+	relative = strings.TrimPrefix(relative, "_")
+	if relative == "" {
+		return nil, fmt.Errorf("%w: %s has an empty path", ErrInvalidOption, key)
+	}
+	segments := strings.Split(relative, source.separator)
+	for index, segment := range segments {
+		segment = strings.ToLower(strings.TrimSpace(segment))
+		if segment == "" {
+			return nil, fmt.Errorf(
+				"%w: %s has an empty path segment",
+				ErrInvalidOption,
+				key,
+			)
+		}
+		segments[index] = segment
+	}
+	return segments, nil
+}
+
+type watcher struct {
+	source       *Source
+	lastRevision string
+	closed       chan struct{}
+	closeOnce    sync.Once
+}
+
+func (watcher *watcher) Next(ctx context.Context) (config.Snapshot, error) {
+	if ctx == nil {
+		return config.Snapshot{}, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	ticker := time.NewTicker(watcher.source.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return config.Snapshot{}, context.Cause(ctx)
+		case <-watcher.closed:
+			return config.Snapshot{}, config.ErrWatcherClosed
+		case <-ticker.C:
+			snapshot, err := watcher.source.Load(ctx)
+			if err != nil {
+				return config.Snapshot{}, err
+			}
+			if snapshot.Revision() == watcher.lastRevision {
+				continue
+			}
+			watcher.lastRevision = snapshot.Revision()
+			return snapshot, nil
+		}
+	}
+}
+
+func (watcher *watcher) Close() error {
+	watcher.closeOnce.Do(func() { close(watcher.closed) })
+	return nil
+}
+
+func set(values map[string]any, path []string, value any) {
+	current := values
+	for _, segment := range path[:len(path)-1] {
+		next, ok := current[segment].(map[string]any)
+		if !ok {
+			next = make(map[string]any)
+			current[segment] = next
+		}
+		current = next
+	}
+	current[path[len(path)-1]] = value
+}

--- a/config/file/source.go
+++ b/config/file/source.go
@@ -1,0 +1,320 @@
+// Package file provides JSON and YAML file-backed configuration snapshots.
+package file
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/config"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultMaxBytes     = 4 * 1024 * 1024
+	defaultPollInterval = 500 * time.Millisecond
+)
+
+var (
+	// ErrInvalidOption reports an invalid file source option.
+	ErrInvalidOption = errors.New("config/file: invalid option")
+	// ErrTooLarge reports a file exceeding the configured byte budget.
+	ErrTooLarge = errors.New("config/file: file is too large")
+	// ErrUnsupportedFormat reports an unknown or ambiguous file format.
+	ErrUnsupportedFormat = errors.New("config/file: unsupported format")
+)
+
+// Format identifies the on-disk configuration syntax.
+type Format string
+
+const (
+	// FormatAuto derives JSON or YAML from the file extension.
+	FormatAuto Format = ""
+	// FormatJSON decodes one JSON object.
+	FormatJSON Format = "json"
+	// FormatYAML decodes one YAML document.
+	FormatYAML Format = "yaml"
+)
+
+// Option configures a Source.
+type Option interface {
+	apply(*options) error
+}
+
+type optionFunc func(*options) error
+
+func (function optionFunc) apply(options *options) error {
+	return function(options)
+}
+
+type options struct {
+	format       Format
+	maxBytes     int64
+	pollInterval time.Duration
+}
+
+// WithFormat explicitly selects JSON or YAML.
+func WithFormat(format Format) Option {
+	return optionFunc(func(options *options) error {
+		switch format {
+		case FormatAuto, FormatJSON, FormatYAML:
+			options.format = format
+			return nil
+		default:
+			return fmt.Errorf("%w: %q", ErrUnsupportedFormat, format)
+		}
+	})
+}
+
+// WithMaxBytes sets the maximum accepted file size.
+func WithMaxBytes(maxBytes int64) Option {
+	return optionFunc(func(options *options) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("%w: max bytes must be positive", ErrInvalidOption)
+		}
+		options.maxBytes = maxBytes
+		return nil
+	})
+}
+
+// WithPollInterval sets the interval used by Watch.
+func WithPollInterval(interval time.Duration) Option {
+	return optionFunc(func(options *options) error {
+		if interval <= 0 {
+			return fmt.Errorf("%w: poll interval must be positive", ErrInvalidOption)
+		}
+		options.pollInterval = interval
+		return nil
+	})
+}
+
+// Source reads complete immutable snapshots from one file.
+type Source struct {
+	path         string
+	format       Format
+	maxBytes     int64
+	pollInterval time.Duration
+}
+
+// New constructs a file Source without reading the file.
+func New(path string, optionList ...Option) (*Source, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("%w: path is empty", ErrInvalidOption)
+	}
+	settings := options{
+		maxBytes:     defaultMaxBytes,
+		pollInterval: defaultPollInterval,
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("config/file: option %d: %w", index, err)
+		}
+	}
+	format := settings.format
+	if format == FormatAuto {
+		var err error
+		format, err = formatFromPath(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Source{
+		path:         path,
+		format:       format,
+		maxBytes:     settings.maxBytes,
+		pollInterval: settings.pollInterval,
+	}, nil
+}
+
+// Load reads, decodes, and fingerprints the complete file.
+func (source *Source) Load(ctx context.Context) (config.Snapshot, error) {
+	if ctx == nil {
+		return config.Snapshot{}, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if err := context.Cause(ctx); err != nil {
+		return config.Snapshot{}, err
+	}
+	content, err := readLimited(source.path, source.maxBytes)
+	if err != nil {
+		return config.Snapshot{}, err
+	}
+	if err := context.Cause(ctx); err != nil {
+		return config.Snapshot{}, err
+	}
+	values, err := decode(content, source.format)
+	if err != nil {
+		return config.Snapshot{}, fmt.Errorf(
+			"config/file: decode %s: %w",
+			source.path,
+			err,
+		)
+	}
+	sum := sha256.Sum256(content)
+	revision := "sha256:" + hex.EncodeToString(sum[:])
+	return config.NewSnapshot(revision, values)
+}
+
+// Watch returns a polling watcher that emits only complete changed snapshots.
+func (source *Source) Watch(ctx context.Context) (config.Watcher, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	initial, err := source.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &watcher{
+		source:       source,
+		lastRevision: initial.Revision(),
+		closed:       make(chan struct{}),
+	}, nil
+}
+
+type watcher struct {
+	source *Source
+
+	mu           sync.RWMutex
+	lastRevision string
+	lastError    error
+	closed       chan struct{}
+	closeOnce    sync.Once
+}
+
+func (watcher *watcher) Next(ctx context.Context) (config.Snapshot, error) {
+	if ctx == nil {
+		return config.Snapshot{}, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	ticker := time.NewTicker(watcher.source.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return config.Snapshot{}, context.Cause(ctx)
+		case <-watcher.closed:
+			return config.Snapshot{}, config.ErrWatcherClosed
+		case <-ticker.C:
+			snapshot, err := watcher.source.Load(ctx)
+			if err != nil {
+				watcher.recordError(err)
+				continue
+			}
+			watcher.mu.Lock()
+			watcher.lastError = nil
+			if snapshot.Revision() == watcher.lastRevision {
+				watcher.mu.Unlock()
+				continue
+			}
+			watcher.lastRevision = snapshot.Revision()
+			watcher.mu.Unlock()
+			return snapshot, nil
+		}
+	}
+}
+
+func (watcher *watcher) Close() error {
+	watcher.closeOnce.Do(func() { close(watcher.closed) })
+	return nil
+}
+
+// LastError returns the most recent transient read/decode failure observed
+// while Watch retained the last-good snapshot.
+func (watcher *watcher) LastError() error {
+	watcher.mu.RLock()
+	defer watcher.mu.RUnlock()
+	return watcher.lastError
+}
+
+func (watcher *watcher) recordError(err error) {
+	watcher.mu.Lock()
+	watcher.lastError = err
+	watcher.mu.Unlock()
+}
+
+func formatFromPath(path string) (Format, error) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		return FormatJSON, nil
+	case ".yaml", ".yml":
+		return FormatYAML, nil
+	default:
+		return FormatAuto, fmt.Errorf(
+			"%w: cannot infer from %q",
+			ErrUnsupportedFormat,
+			path,
+		)
+	}
+}
+
+func readLimited(path string, maxBytes int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("config/file: open %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+	content, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("config/file: read %s: %w", path, err)
+	}
+	if int64(len(content)) > maxBytes {
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrTooLarge, path, maxBytes)
+	}
+	return content, nil
+}
+
+func decode(content []byte, format Format) (map[string]any, error) {
+	values := make(map[string]any)
+	switch format {
+	case FormatJSON:
+		decoder := json.NewDecoder(bytes.NewReader(content))
+		decoder.UseNumber()
+		if err := decoder.Decode(&values); err != nil {
+			return nil, err
+		}
+		if err := requireEOFJSON(decoder); err != nil {
+			return nil, err
+		}
+	case FormatYAML:
+		decoder := yaml.NewDecoder(bytes.NewReader(content))
+		if err := decoder.Decode(&values); err != nil {
+			return nil, err
+		}
+		var extra any
+		if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+			if err == nil {
+				return nil, errors.New("multiple YAML documents are not supported")
+			}
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedFormat, format)
+	}
+	if values == nil {
+		return map[string]any{}, nil
+	}
+	return values, nil
+}
+
+func requireEOFJSON(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values are not supported")
+		}
+		return err
+	}
+	return nil
+}

--- a/config/merge.go
+++ b/config/merge.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Merge combines Snapshots from low to high priority.
+func Merge(snapshots ...Snapshot) (Snapshot, error) {
+	if len(snapshots) == 0 {
+		return Snapshot{}, fmt.Errorf("%w: no snapshots to merge", ErrInvalidSnapshot)
+	}
+
+	merged := make(map[string]any)
+	revisions := make([]string, len(snapshots))
+	for index, snapshot := range snapshots {
+		if err := snapshot.validate(); err != nil {
+			return Snapshot{}, fmt.Errorf("config: source %d: %w", index, err)
+		}
+		revisions[index] = snapshot.revision
+		mergeMap(merged, snapshot.values)
+	}
+
+	values, err := cloneMap(merged, false)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{
+		revision: combineRevisions(revisions),
+		values:   values,
+	}, nil
+}
+
+func mergeMap(target, overlay map[string]any) {
+	for key, overlayValue := range overlay {
+		if _, deleting := overlayValue.(deleteValue); deleting {
+			delete(target, key)
+			continue
+		}
+
+		overlayMap, overlayIsMap := overlayValue.(map[string]any)
+		if overlayIsMap {
+			currentMap, currentIsMap := target[key].(map[string]any)
+			if !currentIsMap {
+				currentMap = make(map[string]any)
+			}
+			mergeMap(currentMap, overlayMap)
+			target[key] = currentMap
+			continue
+		}
+
+		cloned, _ := cloneValue(overlayValue, true)
+		target[key] = cloned
+	}
+}
+
+func combineRevisions(revisions []string) string {
+	if len(revisions) == 1 {
+		return revisions[0]
+	}
+	var builder strings.Builder
+	for index, revision := range revisions {
+		if index > 0 {
+			builder.WriteByte('|')
+		}
+		builder.WriteString(strconv.Itoa(len(revision)))
+		builder.WriteByte(':')
+		builder.WriteString(revision)
+	}
+	return builder.String()
+}

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -1,0 +1,236 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrRuntimeAlreadyStarted reports a repeated Runtime Start.
+	ErrRuntimeAlreadyStarted = errors.New(
+		"config: runtime has already been started",
+	)
+	// ErrRuntimeNotStarted reports Wait before a successful Start.
+	ErrRuntimeNotStarted = errors.New("config: runtime has not been started")
+	// ErrRuntimeExited reports a Watch loop that ended without a cause.
+	ErrRuntimeExited = errors.New("config: runtime watch exited unexpectedly")
+)
+
+var errRuntimeStop = errors.New("config: runtime stop requested")
+
+// RuntimeState is the value-free lifecycle state of a configuration Runtime.
+type RuntimeState string
+
+const (
+	// RuntimeStateNew means the runtime has not started.
+	RuntimeStateNew RuntimeState = "new"
+	// RuntimeStateStarting means source watchers are being established.
+	RuntimeStateStarting RuntimeState = "starting"
+	// RuntimeStateRunning means configuration is actively watched.
+	RuntimeStateRunning RuntimeState = "running"
+	// RuntimeStateStopping means shutdown is in progress.
+	RuntimeStateStopping RuntimeState = "stopping"
+	// RuntimeStateStopped means the runtime has exited.
+	RuntimeStateStopped RuntimeState = "stopped"
+)
+
+// RuntimeDescription is a bounded configuration watcher diagnostic.
+type RuntimeDescription struct {
+	State   RuntimeState
+	Running bool
+	Failed  bool
+}
+
+// Runtime exposes a Manager Watch loop as a server-compatible App resource.
+//
+// Start returns only after every Source watcher is established and the initial
+// merged snapshot is valid and published. Wait reports runtime watcher failure
+// to App, while Stop performs an idempotent bounded shutdown.
+type Runtime struct {
+	manager *Manager
+
+	mu      sync.Mutex
+	state   RuntimeState
+	cancel  context.CancelCauseFunc
+	done    chan struct{}
+	waitErr error
+}
+
+// NewRuntime creates a watch runtime without starting any goroutines.
+func NewRuntime(manager *Manager) (*Runtime, error) {
+	if manager == nil {
+		return nil, fmt.Errorf("%w: manager is nil", ErrInvalidOption)
+	}
+	return &Runtime{
+		manager: manager,
+		state:   RuntimeStateNew,
+		done:    make(chan struct{}),
+	}, nil
+}
+
+// Name returns the stable App server name.
+func (*Runtime) Name() string {
+	return "keelith.config"
+}
+
+// Start establishes Source watchers and publishes a valid initial snapshot.
+func (runtime *Runtime) Start(ctx context.Context) error {
+	if runtime == nil {
+		return fmt.Errorf("%w: runtime is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: nil context", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+
+	runtime.mu.Lock()
+	if runtime.state != RuntimeStateNew {
+		runtime.mu.Unlock()
+		return ErrRuntimeAlreadyStarted
+	}
+	watchContext, cancel := context.WithCancelCause(
+		context.WithoutCancel(ctx),
+	)
+	ready := make(chan error, 1)
+	runtime.state = RuntimeStateStarting
+	runtime.cancel = cancel
+	runtime.mu.Unlock()
+
+	go runtime.run(watchContext, ready)
+
+	select {
+	case err := <-ready:
+		if err != nil {
+			cancel(err)
+			<-runtime.done
+			return err
+		}
+	case <-ctx.Done():
+		cause := context.Cause(ctx)
+		cancel(cause)
+		<-runtime.done
+		return cause
+	}
+
+	runtime.mu.Lock()
+	if runtime.state == RuntimeStateStopped {
+		err := runtime.waitErr
+		runtime.mu.Unlock()
+		if err == nil {
+			return ErrRuntimeExited
+		}
+		return err
+	}
+	runtime.state = RuntimeStateRunning
+	runtime.mu.Unlock()
+	return nil
+}
+
+// Stop cancels the Watch loop and waits for all Source watchers to close.
+func (runtime *Runtime) Stop(ctx context.Context) error {
+	if runtime == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: nil context", ErrInvalidOption)
+	}
+	runtime.mu.Lock()
+	switch runtime.state {
+	case RuntimeStateNew:
+		runtime.mu.Unlock()
+		return nil
+	case RuntimeStateStarting, RuntimeStateRunning:
+		runtime.state = RuntimeStateStopping
+		cancel := runtime.cancel
+		done := runtime.done
+		runtime.mu.Unlock()
+		cancel(errRuntimeStop)
+		return waitRuntime(ctx, done, runtime.waitError)
+	case RuntimeStateStopping:
+		done := runtime.done
+		runtime.mu.Unlock()
+		return waitRuntime(ctx, done, runtime.waitError)
+	case RuntimeStateStopped:
+		runtime.mu.Unlock()
+		return nil
+	default:
+		runtime.mu.Unlock()
+		return nil
+	}
+}
+
+// Wait blocks until the Watch loop ends.
+func (runtime *Runtime) Wait() error {
+	if runtime == nil {
+		return ErrRuntimeNotStarted
+	}
+	runtime.mu.Lock()
+	if runtime.state == RuntimeStateNew {
+		runtime.mu.Unlock()
+		return ErrRuntimeNotStarted
+	}
+	done := runtime.done
+	runtime.mu.Unlock()
+	<-done
+	return runtime.waitError()
+}
+
+// Description returns a value-free lifecycle snapshot.
+func (runtime *Runtime) Description() RuntimeDescription {
+	if runtime == nil {
+		return RuntimeDescription{
+			State:  RuntimeStateStopped,
+			Failed: true,
+		}
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return RuntimeDescription{
+		State:   runtime.state,
+		Running: runtime.state == RuntimeStateRunning,
+		Failed:  runtime.state == RuntimeStateStopped && runtime.waitErr != nil,
+	}
+}
+
+func (runtime *Runtime) run(
+	ctx context.Context,
+	ready chan<- error,
+) {
+	err := runtime.manager.watch(ctx, ready)
+	runtime.mu.Lock()
+	stopping := runtime.state == RuntimeStateStopping
+	if stopping && errors.Is(err, errRuntimeStop) {
+		err = nil
+	}
+	if err == nil && !stopping {
+		err = ErrRuntimeExited
+	}
+	runtime.waitErr = err
+	runtime.state = RuntimeStateStopped
+	runtime.cancel = nil
+	close(runtime.done)
+	runtime.mu.Unlock()
+}
+
+func (runtime *Runtime) waitError() error {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.waitErr
+}
+
+func waitRuntime(
+	ctx context.Context,
+	done <-chan struct{},
+	result func() error,
+) error {
+	select {
+	case <-done:
+		return result()
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}

--- a/config/snapshot.go
+++ b/config/snapshot.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type deleteValue struct{}
+
+// Delete returns the explicit map-key deletion marker.
+//
+// nil remains a regular configuration value.
+func Delete() any {
+	return deleteValue{}
+}
+
+// Snapshot is an immutable revisioned JSON-like configuration tree.
+type Snapshot struct {
+	revision string
+	values   map[string]any
+}
+
+// NewSnapshot validates and defensively copies a source-local Snapshot.
+func NewSnapshot(revision string, values map[string]any) (Snapshot, error) {
+	if strings.TrimSpace(revision) == "" {
+		return Snapshot{}, fmt.Errorf("%w: revision is empty", ErrInvalidSnapshot)
+	}
+	cloned, err := cloneMap(values, true)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{revision: revision, values: cloned}, nil
+}
+
+// Revision returns the source or merged revision.
+func (snapshot Snapshot) Revision() string {
+	return snapshot.revision
+}
+
+// Values returns a deep independent copy of the configuration tree.
+func (snapshot Snapshot) Values() map[string]any {
+	values, _ := cloneMap(snapshot.values, true)
+	return values
+}
+
+// Lookup returns a deep independent value at path.
+func (snapshot Snapshot) Lookup(path ...string) (any, bool) {
+	if len(path) == 0 {
+		return snapshot.Values(), true
+	}
+	var current any = snapshot.values
+	for _, segment := range path {
+		values, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		next, exists := values[segment]
+		if !exists {
+			return nil, false
+		}
+		current = next
+	}
+	cloned, err := cloneValue(current, true)
+	if err != nil {
+		return nil, false
+	}
+	return cloned, true
+}
+
+// Clone returns a deep immutable copy.
+func (snapshot Snapshot) Clone() Snapshot {
+	values, _ := cloneMap(snapshot.values, true)
+	return Snapshot{revision: snapshot.revision, values: values}
+}
+
+func (snapshot Snapshot) validate() error {
+	if strings.TrimSpace(snapshot.revision) == "" {
+		return fmt.Errorf("%w: revision is empty", ErrInvalidSnapshot)
+	}
+	_, err := cloneMap(snapshot.values, true)
+	return err
+}
+
+func cloneMap(source map[string]any, allowDelete bool) (map[string]any, error) {
+	if len(source) == 0 {
+		return map[string]any{}, nil
+	}
+	clone := make(map[string]any, len(source))
+	for key, value := range source {
+		if key == "" {
+			return nil, fmt.Errorf("%w: map key is empty", ErrInvalidSnapshot)
+		}
+		cloned, err := cloneValue(value, allowDelete)
+		if err != nil {
+			return nil, fmt.Errorf("%w: key %q: %w", ErrInvalidSnapshot, key, err)
+		}
+		clone[key] = cloned
+	}
+	return clone, nil
+}
+
+func cloneValue(value any, allowDelete bool) (any, error) {
+	if _, deleting := value.(deleteValue); deleting {
+		if !allowDelete {
+			return nil, fmt.Errorf("%w: Delete() outside a map merge", ErrInvalidSnapshot)
+		}
+		return deleteValue{}, nil
+	}
+	if value == nil {
+		return nil, nil
+	}
+
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64, reflect.String:
+		return value, nil
+	case reflect.Map:
+		if reflected.Type().Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("%w: map key type %s is not string", ErrInvalidSnapshot, reflected.Type().Key())
+		}
+		result := make(map[string]any, reflected.Len())
+		iterator := reflected.MapRange()
+		for iterator.Next() {
+			key := iterator.Key().String()
+			if key == "" {
+				return nil, fmt.Errorf("%w: map key is empty", ErrInvalidSnapshot)
+			}
+			cloned, err := cloneValue(iterator.Value().Interface(), allowDelete)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = cloned
+		}
+		return result, nil
+	case reflect.Array, reflect.Slice:
+		result := make([]any, reflected.Len())
+		for index := range reflected.Len() {
+			cloned, err := cloneValue(reflected.Index(index).Interface(), allowDelete)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = cloned
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported value type %T", ErrInvalidSnapshot, value)
+	}
+}

--- a/config/source.go
+++ b/config/source.go
@@ -1,0 +1,81 @@
+// Package config provides immutable, validated, atomically published
+// configuration snapshots.
+package config
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrInvalidSnapshot means a revision or value tree is invalid.
+	ErrInvalidSnapshot = errors.New("config: invalid snapshot")
+	// ErrInvalidOption means Manager construction received an invalid option.
+	ErrInvalidOption = errors.New("config: invalid option")
+	// ErrUnknownField means a snapshot contains a path outside its schema.
+	ErrUnknownField = errors.New("config: unknown field")
+	// ErrValidation means a Validator rejected a merged snapshot.
+	ErrValidation = errors.New("config: validation failed")
+	// ErrAlreadyWatching means Watch is already running for a Manager.
+	ErrAlreadyWatching = errors.New("config: manager is already watching")
+	// ErrWatcherClosed means a Watcher was closed.
+	ErrWatcherClosed = errors.New("config: watcher closed")
+	// ErrDuplicateSubscriber means a subscriber name is already registered.
+	ErrDuplicateSubscriber = errors.New("config: duplicate subscriber")
+	// ErrTypedDecode means a component subtree cannot be decoded into its
+	// declared Go configuration type.
+	ErrTypedDecode = errors.New("config: typed decode failed")
+	// ErrRestartRequired means a valid update changed a field outside the
+	// component's declared hot-reload boundary.
+	ErrRestartRequired = errors.New("config: component restart required")
+)
+
+// Source loads and watches complete source-local Snapshots.
+type Source interface {
+	Load(context.Context) (Snapshot, error)
+	Watch(context.Context) (Watcher, error)
+}
+
+// Watcher returns complete source-local Snapshots.
+type Watcher interface {
+	Next(context.Context) (Snapshot, error)
+	Close() error
+}
+
+// Validator validates one fully merged Snapshot.
+type Validator func(Snapshot) error
+
+// Subscriber applies one already-published Snapshot.
+//
+// A Subscriber may call Current but must not recursively call Load or Watch.
+type Subscriber func(context.Context, Snapshot) error
+
+// Binding validates and applies one typed component configuration.
+//
+// Manager validates all Bindings before publishing a Snapshot, then invokes
+// Apply as a named Subscriber.
+type Binding interface {
+	Name() string
+	Validate(Snapshot) error
+	Apply(context.Context, Snapshot) error
+}
+
+// UnknownFieldPolicy controls schema enforcement.
+type UnknownFieldPolicy uint8
+
+const (
+	// UnknownAllow accepts paths not present in KnownFields.
+	UnknownAllow UnknownFieldPolicy = iota
+	// UnknownReject rejects paths not present in KnownFields.
+	UnknownReject
+)
+
+// SubscriberStatus is the latest apply outcome for one Subscriber.
+type SubscriberStatus struct {
+	Name            string
+	Revision        string
+	AppliedAt       time.Time
+	RestartRequired bool
+	LastError       string
+}

--- a/config/testsource/source.go
+++ b/config/testsource/source.go
@@ -1,0 +1,104 @@
+// Package testsource provides an in-memory Config Source for tests and local
+// composition.
+package testsource
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keelab/keelith/config"
+)
+
+// Source is an updateable in-memory config.Source.
+type Source struct {
+	mu       sync.Mutex
+	current  config.Snapshot
+	watchers map[*watcher]struct{}
+}
+
+// New creates a Source with initial.
+func New(initial config.Snapshot) *Source {
+	return &Source{
+		current:  initial.Clone(),
+		watchers: make(map[*watcher]struct{}),
+	}
+}
+
+// Load returns the current complete Snapshot.
+func (source *Source) Load(ctx context.Context) (config.Snapshot, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return config.Snapshot{}, cause
+	}
+	source.mu.Lock()
+	defer source.mu.Unlock()
+	return source.current.Clone(), nil
+}
+
+// Watch creates a watcher for future complete Snapshots.
+func (source *Source) Watch(ctx context.Context) (config.Watcher, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	watcher := &watcher{
+		source:  source,
+		updates: make(chan config.Snapshot, 1),
+		done:    make(chan struct{}),
+	}
+	source.mu.Lock()
+	source.watchers[watcher] = struct{}{}
+	source.mu.Unlock()
+	return watcher, nil
+}
+
+// Update atomically replaces the current Snapshot and notifies watchers.
+func (source *Source) Update(snapshot config.Snapshot) {
+	update := snapshot.Clone()
+	source.mu.Lock()
+	source.current = update
+	for watcher := range source.watchers {
+		select {
+		case <-watcher.updates:
+		default:
+		}
+		select {
+		case watcher.updates <- update.Clone():
+		default:
+		}
+	}
+	source.mu.Unlock()
+}
+
+// WatcherCount returns the number of currently open watchers.
+func (source *Source) WatcherCount() int {
+	source.mu.Lock()
+	defer source.mu.Unlock()
+	return len(source.watchers)
+}
+
+type watcher struct {
+	source  *Source
+	updates chan config.Snapshot
+	done    chan struct{}
+	once    sync.Once
+}
+
+func (watcher *watcher) Next(ctx context.Context) (config.Snapshot, error) {
+	select {
+	case snapshot := <-watcher.updates:
+		return snapshot.Clone(), nil
+	case <-watcher.done:
+		return config.Snapshot{}, config.ErrWatcherClosed
+	case <-ctx.Done():
+		return config.Snapshot{}, context.Cause(ctx)
+	}
+}
+
+func (watcher *watcher) Close() error {
+	watcher.once.Do(func() {
+		watcher.source.mu.Lock()
+		delete(watcher.source.watchers, watcher)
+		close(watcher.done)
+		watcher.source.mu.Unlock()
+	})
+	return nil
+}

--- a/config/typed.go
+++ b/config/typed.go
@@ -1,0 +1,940 @@
+package config
+
+import (
+	"context"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+var (
+	durationType        = reflect.TypeOf(time.Duration(0))
+	textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+)
+
+// ComponentDescription is a value-free typed configuration diagnostic.
+type ComponentDescription struct {
+	Name            string
+	Path            string
+	Loaded          bool
+	Revision        string
+	PendingRevision string
+	RestartRequired bool
+	RestartFields   []string
+	Failed          bool
+}
+
+// ComponentOption configures a typed Component.
+type ComponentOption[T any] interface {
+	applyComponent(*componentOptions[T]) error
+}
+
+type componentOptionFunc[T any] func(*componentOptions[T]) error
+
+func (function componentOptionFunc[T]) applyComponent(
+	options *componentOptions[T],
+) error {
+	return function(options)
+}
+
+type componentOptions[T any] struct {
+	defaultValue *T
+	validators   []func(T) error
+	apply        func(context.Context, T) error
+	reloadable   []string
+}
+
+// WithComponentDefault supplies a value when the configured subtree is absent.
+func WithComponentDefault[T any](value T) ComponentOption[T] {
+	return componentOptionFunc[T](func(options *componentOptions[T]) error {
+		cloned := cloneTyped(value)
+		options.defaultValue = &cloned
+		return nil
+	})
+}
+
+// WithComponentValidator validates decoded component configuration before the
+// Manager publishes its containing Snapshot.
+func WithComponentValidator[T any](
+	validator func(T) error,
+) ComponentOption[T] {
+	return componentOptionFunc[T](func(options *componentOptions[T]) error {
+		if validator == nil {
+			return fmt.Errorf("component validator is nil")
+		}
+		options.validators = append(options.validators, validator)
+		return nil
+	})
+}
+
+// WithComponentApply installs the component-specific hot-apply callback.
+//
+// The callback runs before Current changes and receives an independent value.
+func WithComponentApply[T any](
+	apply func(context.Context, T) error,
+) ComponentOption[T] {
+	return componentOptionFunc[T](func(options *componentOptions[T]) error {
+		if apply == nil {
+			return fmt.Errorf("component apply callback is nil")
+		}
+		options.apply = apply
+		return nil
+	})
+}
+
+// WithReloadableFields marks dot-separated fields that may change without a
+// component restart. A parent path makes its complete subtree reloadable.
+//
+// Struct fields may alternatively use `reload:"true"`.
+func WithReloadableFields[T any](paths ...string) ComponentOption[T] {
+	snapshot := append([]string(nil), paths...)
+	return componentOptionFunc[T](func(options *componentOptions[T]) error {
+		for _, path := range snapshot {
+			normalized := strings.TrimSpace(path)
+			if !validComponentPath(normalized) {
+				return fmt.Errorf("reloadable field path %q is invalid", path)
+			}
+			options.reloadable = append(options.reloadable, normalized)
+		}
+		return nil
+	})
+}
+
+type typedPublished[T any] struct {
+	revision string
+	value    T
+}
+
+// Component is an immutable typed view over one Snapshot subtree.
+//
+// It implements Binding and can be passed directly to WithBindings.
+type Component[T any] struct {
+	name       string
+	path       string
+	segments   []string
+	valueType  reflect.Type
+	defaultVal *T
+	validators []func(T) error
+	apply      func(context.Context, T) error
+	reloadable map[string]struct{}
+
+	current atomic.Pointer[typedPublished[T]]
+
+	applyMu           sync.Mutex
+	mu                sync.Mutex
+	validatedRevision string
+	validatedValue    *T
+	pendingRevision   string
+	restartFields     []string
+	lastError         string
+}
+
+// NewComponent declares one strict typed component configuration.
+func NewComponent[T any](
+	name string,
+	path string,
+	optionList ...ComponentOption[T],
+) (*Component[T], error) {
+	name = strings.TrimSpace(name)
+	path = strings.TrimSpace(path)
+	if !validComponentName(name) {
+		return nil, fmt.Errorf("%w: component name %q is invalid", ErrInvalidOption, name)
+	}
+	if !validComponentPath(path) {
+		return nil, fmt.Errorf("%w: component path %q is invalid", ErrInvalidOption, path)
+	}
+	valueType := reflect.TypeOf((*T)(nil)).Elem()
+	if valueType.Kind() != reflect.Struct {
+		return nil, fmt.Errorf(
+			"%w: component type %s must be a struct",
+			ErrInvalidOption,
+			valueType,
+		)
+	}
+	if err := validateTypedStruct(valueType, ""); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidOption, err)
+	}
+	settings := componentOptions[T]{}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyComponent(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	reloadable := make(map[string]struct{}, len(settings.reloadable))
+	for _, field := range settings.reloadable {
+		reloadable[field] = struct{}{}
+	}
+	return &Component[T]{
+		name:       name,
+		path:       path,
+		segments:   strings.Split(path, "."),
+		valueType:  valueType,
+		defaultVal: settings.defaultValue,
+		validators: append([]func(T) error(nil), settings.validators...),
+		apply:      settings.apply,
+		reloadable: reloadable,
+	}, nil
+}
+
+// Name returns the unique Manager subscriber identity.
+func (component *Component[T]) Name() string {
+	if component == nil {
+		return ""
+	}
+	return component.name
+}
+
+// BindApply attaches a runtime component after its initial configuration has
+// been loaded. It is intended for the common sequence:
+//
+//	load typed config -> construct dependency -> bind hot updates
+//
+// A component accepts only one apply callback.
+func (component *Component[T]) BindApply(apply func(context.Context, T) error) error {
+	if component == nil || apply == nil {
+		return fmt.Errorf(
+			"%w: typed component or apply callback is nil",
+			ErrInvalidOption,
+		)
+	}
+	component.applyMu.Lock()
+	defer component.applyMu.Unlock()
+	if component.apply != nil {
+		return fmt.Errorf(
+			"%w: component %q already has an apply callback",
+			ErrInvalidOption,
+			component.name,
+		)
+	}
+	component.apply = apply
+	return nil
+}
+
+// Validate strictly decodes and validates a candidate Snapshot.
+func (component *Component[T]) Validate(snapshot Snapshot) error {
+	if component == nil {
+		return fmt.Errorf("%w: typed component is nil", ErrInvalidOption)
+	}
+	value, err := component.decode(snapshot)
+	component.mu.Lock()
+	defer component.mu.Unlock()
+	if err != nil {
+		component.validatedRevision = ""
+		component.validatedValue = nil
+		component.lastError = err.Error()
+		return err
+	}
+	cloned := cloneTyped(value)
+	component.validatedRevision = snapshot.Revision()
+	component.validatedValue = &cloned
+	component.lastError = ""
+	return nil
+}
+
+// Apply atomically installs a validated Snapshot or reports restart-required
+// fields while retaining the last applied value.
+func (component *Component[T]) Apply(ctx context.Context, snapshot Snapshot) error {
+	if component == nil {
+		return fmt.Errorf("%w: typed component is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: typed component context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+
+	component.applyMu.Lock()
+	defer component.applyMu.Unlock()
+
+	component.mu.Lock()
+	var next T
+	if component.validatedRevision == snapshot.Revision() &&
+		component.validatedValue != nil {
+		next = cloneTyped(*component.validatedValue)
+	} else {
+		component.mu.Unlock()
+		decoded, err := component.decode(snapshot)
+		if err != nil {
+			component.mu.Lock()
+			component.lastError = err.Error()
+			component.mu.Unlock()
+			return err
+		}
+		next = decoded
+		component.mu.Lock()
+	}
+	component.mu.Unlock()
+
+	current := component.current.Load()
+	if current != nil {
+		changed := component.restartChanges(current.value, next)
+		if len(changed) > 0 {
+			component.mu.Lock()
+			component.pendingRevision = snapshot.Revision()
+			component.restartFields = changed
+			err := fmt.Errorf("%w: component %q fields %s", ErrRestartRequired, component.name, strings.Join(changed, ", "))
+			component.lastError = err.Error()
+			component.mu.Unlock()
+			return err
+		}
+	}
+	if component.apply != nil {
+		if err := component.apply(ctx, cloneTyped(next)); err != nil {
+			wrapped := fmt.Errorf("%w: component %q apply: %w", ErrValidation, component.name, err)
+			component.mu.Lock()
+			component.lastError = wrapped.Error()
+			component.mu.Unlock()
+			return wrapped
+		}
+	}
+	component.current.Store(&typedPublished[T]{
+		revision: snapshot.Revision(),
+		value:    cloneTyped(next),
+	})
+	component.mu.Lock()
+	component.pendingRevision = ""
+	component.restartFields = nil
+	component.lastError = ""
+	component.mu.Unlock()
+	return nil
+}
+
+// Current returns an independent copy of the active typed configuration.
+func (component *Component[T]) Current() (T, bool) {
+	var zero T
+	if component == nil {
+		return zero, false
+	}
+	current := component.current.Load()
+	if current == nil {
+		return zero, false
+	}
+	return cloneTyped(current.value), true
+}
+
+// Description returns value-free load, revision, and restart diagnostics.
+func (component *Component[T]) Description() ComponentDescription {
+	if component == nil {
+		return ComponentDescription{}
+	}
+	component.mu.Lock()
+	defer component.mu.Unlock()
+	description := ComponentDescription{
+		Name:            component.name,
+		Path:            component.path,
+		PendingRevision: component.pendingRevision,
+		RestartRequired: len(component.restartFields) > 0,
+		RestartFields:   append([]string(nil), component.restartFields...),
+		Failed:          component.lastError != "",
+	}
+	if current := component.current.Load(); current != nil {
+		description.Loaded = true
+		description.Revision = current.revision
+	}
+	return description
+}
+
+func (component *Component[T]) decode(snapshot Snapshot) (T, error) {
+	var zero T
+	source, exists := snapshot.Lookup(component.segments...)
+	if !exists {
+		if component.defaultVal == nil {
+			return zero, fmt.Errorf("%w: component %q path %q is missing", ErrTypedDecode, component.name, component.path)
+		}
+		value := cloneTyped(*component.defaultVal)
+		for _, validator := range component.validators {
+			if err := validator(cloneTyped(value)); err != nil {
+				return zero, fmt.Errorf("%w: component %q: %w", ErrValidation, component.name, err)
+			}
+		}
+		return value, nil
+	}
+	target := reflect.New(component.valueType).Elem()
+	if err := decodeTypedValue(source, target, component.path); err != nil {
+		return zero, fmt.Errorf("%w: component %q: %w", ErrTypedDecode, component.name, err)
+	}
+	value := target.Interface().(T)
+	for _, validator := range component.validators {
+		if err := validator(cloneTyped(value)); err != nil {
+			return zero, fmt.Errorf("%w: component %q: %w", ErrValidation, component.name, err)
+		}
+	}
+	return value, nil
+}
+
+func (component *Component[T]) restartChanges(current, next T) []string {
+	changed := make([]string, 0)
+	collectRestartChanges(reflect.ValueOf(current), reflect.ValueOf(next), "", component.reloadable, &changed)
+	sort.Strings(changed)
+	return changed
+}
+
+func collectRestartChanges(current reflect.Value, next reflect.Value, path string, reloadable map[string]struct{}, changed *[]string) {
+	if reflect.DeepEqual(current.Interface(), next.Interface()) {
+		return
+	}
+	valueType := current.Type()
+	if valueType.Kind() != reflect.Struct || isScalarStruct(valueType) {
+		if !pathReloadable(path, reloadable) {
+			*changed = append(*changed, path)
+		}
+		return
+	}
+	for index := range valueType.NumField() {
+		field := valueType.Field(index)
+		if field.PkgPath != "" || fieldName(field) == "" {
+			continue
+		}
+		name := fieldName(field)
+		fieldPath := name
+		if path != "" {
+			fieldPath = path + "." + name
+		}
+		if field.Tag.Get("reload") == "true" ||
+			pathReloadable(fieldPath, reloadable) {
+			continue
+		}
+		collectRestartChanges(current.Field(index), next.Field(index), fieldPath, reloadable, changed)
+	}
+}
+
+func pathReloadable(path string, reloadable map[string]struct{}) bool {
+	if path == "" {
+		return false
+	}
+	for allowed := range reloadable {
+		if path == allowed || strings.HasPrefix(path, allowed+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeTypedValue(source any, target reflect.Value, path string) error {
+	if !target.CanSet() {
+		return fmt.Errorf("%s is not settable", path)
+	}
+	if source == nil {
+		switch target.Kind() {
+		case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Interface:
+			target.SetZero()
+			return nil
+		default:
+			return fmt.Errorf("%s cannot be null", path)
+		}
+	}
+	if target.Kind() == reflect.Pointer {
+		target.Set(reflect.New(target.Type().Elem()))
+		return decodeTypedValue(source, target.Elem(), path)
+	}
+	if target.Type() == durationType {
+		value, err := decodeDuration(source)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		target.SetInt(int64(value))
+		return nil
+	}
+	if text, ok := source.(string); ok &&
+		target.CanAddr() &&
+		target.Addr().Type().Implements(textUnmarshalerType) {
+		candidate := reflect.New(target.Type())
+		unmarshaler := candidate.Interface().(encoding.TextUnmarshaler)
+		if err := unmarshaler.UnmarshalText([]byte(text)); err != nil {
+			return fmt.Errorf("%s: text decode: %w", path, err)
+		}
+		target.Set(candidate.Elem())
+		return nil
+	}
+
+	switch target.Kind() {
+	case reflect.Struct:
+		values, ok := stringMap(source)
+		if !ok {
+			return fmt.Errorf("%s must be an object", path)
+		}
+		fields, err := typedFields(target.Type())
+		if err != nil {
+			return err
+		}
+		for key := range values {
+			if _, known := fields[key]; !known {
+				return fmt.Errorf("%w: %s.%s", ErrUnknownField, path, key)
+			}
+		}
+		for name, field := range fields {
+			value, exists := values[name]
+			if !exists {
+				continue
+			}
+			childPath := path + "." + name
+			if err := decodeTypedValue(
+				value,
+				target.Field(field.index),
+				childPath,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Bool:
+		value, err := decodeBool(source)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		target.SetBool(value)
+		return nil
+	case reflect.String:
+		value, ok := source.(string)
+		if !ok {
+			return fmt.Errorf("%s must be a string", path)
+		}
+		target.SetString(value)
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		value, err := decodeInt(source, target.Type().Bits())
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		target.SetInt(value)
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		value, err := decodeUint(source, target.Type().Bits())
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		target.SetUint(value)
+		return nil
+	case reflect.Float32, reflect.Float64:
+		value, err := decodeFloat(source, target.Type().Bits())
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		target.SetFloat(value)
+		return nil
+	case reflect.Slice:
+		values, ok := anySlice(source)
+		if !ok {
+			return fmt.Errorf("%s must be an array", path)
+		}
+		result := reflect.MakeSlice(target.Type(), len(values), len(values))
+		for index, value := range values {
+			if err := decodeTypedValue(
+				value,
+				result.Index(index),
+				fmt.Sprintf("%s[%d]", path, index),
+			); err != nil {
+				return err
+			}
+		}
+		target.Set(result)
+		return nil
+	case reflect.Array:
+		values, ok := anySlice(source)
+		if !ok || len(values) != target.Len() {
+			return fmt.Errorf("%s must be an array of length %d", path, target.Len())
+		}
+		for index, value := range values {
+			if err := decodeTypedValue(
+				value,
+				target.Index(index),
+				fmt.Sprintf("%s[%d]", path, index),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Map:
+		if target.Type().Key().Kind() != reflect.String {
+			return fmt.Errorf("%s map key must be string", path)
+		}
+		values, ok := stringMap(source)
+		if !ok {
+			return fmt.Errorf("%s must be an object", path)
+		}
+		result := reflect.MakeMapWithSize(target.Type(), len(values))
+		for key, value := range values {
+			element := reflect.New(target.Type().Elem()).Elem()
+			if err := decodeTypedValue(
+				value,
+				element,
+				path+"."+key,
+			); err != nil {
+				return err
+			}
+			result.SetMapIndex(reflect.ValueOf(key).Convert(target.Type().Key()), element)
+		}
+		target.Set(result)
+		return nil
+	case reflect.Interface:
+		cloned, err := cloneValue(source, true)
+		if err != nil {
+			return err
+		}
+		target.Set(reflect.ValueOf(cloned))
+		return nil
+	default:
+		return fmt.Errorf("%s has unsupported target type %s", path, target.Type())
+	}
+}
+
+type typedField struct {
+	index int
+}
+
+func typedFields(valueType reflect.Type) (map[string]typedField, error) {
+	fields := make(map[string]typedField)
+	for index := range valueType.NumField() {
+		field := valueType.Field(index)
+		if field.PkgPath != "" {
+			continue
+		}
+		name := fieldName(field)
+		if name == "" {
+			continue
+		}
+		if _, duplicate := fields[name]; duplicate {
+			return nil, fmt.Errorf(
+				"config field %q is duplicated in %s",
+				name,
+				valueType,
+			)
+		}
+		fields[name] = typedField{index: index}
+	}
+	return fields, nil
+}
+
+func fieldName(field reflect.StructField) string {
+	for _, key := range []string{"config", "json", "yaml"} {
+		tag, exists := field.Tag.Lookup(key)
+		if !exists {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "-" {
+			return ""
+		}
+		if name != "" {
+			return name
+		}
+	}
+	if field.Anonymous {
+		return lowerFirst(field.Type.Name())
+	}
+	return lowerFirst(field.Name)
+}
+
+func validateTypedStruct(valueType reflect.Type, path string) error {
+	fields, err := typedFields(valueType)
+	if err != nil {
+		return err
+	}
+	for name, field := range fields {
+		fieldType := valueType.Field(field.index).Type
+		if fieldType.Kind() == reflect.Pointer {
+			fieldType = fieldType.Elem()
+		}
+		if fieldType.Kind() == reflect.Struct && !isScalarStruct(fieldType) {
+			child := name
+			if path != "" {
+				child = path + "." + name
+			}
+			if err := validateTypedStruct(fieldType, child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func isScalarStruct(valueType reflect.Type) bool {
+	return valueType == durationType ||
+		reflect.PointerTo(valueType).Implements(textUnmarshalerType)
+}
+
+func decodeDuration(source any) (time.Duration, error) {
+	if text, ok := source.(string); ok {
+		value, err := time.ParseDuration(text)
+		if err != nil {
+			return 0, fmt.Errorf("duration is invalid")
+		}
+		return value, nil
+	}
+	value, err := decodeInt(source, 64)
+	if err != nil {
+		return 0, fmt.Errorf("duration must be a string or integer nanoseconds")
+	}
+	return time.Duration(value), nil
+}
+
+func decodeBool(source any) (bool, error) {
+	switch value := source.(type) {
+	case bool:
+		return value, nil
+	case string:
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, fmt.Errorf("boolean is invalid")
+		}
+		return parsed, nil
+	default:
+		return false, fmt.Errorf("value must be a boolean")
+	}
+}
+
+func decodeInt(source any, bits int) (int64, error) {
+	text, ok := numericText(source)
+	if !ok {
+		return 0, fmt.Errorf("value must be an integer")
+	}
+	value, err := strconv.ParseInt(text, 10, bits)
+	if err != nil {
+		return 0, fmt.Errorf("integer is invalid or overflows")
+	}
+	return value, nil
+}
+
+func decodeUint(source any, bits int) (uint64, error) {
+	text, ok := numericText(source)
+	if !ok {
+		return 0, fmt.Errorf("value must be an unsigned integer")
+	}
+	value, err := strconv.ParseUint(text, 10, bits)
+	if err != nil {
+		return 0, fmt.Errorf("unsigned integer is invalid or overflows")
+	}
+	return value, nil
+}
+
+func decodeFloat(source any, bits int) (float64, error) {
+	var text string
+	switch value := source.(type) {
+	case float32:
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return 0, fmt.Errorf("number is invalid or non-finite")
+		}
+		text = strconv.FormatFloat(float64(value), 'g', -1, 32)
+	case float64:
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return 0, fmt.Errorf("number is invalid or non-finite")
+		}
+		text = strconv.FormatFloat(value, 'g', -1, 64)
+	default:
+		var ok bool
+		text, ok = numericText(source)
+		if !ok {
+			return 0, fmt.Errorf("value must be numeric")
+		}
+	}
+	value, err := strconv.ParseFloat(text, bits)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("number is invalid or non-finite")
+	}
+	return value, nil
+}
+
+func numericText(source any) (string, bool) {
+	switch value := source.(type) {
+	case string:
+		return value, true
+	case json.Number:
+		return value.String(), true
+	case int:
+		return strconv.FormatInt(int64(value), 10), true
+	case int8:
+		return strconv.FormatInt(int64(value), 10), true
+	case int16:
+		return strconv.FormatInt(int64(value), 10), true
+	case int32:
+		return strconv.FormatInt(int64(value), 10), true
+	case int64:
+		return strconv.FormatInt(value, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(value), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(value), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(value), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(value), 10), true
+	case uint64:
+		return strconv.FormatUint(value, 10), true
+	case float32:
+		if math.Trunc(float64(value)) != float64(value) {
+			return "", false
+		}
+		return strconv.FormatFloat(float64(value), 'f', -1, 32), true
+	case float64:
+		if math.Trunc(value) != value || math.IsNaN(value) || math.IsInf(value, 0) {
+			return "", false
+		}
+		return strconv.FormatFloat(value, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+func stringMap(source any) (map[string]any, bool) {
+	if values, ok := source.(map[string]any); ok {
+		return values, true
+	}
+	reflected := reflect.ValueOf(source)
+	if !reflected.IsValid() ||
+		reflected.Kind() != reflect.Map ||
+		reflected.Type().Key().Kind() != reflect.String {
+		return nil, false
+	}
+	result := make(map[string]any, reflected.Len())
+	iterator := reflected.MapRange()
+	for iterator.Next() {
+		result[iterator.Key().String()] = iterator.Value().Interface()
+	}
+	return result, true
+}
+
+func anySlice(source any) ([]any, bool) {
+	if values, ok := source.([]any); ok {
+		return values, true
+	}
+	reflected := reflect.ValueOf(source)
+	if !reflected.IsValid() ||
+		reflected.Kind() != reflect.Slice && reflected.Kind() != reflect.Array {
+		return nil, false
+	}
+	result := make([]any, reflected.Len())
+	for index := range reflected.Len() {
+		result[index] = reflected.Index(index).Interface()
+	}
+	return result, true
+}
+
+func cloneTyped[T any](value T) T {
+	cloned := cloneTypedValue(reflect.ValueOf(value))
+	if !cloned.IsValid() {
+		var zero T
+		return zero
+	}
+	return cloned.Interface().(T)
+}
+
+func cloneTypedValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.Value{}
+	}
+	switch value.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.New(value.Type().Elem())
+		result.Elem().Set(cloneTypedValue(value.Elem()))
+		return result
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneTypedValue(value.Elem())
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iterator := value.MapRange()
+		for iterator.Next() {
+			result.SetMapIndex(
+				cloneTypedValue(iterator.Key()),
+				cloneTypedValue(iterator.Value()),
+			)
+		}
+		return result
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for index := range value.Len() {
+			result.Index(index).Set(cloneTypedValue(value.Index(index)))
+		}
+		return result
+	case reflect.Array:
+		result := reflect.New(value.Type()).Elem()
+		for index := range value.Len() {
+			result.Index(index).Set(cloneTypedValue(value.Index(index)))
+		}
+		return result
+	case reflect.Struct:
+		result := reflect.New(value.Type()).Elem()
+		result.Set(value)
+		for index := range value.NumField() {
+			field := value.Type().Field(index)
+			if field.PkgPath == "" && result.Field(index).CanSet() {
+				result.Field(index).Set(cloneTypedValue(value.Field(index)))
+			}
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+func validComponentName(value string) bool {
+	if value == "" ||
+		len(value) > 256 ||
+		!utf8.ValidString(value) ||
+		strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validComponentPath(value string) bool {
+	if value == "" || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") {
+		return false
+	}
+	for _, segment := range strings.Split(value, ".") {
+		if segment == "" {
+			return false
+		}
+		for _, character := range segment {
+			if !unicode.IsLetter(character) &&
+				!unicode.IsDigit(character) &&
+				character != '_' &&
+				character != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func lowerFirst(value string) string {
+	if value == "" {
+		return value
+	}
+	characters := []rune(value)
+	characters[0] = unicode.ToLower(characters[0])
+	return string(characters)
+}

--- a/config/versioned/versioned.go
+++ b/config/versioned/versioned.go
@@ -1,0 +1,195 @@
+// Package versioned defines provider-neutral immutable configuration revision
+// and activation contracts.
+package versioned
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// DefaultHistoryLimit bounds history reads when a caller omits a limit.
+	DefaultHistoryLimit = 50
+	// MaxHistoryLimit is the largest activation history page.
+	MaxHistoryLimit = 256
+	maxActorBytes   = 128
+	maxMessageBytes = 512
+)
+
+var (
+	// ErrInvalidRequest reports malformed stage, activation, or history input.
+	ErrInvalidRequest = errors.New("versioned config: invalid request")
+	// ErrInvalidRevision reports corrupt or incomplete immutable metadata.
+	ErrInvalidRevision = errors.New("versioned config: invalid revision")
+	// ErrInvalidActivation reports corrupt or incomplete activation metadata.
+	ErrInvalidActivation = errors.New("versioned config: invalid activation")
+	// ErrNotFound reports an unknown immutable revision.
+	ErrNotFound = errors.New("versioned config: revision not found")
+	// ErrNoActive reports a store without an activated revision.
+	ErrNoActive = errors.New("versioned config: no active revision")
+	// ErrConflict reports a failed generation or backend compare-and-swap.
+	ErrConflict = errors.New("versioned config: activation conflict")
+	// ErrTampered reports a revision whose content no longer matches its ID.
+	ErrTampered = errors.New("versioned config: revision integrity failure")
+	// ErrClosed reports an operation after Store or Source shutdown.
+	ErrClosed = errors.New("versioned config: closed")
+)
+
+// Format identifies a human-authored immutable configuration document.
+type Format string
+
+const (
+	// FormatJSON identifies a JSON configuration document.
+	FormatJSON Format = "json"
+	// FormatYAML identifies a YAML configuration document.
+	FormatYAML Format = "yaml"
+)
+
+// Revision is bounded metadata for one immutable configuration document.
+// Content is intentionally returned separately and never belongs in history.
+type Revision struct {
+	ID        string    `json:"id"`
+	Format    Format    `json:"format"`
+	Size      int       `json:"size"`
+	CreatedAt time.Time `json:"created_at"`
+	Actor     string    `json:"actor"`
+	Message   string    `json:"message,omitempty"`
+}
+
+// Validate verifies immutable revision metadata.
+func (revision Revision) Validate() error {
+	if !ValidRevisionID(revision.ID) || !revision.Format.Valid() ||
+		revision.Size <= 0 || revision.CreatedAt.IsZero() ||
+		!validText(revision.Actor, true, maxActorBytes) ||
+		!validText(revision.Message, false, maxMessageBytes) {
+		return ErrInvalidRevision
+	}
+	return nil
+}
+
+// Activation is one monotonic selection of an immutable Revision.
+type Activation struct {
+	Generation  uint64    `json:"generation"`
+	Revision    string    `json:"revision"`
+	Previous    string    `json:"previous,omitempty"`
+	ActivatedAt time.Time `json:"activated_at"`
+	Actor       string    `json:"actor"`
+	Reason      string    `json:"reason"`
+}
+
+// Validate verifies an activation record without reading revision content.
+func (activation Activation) Validate() error {
+	if activation.Generation == 0 ||
+		!ValidRevisionID(activation.Revision) ||
+		(activation.Previous != "" && !ValidRevisionID(activation.Previous)) ||
+		activation.ActivatedAt.IsZero() ||
+		!validText(activation.Actor, true, maxActorBytes) ||
+		!validText(activation.Reason, true, maxMessageBytes) {
+		return ErrInvalidActivation
+	}
+	return nil
+}
+
+// StageRequest creates or reuses an immutable content-addressed Revision.
+type StageRequest struct {
+	Content []byte
+	Format  Format
+	Actor   string
+	Message string
+}
+
+// Validate checks bounded provider-neutral Stage input.
+func (request StageRequest) Validate() error {
+	if len(request.Content) == 0 || !request.Format.Valid() ||
+		!validText(request.Actor, true, maxActorBytes) ||
+		!validText(request.Message, false, maxMessageBytes) {
+		return ErrInvalidRequest
+	}
+	return nil
+}
+
+// Clone returns an independent request whose content can be safely retained.
+func (request StageRequest) Clone() StageRequest {
+	request.Content = append([]byte(nil), request.Content...)
+	return request
+}
+
+// ActivateRequest atomically selects a staged Revision.
+type ActivateRequest struct {
+	Revision           string
+	ExpectedGeneration uint64
+	Actor              string
+	Reason             string
+}
+
+// Validate checks bounded activation input. Generation zero is valid only as
+// the expectation for the first activation.
+func (request ActivateRequest) Validate() error {
+	if !ValidRevisionID(request.Revision) ||
+		!validText(request.Actor, true, maxActorBytes) ||
+		!validText(request.Reason, true, maxMessageBytes) {
+		return ErrInvalidRequest
+	}
+	return nil
+}
+
+// Store stages immutable documents and serializes activation history.
+type Store interface {
+	Stage(context.Context, StageRequest) (Revision, error)
+	Revision(context.Context, string) (Revision, []byte, error)
+	Active(context.Context) (Activation, error)
+	Activate(context.Context, ActivateRequest) (Activation, error)
+	History(context.Context, int) ([]Activation, error)
+	Close() error
+}
+
+// RevisionID returns the lowercase SHA-256 content address.
+func RevisionID(content []byte) string {
+	digest := sha256.Sum256(content)
+	return hex.EncodeToString(digest[:])
+}
+
+// ValidRevisionID reports whether value is one canonical lowercase SHA-256.
+func ValidRevisionID(value string) bool {
+	if len(value) != sha256.Size*2 || strings.ToLower(value) != value {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
+}
+
+// NormalizeHistoryLimit applies the bounded default.
+func NormalizeHistoryLimit(limit int) (int, error) {
+	if limit == 0 {
+		return DefaultHistoryLimit, nil
+	}
+	if limit < 1 || limit > MaxHistoryLimit {
+		return 0, fmt.Errorf("%w: history limit must be between 1 and %d", ErrInvalidRequest, MaxHistoryLimit)
+	}
+	return limit, nil
+}
+
+// Valid reports whether format is supported by the first versioned contract.
+func (format Format) Valid() bool {
+	return format == FormatJSON || format == FormatYAML
+}
+
+func validText(value string, required bool, maxBytes int) bool {
+	if !utf8.ValidString(value) || len(value) > maxBytes ||
+		(required && strings.TrimSpace(value) == "") {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}

--- a/contract/manifest.go
+++ b/contract/manifest.go
@@ -1,0 +1,728 @@
+// Package contract defines generated service and dependency manifests.
+package contract
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/token"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// ManifestSchemaVersion is the only generated contract schema accepted by
+	// this preview release.
+	ManifestSchemaVersion       = "v3"
+	maxManifestBytes            = 4 * 1024 * 1024
+	maxManifests                = 256
+	maxServices                 = 1024
+	maxMethods                  = 16 * 1024
+	maxRoutes                   = 16 * 1024
+	maxDependencies             = 4096
+	maxProjections              = 1024
+	maxIdentityBytes            = 4 * 1024
+	maxAdditionalBindings       = 15
+	minInlineBudgetMillis       = int64(1)
+	maxInlineBudgetMillis       = int64(60 * 1000)
+	minRetentionSeconds         = int64(60)
+	maxRetentionSeconds         = int64(30 * 24 * 60 * 60)
+	minContinuationPayloadBytes = int64(1)
+	maxContinuationPayloadBytes = int64(1024 * 1024)
+)
+
+const (
+	// DependencyDeclared identifies an application-declared outbound call.
+	DependencyDeclared = "declared"
+	// DependencyGeneratedAdapter identifies a generated adapter relationship
+	// that is not automatically activated by an application profile.
+	DependencyGeneratedAdapter = "generated-adapter"
+	// DependencyBindingRemote requires the existing remote transport binding.
+	DependencyBindingRemote = "REMOTE"
+	// DependencyBindingAuto lets one topology plan choose local or remote.
+	DependencyBindingAuto = "AUTO"
+	// DependencyBindingLocal requires a colocated typed component binding.
+	DependencyBindingLocal = "LOCAL"
+)
+
+var (
+	// ErrInvalidManifest reports malformed or unsafe generated contract data.
+	ErrInvalidManifest = errors.New("contract: invalid manifest")
+)
+
+// Manifest is one generated Proto file's static contract projection.
+type Manifest struct {
+	SchemaVersion     string       `json:"schemaVersion"`
+	GeneratorProtocol string       `json:"generatorProtocol"`
+	Source            string       `json:"source"`
+	Package           string       `json:"package"`
+	GoImportPath      string       `json:"goImportPath,omitempty"`
+	GoPackage         string       `json:"goPackage,omitempty"`
+	Services          []Service    `json:"services"`
+	Listeners         []Listener   `json:"listeners"`
+	Dependencies      []Dependency `json:"dependencies,omitempty"`
+	Projections       []Projection `json:"projections,omitempty"`
+}
+
+// Service describes one provided Protobuf service.
+type Service struct {
+	Name    string   `json:"name"`
+	GoName  string   `json:"goName,omitempty"`
+	Methods []Method `json:"methods"`
+}
+
+// Method describes one transport-neutral RPC contract.
+type Method struct {
+	Name      string       `json:"name"`
+	Operation string       `json:"operation"`
+	Kind      string       `json:"kind"`
+	Input     string       `json:"input"`
+	Output    string       `json:"output"`
+	HTTP      *HTTPBinding `json:"http,omitempty"`
+	// Continuation is present only for unary methods declared as durable calls.
+	Continuation *Continuation `json:"continuation,omitempty"`
+}
+
+// Continuation describes the bounded durable execution contract of one method.
+type Continuation struct {
+	MachineVersion     string `json:"machineVersion"`
+	InlineBudgetMillis int64  `json:"inlineBudgetMs"`
+	RetentionSeconds   int64  `json:"retentionSeconds"`
+	MaxPayloadBytes    int64  `json:"maxPayloadBytes"`
+}
+
+// HTTPBinding describes the standard google.api.http projection used by the
+// generated server, gateway, client, and OpenAPI document.
+type HTTPBinding struct {
+	Method       string        `json:"method"`
+	Path         string        `json:"path"`
+	Body         string        `json:"body,omitempty"`
+	ResponseBody string        `json:"responseBody,omitempty"`
+	Additional   *HTTPBindings `json:"additional,omitempty"`
+}
+
+// HTTPBindings is a bounded list kept behind a pointer so adding standard
+// additional bindings does not remove HTTPBinding comparability.
+type HTTPBindings []HTTPBinding
+
+// Listener describes a generated inbound transport surface.
+type Listener struct {
+	Transport string  `json:"transport"`
+	Service   string  `json:"service"`
+	Routes    []Route `json:"routes,omitempty"`
+}
+
+// Route describes one static HTTP route.
+type Route struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Operation string `json:"operation"`
+}
+
+// Dependency describes one generated outbound service relationship.
+type Dependency struct {
+	Kind         string   `json:"kind"`
+	Transport    string   `json:"transport"`
+	Service      string   `json:"service"`
+	GoImportPath string   `json:"goImportPath,omitempty"`
+	GoPackage    string   `json:"goPackage,omitempty"`
+	GoName       string   `json:"goName,omitempty"`
+	Binding      string   `json:"binding,omitempty"`
+	Reason       string   `json:"reason"`
+	Operations   []string `json:"operations"`
+}
+
+// Projection declares one bounded replicated read model and its stable key.
+type Projection struct {
+	ID          string   `json:"id"`
+	Message     string   `json:"message"`
+	KeyFields   []string `json:"keyFields"`
+	SchemaMajor uint32   `json:"schemaMajor"`
+}
+
+// Description is a bounded, low-detail diagnostic projection of a Catalog.
+type Description struct {
+	Sources      []string             `json:"sources"`
+	Services     []ServiceDescription `json:"services"`
+	Dependencies []Dependency         `json:"dependencies,omitempty"`
+}
+
+// ServiceDescription omits message schemas while retaining the static
+// operations and transport surface.
+type ServiceDescription struct {
+	Name       string   `json:"name"`
+	Operations []string `json:"operations"`
+	Transports []string `json:"transports"`
+	HTTPRoutes int      `json:"httpRoutes"`
+}
+
+// Parse strictly decodes and validates one generated manifest.
+func Parse(payload []byte) (Manifest, error) {
+	if len(payload) == 0 || len(payload) > maxManifestBytes {
+		return Manifest{}, fmt.Errorf("%w: payload is empty or exceeds %d bytes", ErrInvalidManifest, maxManifestBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return Manifest{}, fmt.Errorf("%w: decode: %w", ErrInvalidManifest, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return Manifest{}, fmt.Errorf("%w: payload has trailing content", ErrInvalidManifest)
+	}
+	if err := Validate(manifest); err != nil {
+		return Manifest{}, err
+	}
+	return cloneManifest(manifest), nil
+}
+
+// Validate checks one Manifest's identity, cardinality, and references.
+func Validate(manifest Manifest) error {
+	if manifest.SchemaVersion != ManifestSchemaVersion {
+		return invalid("schema version %q is unsupported", manifest.SchemaVersion)
+	}
+	if !validIdentity(manifest.GeneratorProtocol) || !validSource(manifest.Source) || !validIdentity(manifest.Package) {
+		return invalid("protocol, source, or package is malformed")
+	}
+	hasGoMetadata := manifest.GoImportPath != "" || manifest.GoPackage != ""
+	if hasGoMetadata && (!validGoImportPath(manifest.GoImportPath) || !token.IsIdentifier(manifest.GoPackage)) {
+		return invalid("Go import path or package is malformed")
+	}
+	if len(manifest.Services) > maxServices || len(manifest.Services) == 0 && len(manifest.Projections) == 0 {
+		return invalid("service count is outside the supported range")
+	}
+	serviceNames := make(map[string]struct{}, len(manifest.Services))
+	operations := make(map[string]struct{})
+	methodCount := 0
+	for _, service := range manifest.Services {
+		if !validIdentity(service.Name) {
+			return invalid("service name %q is malformed", service.Name)
+		}
+		if service.GoName != "" && !token.IsIdentifier(service.GoName) {
+			return invalid("service %q Go name is malformed", service.Name)
+		}
+		if hasGoMetadata && service.GoName == "" {
+			return invalid("service %q has no Go name", service.Name)
+		}
+		if _, duplicate := serviceNames[service.Name]; duplicate {
+			return invalid("service %q is duplicated", service.Name)
+		}
+		serviceNames[service.Name] = struct{}{}
+		if len(service.Methods) == 0 {
+			return invalid("service %q has no methods", service.Name)
+		}
+		methodNames := make(map[string]struct{}, len(service.Methods))
+		for _, method := range service.Methods {
+			methodCount++
+			if methodCount > maxMethods {
+				return invalid("method count exceeds %d", maxMethods)
+			}
+			if !validIdentity(method.Name) || !validOperation(method.Operation) || !validIdentity(method.Input) || !validIdentity(method.Output) || !validKind(method.Kind) {
+				return invalid("service %q contains a malformed method", service.Name)
+			}
+			if _, duplicate := methodNames[method.Name]; duplicate {
+				return invalid("service %q method %q is duplicated", service.Name, method.Name)
+			}
+			methodNames[method.Name] = struct{}{}
+			operations[method.Operation] = struct{}{}
+			if method.HTTP != nil {
+				if err := validateHTTP(*method.HTTP); err != nil {
+					return err
+				}
+			}
+			if method.Continuation != nil {
+				if method.Kind != "unary" {
+					return invalid("continuation method %q is not unary", method.Operation)
+				}
+				if err := validateContinuation(*method.Continuation); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if len(manifest.Services) == 0 {
+		if len(manifest.Listeners) != 0 {
+			return invalid("projection-only manifest declares listeners")
+		}
+	} else {
+		if err := validateListeners(manifest.Listeners, serviceNames, operations); err != nil {
+			return err
+		}
+	}
+	if err := validateDependencies(manifest.Dependencies, operations); err != nil {
+		return err
+	}
+	if err := validateProjections(manifest.Projections); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateContinuation(rule Continuation) error {
+	if !validIdentity(rule.MachineVersion) || rule.InlineBudgetMillis < minInlineBudgetMillis || rule.InlineBudgetMillis > maxInlineBudgetMillis || rule.RetentionSeconds < minRetentionSeconds || rule.RetentionSeconds > maxRetentionSeconds || rule.MaxPayloadBytes < minContinuationPayloadBytes || rule.MaxPayloadBytes > maxContinuationPayloadBytes {
+		return invalid("continuation identity or budget is malformed")
+	}
+	return nil
+}
+
+func validateProjections(projections []Projection) error {
+	if len(projections) > maxProjections {
+		return invalid("projection count exceeds %d", maxProjections)
+	}
+	identities := make(map[string]struct{}, len(projections))
+	for _, projection := range projections {
+		if !validIdentity(projection.ID) || !validIdentity(projection.Message) || projection.SchemaMajor == 0 || len(projection.KeyFields) == 0 || len(projection.KeyFields) > 8 {
+			return invalid("projection is malformed")
+		}
+		if _, duplicate := identities[projection.ID]; duplicate {
+			return invalid("projection %q is duplicated", projection.ID)
+		}
+		identities[projection.ID] = struct{}{}
+		fields := make(map[string]struct{}, len(projection.KeyFields))
+		for _, field := range projection.KeyFields {
+			if !validProjectionField(field) {
+				return invalid("projection key field is malformed")
+			}
+			if _, duplicate := fields[field]; duplicate {
+				return invalid("projection %q key field %q is duplicated", projection.ID, field)
+			}
+			fields[field] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func validProjectionField(value string) bool {
+	if value == "" || len(value) > 1024 || strings.TrimSpace(value) != value {
+		return false
+	}
+	for index, character := range value {
+		valid := character == '_' || character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || index > 0 && character >= '0' && character <= '9'
+		if !valid {
+			return false
+		}
+	}
+	return true
+}
+
+// Catalog merges validated manifests and rejects duplicate service ownership.
+type Catalog struct {
+	manifests []Manifest
+}
+
+// NewCatalog creates one immutable manifest catalog.
+func NewCatalog(manifests ...Manifest) (*Catalog, error) {
+	if len(manifests) == 0 || len(manifests) > maxManifests {
+		return nil, invalid("manifest count is outside the supported range")
+	}
+	sources := make(map[string]struct{}, len(manifests))
+	services := make(map[string]string)
+	snapshot := make([]Manifest, 0, len(manifests))
+	for _, manifest := range manifests {
+		if err := Validate(manifest); err != nil {
+			return nil, err
+		}
+		if _, duplicate := sources[manifest.Source]; duplicate {
+			return nil, invalid("source %q is duplicated", manifest.Source)
+		}
+		sources[manifest.Source] = struct{}{}
+		for _, service := range manifest.Services {
+			if owner, duplicate := services[service.Name]; duplicate {
+				return nil, invalid("service %q is declared by %q and %q", service.Name, owner, manifest.Source)
+			}
+			services[service.Name] = manifest.Source
+		}
+		snapshot = append(snapshot, cloneManifest(manifest))
+	}
+	sort.Slice(snapshot, func(first, second int) bool {
+		return snapshot[first].Source < snapshot[second].Source
+	})
+	return &Catalog{manifests: snapshot}, nil
+}
+
+// Manifests returns an independent copy of all source manifests.
+func (catalog *Catalog) Manifests() []Manifest {
+	if catalog == nil {
+		return nil
+	}
+	result := make([]Manifest, len(catalog.manifests))
+	for index, manifest := range catalog.manifests {
+		result[index] = cloneManifest(manifest)
+	}
+	return result
+}
+
+// Describe returns deterministic static dependency diagnostics.
+func (catalog *Catalog) Describe() Description {
+	if catalog == nil {
+		return Description{}
+	}
+	description := Description{}
+	for _, manifest := range catalog.manifests {
+		description.Sources = append(description.Sources, manifest.Source)
+		transports := make(map[string]map[string]struct{})
+		httpRoutes := make(map[string]int)
+		for _, listener := range manifest.Listeners {
+			serviceTransports := transports[listener.Service]
+			if serviceTransports == nil {
+				serviceTransports = make(map[string]struct{})
+				transports[listener.Service] = serviceTransports
+			}
+			serviceTransports[listener.Transport] = struct{}{}
+			httpRoutes[listener.Service] += len(listener.Routes)
+		}
+		for _, service := range manifest.Services {
+			entry := ServiceDescription{
+				Name:       service.Name,
+				HTTPRoutes: httpRoutes[service.Name],
+			}
+			for _, method := range service.Methods {
+				entry.Operations = append(entry.Operations, method.Operation)
+			}
+			for transport := range transports[service.Name] {
+				entry.Transports = append(entry.Transports, transport)
+			}
+			sort.Strings(entry.Operations)
+			sort.Strings(entry.Transports)
+			description.Services = append(description.Services, entry)
+		}
+		for _, dependency := range manifest.Dependencies {
+			description.Dependencies = append(
+				description.Dependencies,
+				cloneDependency(dependency),
+			)
+		}
+	}
+	sort.Strings(description.Sources)
+	sort.Slice(description.Services, func(first, second int) bool {
+		return description.Services[first].Name < description.Services[second].Name
+	})
+	sort.Slice(description.Dependencies, func(first, second int) bool {
+		left := description.Dependencies[first]
+		right := description.Dependencies[second]
+		if left.Service == right.Service {
+			if left.Transport == right.Transport {
+				if left.Binding != right.Binding {
+					return left.Binding < right.Binding
+				}
+				return left.Reason < right.Reason
+			}
+			return left.Transport < right.Transport
+		}
+		return left.Service < right.Service
+	})
+	return description
+}
+
+// ValidateDescription protects diagnostic providers that do not use Catalog.
+func ValidateDescription(description Description) error {
+	if len(description.Sources) > maxManifests ||
+		len(description.Services) > maxServices ||
+		len(description.Dependencies) > maxDependencies {
+		return invalid("diagnostic cardinality exceeds limits")
+	}
+	for _, source := range description.Sources {
+		if !validSource(source) {
+			return invalid("diagnostic source is malformed")
+		}
+	}
+	for _, service := range description.Services {
+		if !validIdentity(service.Name) || service.HTTPRoutes < 0 || len(service.Operations) > maxMethods || len(service.Transports) > 16 {
+			return invalid("diagnostic service is malformed")
+		}
+		for _, operation := range service.Operations {
+			if !validOperation(operation) {
+				return invalid("diagnostic operation is malformed")
+			}
+		}
+		for _, transport := range service.Transports {
+			if !validIdentity(transport) {
+				return invalid("diagnostic transport is malformed")
+			}
+		}
+	}
+	return validateDependencies(description.Dependencies, nil)
+}
+
+func validateListeners(listeners []Listener, services map[string]struct{}, operations map[string]struct{}) error {
+	if len(listeners) == 0 || len(listeners) > maxServices*2 {
+		return invalid("listener count is outside the supported range")
+	}
+	routeCount := 0
+	for _, listener := range listeners {
+		if !validIdentity(listener.Transport) || !validIdentity(listener.Service) {
+			return invalid("listener identity is malformed")
+		}
+		if _, exists := services[listener.Service]; !exists {
+			return invalid("listener service %q is not declared", listener.Service)
+		}
+		for _, route := range listener.Routes {
+			routeCount++
+			if routeCount > maxRoutes {
+				return invalid("route count exceeds %d", maxRoutes)
+			}
+			if !validHTTPMethod(route.Method) || !validHTTPPath(route.Path) || !validOperation(route.Operation) {
+				return invalid("listener route is malformed")
+			}
+			if _, exists := operations[route.Operation]; !exists {
+				return invalid("route operation %q is not declared", route.Operation)
+			}
+		}
+	}
+	return nil
+}
+
+func validateDependencies(dependencies []Dependency, knownOperations map[string]struct{}) error {
+	if len(dependencies) > maxDependencies {
+		return invalid("dependency count exceeds %d", maxDependencies)
+	}
+	for _, dependency := range dependencies {
+		if !validDependencyKind(dependency.Kind) || !validDependencyBinding(dependency.Binding) || !validIdentity(dependency.Transport) || !validIdentity(dependency.Service) || !validIdentity(dependency.Reason) || len(dependency.Operations) == 0 || len(dependency.Operations) > maxMethods {
+			return invalid("dependency is malformed")
+		}
+		hasGoMetadata := dependency.GoImportPath != "" || dependency.GoPackage != "" || dependency.GoName != ""
+		if hasGoMetadata &&
+			(!validGoImportPath(dependency.GoImportPath) || !token.IsIdentifier(dependency.GoPackage) || !token.IsIdentifier(dependency.GoName)) {
+			return invalid("dependency Go binding metadata is malformed")
+		}
+		if dependency.Kind == DependencyDeclared && !hasGoMetadata {
+			return invalid("declared dependency has no Go binding metadata")
+		}
+		if dependency.Kind == DependencyDeclared && dependency.Binding == "" {
+			return invalid("declared dependency has no explicit binding")
+		}
+		seen := make(map[string]struct{}, len(dependency.Operations))
+		for _, operation := range dependency.Operations {
+			if !validOperation(operation) {
+				return invalid("dependency operation is malformed")
+			}
+			if _, duplicate := seen[operation]; duplicate {
+				return invalid("dependency operation %q is duplicated", operation)
+			}
+			seen[operation] = struct{}{}
+			if knownOperations != nil {
+				if _, exists := knownOperations[operation]; !exists {
+					return invalid("dependency operation %q is not declared", operation)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validDependencyBinding(binding string) bool {
+	switch binding {
+	case "", DependencyBindingRemote, DependencyBindingAuto, DependencyBindingLocal:
+		return true
+	default:
+		return false
+	}
+}
+
+func validDependencyKind(kind string) bool {
+	switch kind {
+	case DependencyDeclared, DependencyGeneratedAdapter:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateHTTP(binding HTTPBinding) error {
+	additional := binding.Additional
+	if additional != nil && len(*additional) > maxAdditionalBindings {
+		return invalid("HTTP binding has too many additional routes")
+	}
+	if err := validateHTTPLeaf(binding); err != nil {
+		return err
+	}
+	seen := map[string]struct{}{binding.Method + "\x00" + binding.Path: {}}
+	if additional == nil {
+		return nil
+	}
+	for _, additionalBinding := range *additional {
+		if additionalBinding.Additional != nil {
+			return invalid("nested additional HTTP bindings are unsupported")
+		}
+		if err := validateHTTPLeaf(additionalBinding); err != nil {
+			return err
+		}
+		key := additionalBinding.Method + "\x00" + additionalBinding.Path
+		if _, duplicate := seen[key]; duplicate {
+			return invalid("HTTP binding route is duplicated")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateHTTPLeaf(binding HTTPBinding) error {
+	if !validHTTPMethod(binding.Method) || !validHTTPPath(binding.Path) || !validHTTPBody(binding.Body) || binding.ResponseBody != "" &&
+		!validHTTPResponseBodyPath(binding.ResponseBody) {
+		return invalid("HTTP binding is malformed")
+	}
+	if (binding.Method == "GET" || binding.Method == "DELETE" || binding.Method == "HEAD") && binding.Body != "" {
+		return invalid("HTTP GET/DELETE binding cannot have a body")
+	}
+	return nil
+}
+
+func validHTTPBody(body string) bool {
+	if body == "" || body == "*" {
+		return true
+	}
+	return validHTTPResponseBodyPath(body)
+}
+
+func validHTTPFieldName(value string) bool {
+	if value == "" || len(value) > 1024 || strings.TrimSpace(value) != value {
+		return false
+	}
+	if strings.Contains(value, ".") {
+		return false
+	}
+	for index, character := range value {
+		valid := character == '_' || character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || index > 0 && character >= '0' && character <= '9'
+		if !valid {
+			return false
+		}
+	}
+	return true
+}
+
+func validHTTPResponseBodyPath(value string) bool {
+	if value == "" || len(value) > 1024 || strings.TrimSpace(value) != value {
+		return false
+	}
+	segments := strings.Split(value, ".")
+	if len(segments) > 16 {
+		return false
+	}
+	for _, segment := range segments {
+		if !validHTTPFieldName(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+func validHTTPMethod(method string) bool {
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
+		return true
+	default:
+		return false
+	}
+}
+
+func validHTTPPath(value string) bool {
+	return strings.HasPrefix(value, "/") &&
+		!strings.ContainsAny(value, "?#\r\n") &&
+		validIdentity(value)
+}
+
+func validKind(kind string) bool {
+	switch kind {
+	case "unary", "client-stream", "server-stream", "bidi-stream":
+		return true
+	default:
+		return false
+	}
+}
+
+func validOperation(value string) bool {
+	return strings.HasPrefix(value, "/") && validIdentity(value)
+}
+
+func validSource(value string) bool {
+	return validIdentity(value) && !strings.HasPrefix(value, "/") && path.Clean(value) == value && value != "." && !strings.HasPrefix(value, "../")
+}
+
+func validGoImportPath(value string) bool {
+	if !validSource(value) || !strings.Contains(value, "/") {
+		return false
+	}
+	first, _, _ := strings.Cut(value, "/")
+	return strings.Contains(first, ".") && !strings.HasPrefix(first, ".") && !strings.HasSuffix(first, ".")
+}
+
+func validIdentity(value string) bool {
+	if value == "" || len(value) > maxIdentityBytes || !utf8.ValidString(value) || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func invalid(format string, arguments ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidManifest, fmt.Sprintf(format, arguments...))
+}
+
+func cloneManifest(manifest Manifest) Manifest {
+	result := manifest
+	result.Services = make([]Service, len(manifest.Services))
+	for serviceIndex, service := range manifest.Services {
+		result.Services[serviceIndex] = service
+		result.Services[serviceIndex].Methods = make([]Method, len(service.Methods))
+		for methodIndex, method := range service.Methods {
+			result.Services[serviceIndex].Methods[methodIndex] = method
+			if method.HTTP != nil {
+				result.Services[serviceIndex].Methods[methodIndex].HTTP =
+					cloneHTTPBinding(method.HTTP)
+			}
+			if method.Continuation != nil {
+				continuation := *method.Continuation
+				result.Services[serviceIndex].Methods[methodIndex].Continuation =
+					&continuation
+			}
+		}
+	}
+	result.Listeners = make([]Listener, len(manifest.Listeners))
+	for index, listener := range manifest.Listeners {
+		result.Listeners[index] = listener
+		result.Listeners[index].Routes = append([]Route(nil), listener.Routes...)
+	}
+	result.Dependencies = make([]Dependency, len(manifest.Dependencies))
+	for index, dependency := range manifest.Dependencies {
+		result.Dependencies[index] = cloneDependency(dependency)
+	}
+	result.Projections = make([]Projection, len(manifest.Projections))
+	for index, projection := range manifest.Projections {
+		result.Projections[index] = projection
+		result.Projections[index].KeyFields = append([]string(nil), projection.KeyFields...)
+	}
+	return result
+}
+
+func cloneHTTPBinding(binding *HTTPBinding) *HTTPBinding {
+	if binding == nil {
+		return nil
+	}
+	result := *binding
+	if binding.Additional != nil {
+		additional := append(HTTPBindings(nil), (*binding.Additional)...)
+		for index := range additional {
+			if additional[index].Additional != nil {
+				nested := append(HTTPBindings(nil), (*additional[index].Additional)...)
+				additional[index].Additional = &nested
+			}
+		}
+		result.Additional = &additional
+	}
+	return &result
+}
+
+func cloneDependency(dependency Dependency) Dependency {
+	dependency.Operations = append([]string(nil), dependency.Operations...)
+	return dependency
+}

--- a/errors/codec.go
+++ b/errors/codec.go
@@ -1,0 +1,35 @@
+package errors
+
+// Frame is the transport-neutral, serializable projection of an Error.
+//
+// Cause is deliberately absent because implementation errors must not cross a
+// transport boundary.
+type Frame struct {
+	Code     int32
+	Reason   string
+	Message  string
+	Metadata map[string]string
+}
+
+// ToFrame creates an independent wire projection of target.
+func ToFrame(target *Error) Frame {
+	if target == nil {
+		return Frame{}
+	}
+	return Frame{
+		Code:     target.Code(),
+		Reason:   target.Reason(),
+		Message:  target.Message(),
+		Metadata: target.Metadata(),
+	}
+}
+
+// FromFrame creates an Error without a private Cause.
+func FromFrame(frame Frame) *Error {
+	return New(
+		frame.Code,
+		frame.Reason,
+		frame.Message,
+		WithMetadata(frame.Metadata),
+	)
+}

--- a/errors/error.go
+++ b/errors/error.go
@@ -1,0 +1,173 @@
+// Package errors defines transport-neutral Keelith application errors.
+package errors
+
+import (
+	"maps"
+	"strconv"
+)
+
+// Error is an immutable transport-neutral application error.
+//
+// Code and Reason form its stable machine identity. Message is human-facing
+// and may vary without changing errors.Is matching.
+type Error struct {
+	code     int32
+	reason   string
+	message  string
+	metadata map[string]string
+	cause    error
+}
+
+// Option configures a new Error or an immutable Clone.
+type Option interface {
+	apply(*Error)
+}
+
+type optionFunc func(*Error)
+
+func (function optionFunc) apply(target *Error) {
+	function(target)
+}
+
+// WithMessage replaces the human-facing message.
+func WithMessage(message string) Option {
+	return optionFunc(func(target *Error) {
+		target.message = message
+	})
+}
+
+// WithMetadata merges a defensive copy of metadata into the Error.
+func WithMetadata(metadata map[string]string) Option {
+	snapshot := cloneMetadata(metadata)
+	return optionFunc(func(target *Error) {
+		if len(snapshot) == 0 {
+			return
+		}
+		if target.metadata == nil {
+			target.metadata = make(map[string]string, len(snapshot))
+		}
+		for key, value := range snapshot {
+			target.metadata[key] = value
+		}
+	})
+}
+
+// New constructs an Error without a Cause.
+func New(code int32, reason, message string, options ...Option) *Error {
+	return newError(nil, code, reason, message, options...)
+}
+
+// Wrap constructs an Error that unwraps to cause.
+func Wrap(cause error, code int32, reason, message string, options ...Option) *Error {
+	return newError(cause, code, reason, message, options...)
+}
+
+func newError(cause error, code int32, reason, message string, options ...Option) *Error {
+	target := &Error{
+		code:    code,
+		reason:  reason,
+		message: message,
+		cause:   cause,
+	}
+	for _, option := range options {
+		if option != nil {
+			option.apply(target)
+		}
+	}
+	return target
+}
+
+// Error returns a human-readable description without exposing the Cause.
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	switch {
+	case e.reason != "" && e.message != "":
+		return e.reason + ": " + e.message
+	case e.reason != "":
+		return e.reason
+	case e.message != "":
+		return e.message
+	default:
+		return "error code " + strconv.FormatInt(int64(e.code), 10)
+	}
+}
+
+// Unwrap returns the private implementation Cause.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// Is matches another Error by stable Code and Reason.
+func (e *Error) Is(candidate error) bool {
+	other, ok := candidate.(*Error)
+	if !ok || e == nil || other == nil {
+		return false
+	}
+	return e.code == other.code && e.reason == other.reason
+}
+
+// Clone returns an independent immutable copy with options applied.
+func (e *Error) Clone(options ...Option) *Error {
+	if e == nil {
+		return nil
+	}
+	clone := &Error{
+		code:     e.code,
+		reason:   e.reason,
+		message:  e.message,
+		metadata: cloneMetadata(e.metadata),
+		cause:    e.cause,
+	}
+	for _, option := range options {
+		if option != nil {
+			option.apply(clone)
+		}
+	}
+	return clone
+}
+
+// Code returns the stable numeric application code.
+func (e *Error) Code() int32 {
+	if e == nil {
+		return 0
+	}
+	return e.code
+}
+
+// Reason returns the stable machine-readable reason.
+func (e *Error) Reason() string {
+	if e == nil {
+		return ""
+	}
+	return e.reason
+}
+
+// Message returns the human-facing message.
+func (e *Error) Message() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+// Metadata returns a defensive copy of error metadata.
+func (e *Error) Metadata() map[string]string {
+	if e == nil {
+		return nil
+	}
+	return cloneMetadata(e.metadata)
+}
+
+func cloneMetadata(source map[string]string) map[string]string {
+	if len(source) == 0 {
+		return nil
+	}
+	clone := make(map[string]string, len(source))
+	maps.Copy(clone, source)
+	return clone
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/keelab/keelith
 
-go 1.26.3
+go 1.26.6
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require google.golang.org/protobuf v1.36.12

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/governance/admission/admission.go
+++ b/governance/admission/admission.go
@@ -1,0 +1,336 @@
+// Package admission applies dynamic, provider-neutral outbound drop policies.
+package admission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unicode"
+	"unicode/utf8"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+const (
+	maximumCategories  = 16
+	maximumIdentityLen = 1_024
+	maximumDenominator = 1_000_000
+)
+
+var (
+	// ErrDropped reports that a dynamic admission policy rejected a logical
+	// outbound call before any transport attempt was started.
+	ErrDropped = kerrors.New(
+		503,
+		"ADMISSION_DROPPED",
+		"request was dropped by an admission policy",
+	)
+	// ErrInvalidPolicy reports an unsafe drop category or percentage.
+	ErrInvalidPolicy = errors.New("admission: invalid policy")
+	// ErrInvalidUpdate reports an invalid service or revision identity.
+	ErrInvalidUpdate = errors.New("admission: invalid update")
+	// ErrInvalidOption reports a nil resolver, random source, or handler.
+	ErrInvalidOption = errors.New("admission: invalid option")
+	// ErrMissingOperation reports an invocation without a stable Operation.
+	ErrMissingOperation = errors.New("admission: operation is missing")
+)
+
+// Category is one ordered drop decision. Categories are evaluated in order;
+// each percentage applies to traffic remaining after earlier categories.
+type Category struct {
+	Name        string
+	Numerator   uint32
+	Denominator uint32
+}
+
+// Policy is an immutable-by-convention ordered admission policy.
+type Policy struct {
+	Categories []Category
+}
+
+// Clone returns an independent Policy value.
+func (policy Policy) Clone() Policy {
+	return Policy{Categories: append([]Category(nil), policy.Categories...)}
+}
+
+// Validate verifies bounded category identities and fractional percentages.
+func Validate(policy Policy) error {
+	if len(policy.Categories) > maximumCategories {
+		return fmt.Errorf("%w: category count exceeds %d", ErrInvalidPolicy, maximumCategories)
+	}
+	seen := make(map[string]struct{}, len(policy.Categories))
+	for _, category := range policy.Categories {
+		if !validIdentity(category.Name) {
+			return fmt.Errorf("%w: category name is invalid", ErrInvalidPolicy)
+		}
+		if category.Denominator == 0 ||
+			category.Denominator > maximumDenominator ||
+			category.Numerator > category.Denominator {
+			return fmt.Errorf("%w: category percentage is invalid", ErrInvalidPolicy)
+		}
+		if _, duplicate := seen[category.Name]; duplicate {
+			return fmt.Errorf("%w: category name is duplicated", ErrInvalidPolicy)
+		}
+		seen[category.Name] = struct{}{}
+	}
+	return nil
+}
+
+// Resolver returns the current complete Policy for one logical service.
+type Resolver interface {
+	Resolve(string) Policy
+}
+
+// Sink atomically accepts a complete Policy for one logical service.
+type Sink interface {
+	Update(string, string, Policy) (bool, error)
+}
+
+type storeEntry struct {
+	revision string
+	policy   Policy
+}
+
+// Store publishes immutable per-service admission policies.
+type Store struct {
+	mu       sync.RWMutex
+	services map[string]storeEntry
+	updates  uint64
+}
+
+// StoreDescription is a value-free aggregate of current policy state.
+type StoreDescription struct {
+	Services   int
+	Categories int
+	Updates    uint64
+}
+
+// NewStore creates an empty Store. An absent service policy allows traffic.
+func NewStore() *Store {
+	return &Store{services: make(map[string]storeEntry)}
+}
+
+// Update validates and atomically replaces one service policy. A repeated
+// revision is ignored so duplicate xDS responses do not perturb state.
+func (s *Store) Update(service string, revision string, policy Policy) (bool, error) {
+	if s == nil {
+		return false, fmt.Errorf("%w: store is nil", ErrInvalidUpdate)
+	}
+	if !validIdentity(service) || !validIdentity(revision) {
+		return false, fmt.Errorf("%w: service or revision is invalid", ErrInvalidUpdate)
+	}
+	if err := Validate(policy); err != nil {
+		return false, err
+	}
+	next := policy.Clone()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if current, exists := s.services[service]; exists && current.revision == revision {
+		return false, nil
+	}
+	if s.services == nil {
+		s.services = make(map[string]storeEntry)
+	}
+	s.services[service] = storeEntry{revision: revision, policy: next}
+	s.updates++
+	return true, nil
+}
+
+// Resolve returns an independent current Policy. Unknown services resolve to
+// an empty allow-all policy.
+func (s *Store) Resolve(service string) Policy {
+	if s == nil {
+		return Policy{}
+	}
+	s.mu.RLock()
+	entry, exists := s.services[service]
+	s.mu.RUnlock()
+	if !exists {
+		return Policy{}
+	}
+	return entry.policy.Clone()
+}
+
+// Describe returns aggregate cardinality without service, revision, or
+// category values.
+func (s *Store) Describe() StoreDescription {
+	if s == nil {
+		return StoreDescription{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	description := StoreDescription{
+		Services: len(s.services),
+		Updates:  s.updates,
+	}
+	for _, entry := range s.services {
+		description.Categories += len(entry.policy.Categories)
+	}
+	return description
+}
+
+// Random supplies unbiased values in [0, limit).
+type Random interface {
+	Uint64N(uint64) uint64
+}
+
+// Option configures a Controller.
+type Option interface {
+	apply(*controllerOptions) error
+}
+
+type optionFunc func(*controllerOptions) error
+
+func (function optionFunc) apply(options *controllerOptions) error {
+	return function(options)
+}
+
+type controllerOptions struct {
+	random Random
+}
+
+// WithRandom replaces the production sampler for deterministic tests.
+func WithRandom(random Random) Option {
+	return optionFunc(func(options *controllerOptions) error {
+		if isNil(random) {
+			return fmt.Errorf("random source is nil")
+		}
+		options.random = random
+		return nil
+	})
+}
+
+// Description is a bounded Controller snapshot.
+type Description struct {
+	Enabled    bool
+	Services   int
+	Categories int
+	Updates    uint64
+	Accepted   uint64
+	Dropped    uint64
+}
+
+// Controller resolves and samples one admission policy per logical call.
+type Controller struct {
+	resolver Resolver
+	random   Random
+	accepted atomic.Uint64
+	dropped  atomic.Uint64
+}
+
+// New creates a Controller without starting goroutines.
+func New(resolver Resolver, optionList ...Option) (*Controller, error) {
+	if isNil(resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidOption)
+	}
+	settings := controllerOptions{random: packageRandom{}}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	return &Controller{resolver: resolver, random: settings.random}, nil
+}
+
+// Middleware rejects a dropped logical call before invoking next.
+func (c *Controller) Middleware() middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return invalidHandler("next handler is nil")
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if c == nil || ctx == nil {
+				return nil, fmt.Errorf("%w: controller or context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			policy := c.resolver.Resolve(target.Service())
+			if err := Validate(policy); err != nil {
+				return nil, err
+			}
+			for _, category := range policy.Categories {
+				if category.Numerator == category.Denominator || c.random.Uint64N(uint64(category.Denominator)) < uint64(category.Numerator) {
+					c.dropped.Add(1)
+					return nil, ErrDropped
+				}
+			}
+			c.accepted.Add(1)
+			return next(ctx, request)
+		}
+	}
+}
+
+// Describe returns aggregate policy and decision state.
+func (c *Controller) Describe() Description {
+	if c == nil {
+		return Description{}
+	}
+	description := Description{
+		Enabled:  true,
+		Accepted: c.accepted.Load(),
+		Dropped:  c.dropped.Load(),
+	}
+	if describer, ok := c.resolver.(interface {
+		Describe() StoreDescription
+	}); ok {
+		store := describer.Describe()
+		description.Services = store.Services
+		description.Categories = store.Categories
+		description.Updates = store.Updates
+	}
+	return description
+}
+
+type packageRandom struct{}
+
+func (packageRandom) Uint64N(limit uint64) uint64 {
+	return rand.Uint64N(limit)
+}
+
+func invalidHandler(message string) middleware.Handler {
+	return func(context.Context, any) (any, error) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidOption, message)
+	}
+}
+
+func validIdentity(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value || len(value) > maximumIdentityLen || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+var (
+	_ Resolver = (*Store)(nil)
+	_ Sink     = (*Store)(nil)
+)

--- a/governance/attempt/context.go
+++ b/governance/attempt/context.go
@@ -1,0 +1,38 @@
+// Package attempt carries low-cardinality governance attempt metadata.
+package attempt
+
+import (
+	"context"
+
+	"github.com/keelab/keelith/operation"
+)
+
+type probeContextKey struct{}
+
+// WithContext records a one-based invocation attempt.
+func WithContext(ctx context.Context, number int) context.Context {
+	return operation.WithAttempt(ctx, number)
+}
+
+// FromContext returns a one-based invocation attempt. Calls that have not
+// entered retry or hedging middleware are reported as attempt one.
+func FromContext(ctx context.Context) int {
+	return operation.AttemptFromContext(ctx)
+}
+
+// WithProbe marks a circuit-breaker recovery probe.
+//
+// Attempt controllers must not amplify a probe through retries or hedging:
+// one admitted half-open probe represents exactly one transport invocation.
+func WithProbe(ctx context.Context) context.Context {
+	return context.WithValue(ctx, probeContextKey{}, true)
+}
+
+// IsProbe reports whether the invocation is a circuit-breaker recovery probe.
+func IsProbe(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	probe, _ := ctx.Value(probeContextKey{}).(bool)
+	return probe
+}

--- a/governance/breaker/breaker.go
+++ b/governance/breaker/breaker.go
@@ -1,0 +1,361 @@
+// Package breaker provides explainable service and instance circuit breakers.
+package breaker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/governance/policy"
+)
+
+var (
+	// ErrOpen is non-retryable so rejections cannot create retry storms.
+	ErrOpen = kerrors.New(503, "CIRCUIT_OPEN", "circuit breaker is open")
+	// ErrInvalidOption means a breaker dependency or scope is invalid.
+	ErrInvalidOption = errors.New("breaker: invalid option")
+)
+
+// State is the stable circuit state.
+type State string
+
+const (
+	// StateClosed accepts invocations and records outcomes.
+	StateClosed State = "closed"
+	// StateOpen rejects invocations until the open deadline.
+	StateOpen State = "open"
+	// StateHalfOpen admits bounded probes before recovery.
+	StateHalfOpen State = "half-open"
+)
+
+// Scope separates aggregate service health from one selected instance.
+type Scope string
+
+const (
+	// ScopeService aggregates failures across a logical service.
+	ScopeService Scope = "service"
+	// ScopeInstance isolates failures for one selected instance.
+	ScopeInstance Scope = "instance"
+)
+
+// Clock supplies deterministic state-machine time.
+type Clock interface {
+	Now() time.Time
+}
+
+// Description is a low-cardinality debug snapshot.
+type Description struct {
+	Scope          Scope
+	Key            string
+	State          State
+	Requests       uint64
+	Failures       uint64
+	OpenUntil      time.Time
+	ProbesInFlight int
+	ProbeSuccesses int
+}
+
+// Breaker is one isolated state machine.
+type Breaker struct {
+	clock Clock
+
+	mu             sync.Mutex
+	state          State
+	windowStart    time.Time
+	requests       uint64
+	failures       uint64
+	openUntil      time.Time
+	probesInFlight int
+	probeSuccesses int
+	generation     uint64
+}
+
+// Permit must be completed exactly once after an allowed invocation.
+type Permit struct {
+	breaker    *Breaker
+	config     policy.BreakerPolicy
+	state      State
+	generation uint64
+	once       sync.Once
+}
+
+// NewBreaker creates one closed state machine.
+func NewBreaker(clock Clock) *Breaker {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	return &Breaker{clock: clock, state: StateClosed}
+}
+
+// Allow advances timed transitions and returns a completion Permit.
+func (b *Breaker) Allow(config policy.BreakerPolicy) (*Permit, error) {
+	if b == nil {
+		return nil, fmt.Errorf("%w: breaker is nil", ErrInvalidOption)
+	}
+	if !config.Enabled {
+		return &Permit{}, nil
+	}
+	if err := validate(config); err != nil {
+		return nil, err
+	}
+
+	now := b.clock.Now()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateClosed:
+		b.rollWindow(now, config.Window)
+	case StateOpen:
+		if now.Before(b.openUntil) {
+			return nil, ErrOpen
+		}
+		b.state = StateHalfOpen
+		b.probesInFlight = 0
+		b.probeSuccesses = 0
+	case StateHalfOpen:
+	default:
+		b.state = StateClosed
+		b.rollWindow(now, config.Window)
+	}
+	if b.state == StateHalfOpen {
+		if b.probesInFlight >= config.HalfOpenProbes {
+			return nil, ErrOpen
+		}
+		b.probesInFlight++
+	}
+	return &Permit{
+		breaker:    b,
+		config:     config,
+		state:      b.state,
+		generation: b.generation,
+	}, nil
+}
+
+// Done records one allowed invocation result. Repeated calls are ignored.
+func (permit *Permit) Done(err error) {
+	if permit == nil || permit.breaker == nil {
+		return
+	}
+	permit.once.Do(func() {
+		permit.breaker.complete(
+			permit.config,
+			permit.state,
+			permit.generation,
+			err,
+		)
+	})
+}
+
+// Probe reports whether this permit was admitted in half-open state.
+func (permit *Permit) Probe() bool {
+	return permit != nil &&
+		permit.breaker != nil &&
+		permit.state == StateHalfOpen
+}
+
+// Describe returns an immutable state snapshot.
+func (b *Breaker) Describe() Description {
+	if b == nil {
+		return Description{State: StateOpen}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return Description{
+		State:          b.state,
+		Requests:       b.requests,
+		Failures:       b.failures,
+		OpenUntil:      b.openUntil,
+		ProbesInFlight: b.probesInFlight,
+		ProbeSuccesses: b.probeSuccesses,
+	}
+}
+
+func (b *Breaker) complete(config policy.BreakerPolicy, permittedState State, generation uint64, err error) {
+	now := b.clock.Now()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if generation != b.generation || permittedState != b.state {
+		return
+	}
+	failed := instanceFailure(err)
+	switch b.state {
+	case StateClosed:
+		b.rollWindow(now, config.Window)
+		b.requests++
+		if failed {
+			b.failures++
+		}
+		if b.requests >= uint64(config.MinRequests) &&
+			float64(b.failures)/float64(b.requests) >= config.FailureRatio {
+			b.open(now, config.OpenTimeout)
+		}
+	case StateHalfOpen:
+		if b.probesInFlight > 0 {
+			b.probesInFlight--
+		}
+		if failed {
+			b.open(now, config.OpenTimeout)
+			return
+		}
+		b.probeSuccesses++
+		if b.probeSuccesses >= config.HalfOpenProbes {
+			b.close(now)
+		}
+	}
+}
+
+func (b *Breaker) rollWindow(now time.Time, window time.Duration) {
+	if b.windowStart.IsZero() ||
+		now.Sub(b.windowStart) >= window ||
+		now.Before(b.windowStart) {
+		b.windowStart = now
+		b.requests = 0
+		b.failures = 0
+	}
+}
+
+func (b *Breaker) open(now time.Time, duration time.Duration) {
+	b.state = StateOpen
+	b.openUntil = now.Add(duration)
+	b.probesInFlight = 0
+	b.probeSuccesses = 0
+	b.generation++
+}
+
+func (b *Breaker) close(now time.Time) {
+	b.state = StateClosed
+	b.windowStart = now
+	b.requests = 0
+	b.failures = 0
+	b.openUntil = time.Time{}
+	b.probesInFlight = 0
+	b.probeSuccesses = 0
+	b.generation++
+}
+
+func instanceFailure(err error) bool {
+	switch failure.Classify(err) {
+	case failure.Transport, failure.Timeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func validate(config policy.BreakerPolicy) error {
+	if config.FailureRatio <= 0 || config.FailureRatio > 1 || config.Window <= 0 || config.MinRequests <= 0 || config.OpenTimeout <= 0 || config.HalfOpenProbes <= 0 {
+		return fmt.Errorf("%w: resolved breaker policy is invalid", policy.ErrInvalidPolicy)
+	}
+	return nil
+}
+
+// Pool owns breaker state by explicit low-cardinality scope and key.
+type Pool struct {
+	clock Clock
+
+	mu       sync.Mutex
+	breakers map[poolKey]*Breaker
+}
+
+type poolKey struct {
+	scope Scope
+	key   string
+}
+
+// NewPool creates an isolated breaker pool.
+func NewPool(clock Clock) *Pool {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	return &Pool{clock: clock, breakers: make(map[poolKey]*Breaker)}
+}
+
+// Get returns the stable breaker for scope/key.
+func (p *Pool) Get(scope Scope, key string) *Breaker {
+	if p == nil {
+		return nil
+	}
+	normalized := strings.TrimSpace(key)
+	identity := poolKey{scope: scope, key: normalized}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	subject := p.breakers[identity]
+	if subject == nil {
+		subject = NewBreaker(p.clock)
+		p.breakers[identity] = subject
+	}
+	return subject
+}
+
+// Describe returns sorted low-cardinality snapshots.
+func (p *Pool) Describe() []Description {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	entries := make([]struct {
+		identity poolKey
+		breaker  *Breaker
+	}, 0, len(p.breakers))
+	for identity, subject := range p.breakers {
+		entries = append(entries, struct {
+			identity poolKey
+			breaker  *Breaker
+		}{identity: identity, breaker: subject})
+	}
+	p.mu.Unlock()
+
+	result := make([]Description, 0, len(entries))
+	for _, entry := range entries {
+		description := entry.breaker.Describe()
+		description.Scope = entry.identity.scope
+		description.Key = entry.identity.key
+		result = append(result, description)
+	}
+	sort.Slice(result, func(first, second int) bool {
+		if result[first].Scope == result[second].Scope {
+			return result[first].Key < result[second].Key
+		}
+		return result[first].Scope < result[second].Scope
+	})
+	return result
+}
+
+type instanceContextKey struct{}
+
+// WithInstance records the selected stable instance identity.
+func WithInstance(ctx context.Context, instance string) context.Context {
+	return context.WithValue(ctx, instanceContextKey{}, strings.TrimSpace(instance))
+}
+
+func instanceFromContext(ctx context.Context) (string, bool) {
+	instance, ok := ctx.Value(instanceContextKey{}).(string)
+	return instance, ok && instance != ""
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/breaker/middleware.go
+++ b/governance/breaker/middleware.go
@@ -1,0 +1,101 @@
+package breaker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/attempt"
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// ErrMissingInstance reports an instance breaker without a selected instance.
+var ErrMissingInstance = kerrors.New(
+	500,
+	"BREAKER_INSTANCE_MISSING",
+	"instance breaker requires a selected instance",
+)
+
+// NewService creates the service-level dependency breaker.
+//
+// Place it outside retry or hedging middleware so one logical dependency call
+// contributes exactly one final outcome to aggregate service health.
+func NewService(resolver policy.Resolver, pool *Pool) (middleware.Middleware, error) {
+	return New(resolver, pool, ScopeService)
+}
+
+// NewInstance creates an instance-scoped breaker for advanced adapters that
+// attach a selected instance with WithInstance before entering middleware.
+//
+// Selector-based clients should normally use outlier.Detector instead because
+// it observes every selected attempt and can exclude unhealthy nodes before
+// transport dispatch.
+func NewInstance(resolver policy.Resolver, pool *Pool) (middleware.Middleware, error) {
+	return New(resolver, pool, ScopeInstance)
+}
+
+// New creates service- or instance-scoped breaker Middleware.
+func New(resolver policy.Resolver, pool *Pool, scope Scope) (middleware.Middleware, error) {
+	if isNil(resolver) || pool == nil {
+		return nil, fmt.Errorf("%w: resolver or pool is nil", ErrInvalidOption)
+	}
+	if scope != ScopeService && scope != ScopeInstance {
+		return nil, fmt.Errorf("%w: scope %q", ErrInvalidOption, scope)
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, errors.New("breaker: operation is missing")
+			}
+			config := policy.Resolve(ctx, resolver, target).Breaker
+			if !config.Enabled {
+				return next(ctx, request)
+			}
+			key := target.Transport() + "/" + target.Service()
+			if scope == ScopeInstance {
+				var exists bool
+				key, exists = instanceFromContext(ctx)
+				if !exists {
+					return nil, ErrMissingInstance
+				}
+			}
+			permit, err := pool.Get(scope, key).Allow(config)
+			if err != nil {
+				return nil, err
+			}
+			invokeContext := ctx
+			if permit.Probe() {
+				invokeContext = attempt.WithProbe(ctx)
+			}
+			var response any
+			var resultErr error
+
+			defer func() {
+				recovered := recover()
+				if recovered != nil {
+					permit.Done(failure.MarkTransport(
+						errors.New("breaker: downstream invocation panic"),
+					))
+					panic(recovered)
+				}
+				permit.Done(resultErr)
+			}()
+			response, resultErr = next(invokeContext, request)
+			return response, resultErr
+		}
+	}, nil
+}

--- a/governance/bulkhead/bulkhead.go
+++ b/governance/bulkhead/bulkhead.go
@@ -1,0 +1,352 @@
+// Package bulkhead provides dependency-scoped concurrency isolation.
+package bulkhead
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/policy"
+)
+
+var (
+	// ErrFull reports a fail-fast rejection because all concurrency and queue
+	// slots are occupied.
+	ErrFull = kerrors.New(503, "BULKHEAD_FULL", "dependency bulkhead is full")
+	// ErrQueueTimeout reports expiration while waiting in the bounded queue.
+	ErrQueueTimeout = kerrors.New(
+		503,
+		"BULKHEAD_QUEUE_TIMEOUT",
+		"dependency bulkhead queue timed out",
+	)
+	// ErrInvalidOption reports an invalid dependency or resolved policy.
+	ErrInvalidOption = errors.New("bulkhead: invalid option")
+)
+
+// Clock supplies deterministic queue timeout channels.
+type Clock interface {
+	After(time.Duration) <-chan time.Time
+}
+
+// Description is one bounded dependency-isolation snapshot.
+type Description struct {
+	Key                string
+	MaxConcurrency     int
+	MaxQueue           int
+	Inflight           int
+	Queued             int
+	QueueHighWater     int
+	Accepted           uint64
+	Rejected           uint64
+	QueueTimeouts      uint64
+	QueueCancellations uint64
+}
+
+type waiterState uint8
+
+const (
+	waiterQueued waiterState = iota
+	waiterGranted
+	waiterCanceled
+)
+
+type waiter struct {
+	ready chan struct{}
+	state waiterState
+}
+
+// Bulkhead isolates concurrent logical calls to one dependency key.
+//
+// Waiting is FIFO. A slot is reserved before a queued waiter is awakened, so
+// a newly arriving caller cannot overtake it.
+type Bulkhead struct {
+	clock Clock
+
+	mu                 sync.Mutex
+	maxConcurrency     int
+	maxQueue           int
+	inflight           int
+	waiters            []*waiter
+	queueHighWater     int
+	accepted           uint64
+	rejected           uint64
+	queueTimeouts      uint64
+	queueCancellations uint64
+}
+
+// Permit releases one logical-call slot exactly once.
+type Permit struct {
+	bulkhead *Bulkhead
+	once     sync.Once
+}
+
+// NewBulkhead creates one isolated dependency gate.
+func NewBulkhead(clock Clock) *Bulkhead {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	return &Bulkhead{clock: clock}
+}
+
+// Acquire obtains a logical-call slot or waits in the bounded FIFO queue.
+func (b *Bulkhead) Acquire(ctx context.Context, config policy.BulkheadPolicy) (*Permit, error) {
+	if b == nil {
+		return nil, fmt.Errorf("%w: bulkhead is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	if !config.Enabled {
+		return &Permit{}, nil
+	}
+	if err := validate(config); err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock()
+	b.maxConcurrency = config.MaxConcurrency
+	b.maxQueue = config.MaxQueue
+
+	for b.inflight < b.maxConcurrency &&
+		len(b.waiters) > 0 {
+		b.grantNextLocked()
+	}
+	if b.inflight < config.MaxConcurrency && len(b.waiters) == 0 {
+		b.inflight++
+		b.accepted++
+		b.mu.Unlock()
+		return &Permit{bulkhead: b}, nil
+	}
+	if config.MaxQueue == 0 || len(b.waiters) >= config.MaxQueue {
+		b.rejected++
+		b.mu.Unlock()
+		return nil, ErrFull
+	}
+	candidate := &waiter{ready: make(chan struct{}), state: waiterQueued}
+	b.waiters = append(b.waiters, candidate)
+	if len(b.waiters) > b.queueHighWater {
+		b.queueHighWater = len(b.waiters)
+	}
+	b.mu.Unlock()
+
+	select {
+	case <-candidate.ready:
+		if cause := context.Cause(ctx); cause != nil {
+			b.cancelGranted(candidate, false)
+			return nil, cause
+		}
+		return &Permit{bulkhead: b}, nil
+	case <-ctx.Done():
+		b.cancelGranted(candidate, false)
+		return nil, context.Cause(ctx)
+	case <-b.clock.After(config.QueueTimeout):
+		b.cancelGranted(candidate, true)
+		return nil, ErrQueueTimeout
+	}
+}
+
+// Release returns one logical-call slot and grants the oldest queued waiter.
+func (permit *Permit) Release() {
+	if permit == nil || permit.bulkhead == nil {
+		return
+	}
+	permit.once.Do(func() {
+		permit.bulkhead.release()
+	})
+}
+
+// Describe returns immutable gate state.
+func (b *Bulkhead) Describe() Description {
+	if b == nil {
+		return Description{}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return Description{
+		MaxConcurrency:     b.maxConcurrency,
+		MaxQueue:           b.maxQueue,
+		Inflight:           b.inflight,
+		Queued:             len(b.waiters),
+		QueueHighWater:     b.queueHighWater,
+		Accepted:           b.accepted,
+		Rejected:           b.rejected,
+		QueueTimeouts:      b.queueTimeouts,
+		QueueCancellations: b.queueCancellations,
+	}
+}
+
+func (b *Bulkhead) release() {
+	b.mu.Lock()
+	if b.inflight > 0 {
+		b.inflight--
+	}
+	b.grantNextLocked()
+	b.mu.Unlock()
+}
+
+// cancelGranted removes a queued waiter. If it had already received a slot,
+// that reservation is released and handed to the next waiter.
+//
+// It returns true when the timeout/cancellation won while the waiter was
+// still queued.
+func (b *Bulkhead) cancelGranted(candidate *waiter, timedOut bool) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch candidate.state {
+	case waiterQueued:
+		candidate.state = waiterCanceled
+		b.removeWaiterLocked(candidate)
+		if timedOut {
+			b.queueTimeouts++
+		} else {
+			b.queueCancellations++
+		}
+		b.grantNextLocked()
+		return true
+	case waiterGranted:
+		candidate.state = waiterCanceled
+		if b.inflight > 0 {
+			b.inflight--
+		}
+		if timedOut {
+			b.queueTimeouts++
+		} else {
+			b.queueCancellations++
+		}
+		b.grantNextLocked()
+		return false
+	default:
+		return true
+	}
+}
+
+func (b *Bulkhead) grantNextLocked() {
+	if b.maxConcurrency <= 0 ||
+		b.inflight >= b.maxConcurrency {
+		return
+	}
+	for len(b.waiters) > 0 {
+		candidate := b.waiters[0]
+		b.waiters = b.waiters[1:]
+		if candidate.state != waiterQueued {
+			continue
+		}
+		candidate.state = waiterGranted
+		b.inflight++
+		b.accepted++
+		close(candidate.ready)
+		return
+	}
+}
+
+func (b *Bulkhead) removeWaiterLocked(candidate *waiter) {
+	for index, current := range b.waiters {
+		if current != candidate {
+			continue
+		}
+		copy(b.waiters[index:], b.waiters[index+1:])
+		b.waiters[len(b.waiters)-1] = nil
+		b.waiters = b.waiters[:len(b.waiters)-1]
+		return
+	}
+}
+
+func validate(config policy.BulkheadPolicy) error {
+	if config.MaxConcurrency <= 0 ||
+		config.MaxQueue < 0 ||
+		config.QueueTimeout < 0 ||
+		config.MaxQueue > 0 && config.QueueTimeout <= 0 ||
+		config.MaxQueue == 0 && config.QueueTimeout > 0 {
+		return fmt.Errorf("%w: resolved bulkhead policy is invalid", policy.ErrInvalidPolicy)
+	}
+	return nil
+}
+
+// Pool owns Bulkhead state by a stable dependency key.
+type Pool struct {
+	clock Clock
+
+	mu        sync.Mutex
+	bulkheads map[string]*Bulkhead
+}
+
+// NewPool creates an isolated dependency bulkhead pool.
+func NewPool(clock Clock) *Pool {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	return &Pool{
+		clock:     clock,
+		bulkheads: make(map[string]*Bulkhead),
+	}
+}
+
+// Get returns the stable Bulkhead for key.
+func (p *Pool) Get(key string) *Bulkhead {
+	if p == nil {
+		return nil
+	}
+	normalized := strings.TrimSpace(key)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	subject := p.bulkheads[normalized]
+	if subject == nil {
+		subject = NewBulkhead(p.clock)
+		p.bulkheads[normalized] = subject
+	}
+	return subject
+}
+
+// Describe returns sorted low-cardinality snapshots.
+func (p *Pool) Describe() []Description {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	entries := make(map[string]*Bulkhead, len(p.bulkheads))
+	for key, subject := range p.bulkheads {
+		entries[key] = subject
+	}
+	p.mu.Unlock()
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]Description, 0, len(keys))
+	for _, key := range keys {
+		description := entries[key].Describe()
+		description.Key = key
+		result = append(result, description)
+	}
+	return result
+}
+
+type systemClock struct{}
+
+func (systemClock) After(duration time.Duration) <-chan time.Time {
+	return time.After(duration)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/bulkhead/middleware.go
+++ b/governance/bulkhead/middleware.go
@@ -1,0 +1,46 @@
+package bulkhead
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// New creates dependency-scoped logical-call concurrency middleware.
+func New(resolver policy.Resolver, pool *Pool) (middleware.Middleware, error) {
+	if isNil(resolver) || pool == nil {
+		return nil, fmt.Errorf("%w: resolver or pool is nil", ErrInvalidOption)
+	}
+
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, fmt.Errorf("%w: operation is missing", ErrInvalidOption)
+			}
+			config := policy.Resolve(ctx, resolver, target).Bulkhead
+			if !config.Enabled {
+				return next(ctx, request)
+			}
+			key := target.Transport() + "/" + target.Service()
+			permit, err := pool.Get(key).Acquire(ctx, config)
+			if err != nil {
+				return nil, err
+			}
+			defer permit.Release()
+			return next(ctx, request)
+		}
+	}, nil
+}

--- a/governance/dependency/runtime.go
+++ b/governance/dependency/runtime.go
@@ -1,0 +1,346 @@
+// Package dependency assembles coherent outbound dependency governance.
+package dependency
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/keelab/keelith/governance/admission"
+	"github.com/keelab/keelith/governance/attempt"
+	"github.com/keelab/keelith/governance/breaker"
+	"github.com/keelab/keelith/governance/bulkhead"
+	"github.com/keelab/keelith/governance/hedging"
+	"github.com/keelab/keelith/governance/outlier"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/governance/retry"
+	ktimeout "github.com/keelab/keelith/governance/timeout"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/selector"
+)
+
+const (
+	defaultOutlierFailures = 5
+	defaultOutlierEjection = 30 * time.Second
+	defaultRetryBurst      = 1
+	defaultSource          = "dependency-runtime"
+)
+
+var (
+	// ErrInvalidConfig means a dependency Runtime cannot be assembled safely.
+	ErrInvalidConfig = errors.New("dependency: invalid config")
+	// ErrMissingOperation means outbound middleware did not receive an
+	// Operation from its transport adapter.
+	ErrMissingOperation = errors.New("dependency: operation is missing")
+)
+
+// Config defines one coherent outbound dependency-governance runtime.
+//
+// The Runtime owns its service-breaker pool and retry budget unless explicit
+// shared instances are supplied. InstanceOutlier is defaulted when omitted.
+type Config struct {
+	Resolver               policy.Resolver
+	Admission              admission.Resolver
+	AdmissionOptions       []admission.Option
+	Breakers               *breaker.Pool
+	Bulkheads              *bulkhead.Pool
+	RetryBudget            *retry.Budget
+	RetryOptions           []retry.Option
+	HedgingOptions         []hedging.Option
+	InstanceOutlier        outlier.Config
+	DisableInstanceOutlier bool
+	Source                 string
+}
+
+// Description is an immutable operational snapshot.
+type Description struct {
+	Middleware []middleware.Description
+	Admission  admission.Description
+	Breakers   []breaker.Description
+	Bulkheads  []bulkhead.Description
+	Retry      []retry.BudgetDescription
+	Instances  []outlier.Status
+}
+
+// Runtime coordinates aggregate service health, attempt amplification, and
+// per-instance passive health.
+//
+// Its middleware order is fixed:
+//
+//	policy snapshot -> optional dynamic admission -> logical-call timeout -> dependency bulkhead
+//	-> service breaker -> retry/hedging dispatcher
+//
+// The timeout and service breaker therefore observe one final logical call
+// while the selector Observer sees every selected transport attempt.
+type Runtime struct {
+	bundle       *middleware.Bundle
+	admission    *admission.Controller
+	breakers     *breaker.Pool
+	bulkheads    *bulkhead.Pool
+	retryBudget  *retry.Budget
+	instanceTier *outlier.Detector
+}
+
+// New assembles an outbound dependency Runtime.
+func New(config Config) (*Runtime, error) {
+	if isNil(config.Resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidConfig)
+	}
+
+	breakers := config.Breakers
+	if breakers == nil {
+		breakers = breaker.NewPool(nil)
+	}
+	bulkheads := config.Bulkheads
+	if bulkheads == nil {
+		bulkheads = bulkhead.NewPool(nil)
+	}
+	budget := config.RetryBudget
+	if budget == nil {
+		budget = retry.NewBudget(defaultRetryBurst)
+	}
+	instanceTier, err := newInstanceTier(config)
+	if err != nil {
+		return nil, err
+	}
+	var admissionController *admission.Controller
+	if !isNil(config.Admission) {
+		admissionController, err = admission.New(
+			config.Admission,
+			config.AdmissionOptions...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%w: admission: %w",
+				ErrInvalidConfig,
+				err,
+			)
+		}
+	}
+
+	serviceBreaker, err := breaker.NewService(config.Resolver, breakers)
+	if err != nil {
+		return nil, fmt.Errorf("%w: service breaker: %w", ErrInvalidConfig, err)
+	}
+	callTimeout, err := ktimeout.New(config.Resolver)
+	if err != nil {
+		return nil, fmt.Errorf("%w: timeout: %w", ErrInvalidConfig, err)
+	}
+	dependencyBulkhead, err := bulkhead.New(config.Resolver, bulkheads)
+	if err != nil {
+		return nil, fmt.Errorf("%w: bulkhead: %w", ErrInvalidConfig, err)
+	}
+	retryOptions := append([]retry.Option(nil), config.RetryOptions...)
+	retryOptions = append(retryOptions, retry.WithBudget(budget))
+	retryMiddleware, err := retry.New(config.Resolver, retryOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: retry: %w", ErrInvalidConfig, err)
+	}
+	hedgingMiddleware, err := hedging.New(
+		config.Resolver,
+		config.HedgingOptions...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: hedging: %w", ErrInvalidConfig, err)
+	}
+	attempts := dispatchAttempts(
+		config.Resolver,
+		retryMiddleware,
+		hedgingMiddleware,
+	)
+	source := strings.TrimSpace(config.Source)
+	if source == "" {
+		source = defaultSource
+	}
+	entries := []middleware.Entry{
+		{
+			Name:       "policy-snapshot",
+			Source:     source,
+			Middleware: snapshotPolicy(config.Resolver),
+		},
+	}
+	if admissionController != nil {
+		entries = append(entries, middleware.Entry{
+			Name:       "admission",
+			Source:     source,
+			Middleware: admissionController.Middleware(),
+		})
+	}
+	entries = append(entries,
+		middleware.Entry{
+			Name:       "timeout",
+			Source:     source,
+			Middleware: callTimeout,
+		},
+		middleware.Entry{
+			Name:       "dependency-bulkhead",
+			Source:     source,
+			Middleware: dependencyBulkhead,
+		},
+		middleware.Entry{
+			Name:       "service-breaker",
+			Source:     source,
+			Middleware: serviceBreaker,
+		},
+		middleware.Entry{
+			Name:       "attempts",
+			Source:     source,
+			Middleware: attempts,
+		},
+	)
+	bundle, err := middleware.NewBundle(entries...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: middleware bundle: %w", ErrInvalidConfig, err)
+	}
+	return &Runtime{
+		bundle:       bundle,
+		admission:    admissionController,
+		breakers:     breakers,
+		bulkheads:    bulkheads,
+		retryBudget:  budget,
+		instanceTier: instanceTier,
+	}, nil
+}
+
+// Middleware returns the immutable client middleware bundle.
+func (r *Runtime) Middleware() *middleware.Bundle {
+	if r == nil {
+		return nil
+	}
+	return r.bundle
+}
+
+// InstanceObserver returns the passive per-instance health observer.
+//
+// It returns nil only when DisableInstanceOutlier was explicitly configured.
+func (r *Runtime) InstanceObserver() selector.Observer {
+	if r == nil || r.instanceTier == nil {
+		return nil
+	}
+	return r.instanceTier
+}
+
+// SelectorOptions returns the options needed to attach instance health to a
+// Keelith Selector. The result is empty when the instance tier is disabled.
+func (r *Runtime) SelectorOptions() []selector.Option {
+	observer := r.InstanceObserver()
+	if observer == nil {
+		return nil
+	}
+	return []selector.Option{selector.WithObserver(observer)}
+}
+
+// Describe returns bounded state for middleware order, service breakers,
+// retry amplification, and instance health.
+func (r *Runtime) Describe() Description {
+	if r == nil {
+		return Description{}
+	}
+	description := Description{
+		Middleware: r.bundle.Describe(),
+		Breakers:   r.breakers.Describe(),
+		Bulkheads:  r.bulkheads.Describe(),
+		Retry:      r.retryBudget.Describe(),
+	}
+	if r.admission != nil {
+		description.Admission = r.admission.Describe()
+	}
+	if r.instanceTier != nil {
+		description.Instances = r.instanceTier.Status()
+	}
+	return description
+}
+
+func newInstanceTier(config Config) (*outlier.Detector, error) {
+	if config.DisableInstanceOutlier {
+		return nil, nil
+	}
+	instanceConfig := config.InstanceOutlier
+	if instanceConfig.ConsecutiveFailures == 0 {
+		instanceConfig.ConsecutiveFailures = defaultOutlierFailures
+	}
+	if instanceConfig.EjectionTime == 0 {
+		instanceConfig.EjectionTime = defaultOutlierEjection
+	}
+	detector, err := outlier.New(instanceConfig)
+	if err != nil {
+		return nil, fmt.Errorf("%w: instance outlier: %w", ErrInvalidConfig, err)
+	}
+	return detector, nil
+}
+
+func snapshotPolicy(resolver policy.Resolver) middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return invalidHandler("policy snapshot next handler is nil")
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidConfig)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			resolved := resolver.Resolve(target)
+			if err := policy.Validate(resolved); err != nil {
+				return nil, err
+			}
+			return next(policy.WithResolved(ctx, target, resolved), request)
+		}
+	}
+}
+
+func dispatchAttempts(resolver policy.Resolver, retryMiddleware middleware.Middleware, hedgingMiddleware middleware.Middleware) middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return invalidHandler("attempt dispatcher next handler is nil")
+		}
+		retryHandler := retryMiddleware(next)
+		hedgingHandler := hedgingMiddleware(next)
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidConfig)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			resolved := policy.Resolve(ctx, resolver, target)
+			switch {
+			case resolved.Retry.Enabled && resolved.Hedging.Enabled:
+				return nil, fmt.Errorf("%w: retry and hedging are both enabled", policy.ErrInvalidPolicy)
+			case resolved.Retry.Enabled:
+				return retryHandler(ctx, request)
+			case resolved.Hedging.Enabled:
+				return hedgingHandler(ctx, request)
+			default:
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+		}
+	}
+}
+
+func invalidHandler(message string) middleware.Handler {
+	return func(context.Context, any) (any, error) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidConfig, message)
+	}
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/failure/failure.go
+++ b/governance/failure/failure.go
@@ -1,0 +1,93 @@
+// Package failure classifies transport-neutral invocation failures.
+package failure
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	kerrors "github.com/keelab/keelith/errors"
+)
+
+// Kind is a stable, low-cardinality failure class.
+type Kind string
+
+const (
+	// None represents a successful invocation.
+	None Kind = "none"
+	// Transport represents a network or adapter failure.
+	Transport Kind = "transport"
+	// Timeout represents a deadline or timeout failure.
+	Timeout Kind = "timeout"
+	// Business represents a framework application error.
+	Business Kind = "business"
+	// Canceled represents explicit context cancellation.
+	Canceled Kind = "canceled"
+	// Unknown represents a failure without a more specific classification.
+	Unknown Kind = "unknown"
+)
+
+type transportError struct {
+	cause error
+}
+
+func (failure *transportError) Error() string {
+	return failure.cause.Error()
+}
+
+func (failure *transportError) Unwrap() error {
+	return failure.cause
+}
+
+// MarkTransport marks an adapter/client failure as transport-level without
+// changing its errors.Is/errors.As chain.
+func MarkTransport(err error) error {
+	if err == nil {
+		return nil
+	}
+	var marked *transportError
+	if errors.As(err, &marked) {
+		return err
+	}
+	return &transportError{cause: err}
+}
+
+// Classify maps err to a transport-neutral failure class.
+func Classify(err error) Kind {
+	if err == nil {
+		return None
+	}
+	var marked *transportError
+	if errors.As(err, &marked) {
+		return Transport
+	}
+	if errors.Is(err, context.Canceled) {
+		return Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return Timeout
+	}
+	var application *kerrors.Error
+	if errors.As(err, &application) {
+		return Business
+	}
+	var network net.Error
+	if errors.As(err, &network) {
+		if network.Timeout() {
+			return Timeout
+		}
+		return Transport
+	}
+	return Unknown
+}
+
+// Retryable reports whether a failure may be repeated when the root context
+// is still active and the method policy permits it.
+func Retryable(err error) bool {
+	switch Classify(err) {
+	case Transport, Timeout:
+		return true
+	default:
+		return false
+	}
+}

--- a/governance/fallback/fallback.go
+++ b/governance/fallback/fallback.go
@@ -1,0 +1,192 @@
+// Package fallback provides explicit, transport-neutral degraded responses.
+package fallback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+var (
+	// ErrInvalidOption reports an invalid fallback dependency or option.
+	ErrInvalidOption = errors.New("fallback: invalid option")
+	// ErrMissingOperation reports a failed call without an operation identity.
+	ErrMissingOperation = errors.New("fallback: operation is missing")
+)
+
+// Replacement is an explicitly resolved degraded value.
+type Replacement struct {
+	Value any
+	Found bool
+	Stale bool
+}
+
+// Response makes degradation visible to application and transport adapters.
+//
+// Cause is intentionally exposed through a method instead of an exported
+// field so generic encoders cannot accidentally serialize internal errors.
+type Response struct {
+	Value    any
+	Degraded bool
+	Stale    bool
+
+	cause error
+}
+
+// Cause returns the original invocation error.
+func (response Response) Cause() error {
+	return response.cause
+}
+
+// Resolver obtains an operation-specific replacement after a failed call.
+type Resolver interface {
+	Resolve(context.Context, operation.Operation, any, error) (Replacement, error)
+}
+
+// ResolverFunc adapts a function to Resolver.
+type ResolverFunc func(context.Context, operation.Operation, any, error) (Replacement, error)
+
+// Resolve implements Resolver.
+func (f ResolverFunc) Resolve(ctx context.Context, target operation.Operation, request any, cause error) (Replacement, error) {
+	return f(ctx, target, request, cause)
+}
+
+// Classifier decides which invocation failures may use a fallback.
+type Classifier func(error) bool
+
+// Event is a low-cardinality fallback decision for instrumentation.
+type Event struct {
+	Operation operation.Operation
+	Stale     bool
+	Cause     error
+}
+
+// Recorder observes successful fallback decisions.
+type Recorder interface {
+	Record(Event)
+}
+
+// Option configures fallback Middleware.
+type Option interface {
+	apply(*settings) error
+}
+
+type optionFunc func(*settings) error
+
+func (function optionFunc) apply(settings *settings) error {
+	return function(settings)
+}
+
+type settings struct {
+	classify Classifier
+	recorder Recorder
+}
+
+// WithClassifier replaces the default transport/timeout classifier.
+func WithClassifier(classifier Classifier) Option {
+	return optionFunc(func(settings *settings) error {
+		if classifier == nil {
+			return fmt.Errorf("classifier is nil")
+		}
+		settings.classify = classifier
+		return nil
+	})
+}
+
+// WithRecorder observes successful degraded responses.
+func WithRecorder(recorder Recorder) Option {
+	return optionFunc(func(settings *settings) error {
+		if isNil(recorder) {
+			return fmt.Errorf("recorder is nil")
+		}
+		settings.recorder = recorder
+		return nil
+	})
+}
+
+// New creates explicit fallback Middleware.
+func New(resolver Resolver, options ...Option) (middleware.Middleware, error) {
+	if isNil(resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidOption)
+	}
+	settings := settings{classify: failure.Retryable}
+	for index, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	return middlewareFor(resolver, settings), nil
+}
+
+func middlewareFor(resolver Resolver, settings settings) middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			response, err := next(ctx, request)
+			if err == nil || !settings.classify(err) {
+				return response, err
+			}
+			if errors.Is(err, context.Canceled) {
+				return response, err
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return response, errors.Join(err, ErrMissingOperation)
+			}
+			replacement, resolveErr := resolver.Resolve(
+				ctx,
+				target,
+				request,
+				err,
+			)
+			if resolveErr != nil {
+				return response, errors.Join(err, fmt.Errorf("fallback resolver: %w", resolveErr))
+			}
+			if !replacement.Found {
+				return response, err
+			}
+			if settings.recorder != nil {
+				settings.recorder.Record(Event{
+					Operation: target,
+					Stale:     replacement.Stale,
+					Cause:     err,
+				})
+			}
+			return Response{
+				Value:    replacement.Value,
+				Degraded: true,
+				Stale:    replacement.Stale,
+				cause:    err,
+			}, nil
+		}
+	}
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/fallback/invoke.go
+++ b/governance/fallback/invoke.go
@@ -1,0 +1,137 @@
+package fallback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+var (
+	// ErrInvalidInvocation reports an invalid typed fallback invocation.
+	ErrInvalidInvocation = errors.New("fallback: invalid invocation")
+	// ErrInvalidReplacement reports a resolver value that cannot safely be
+	// returned as the invocation's declared response type.
+	ErrInvalidReplacement = errors.New("fallback: invalid replacement")
+)
+
+// Invocation is one already-governed unary dependency call.
+//
+// The supplied context carries target as its operation identity. Implementations
+// should pass it to the underlying HTTP, gRPC, Hertz, or Kitex client unchanged.
+type Invocation[T any] func(context.Context) (T, error)
+
+// Result makes a normal or degraded typed response explicit to application
+// code. Cause is deliberately private so transport encoders cannot serialize an
+// internal dependency error by accident.
+type Result[T any] struct {
+	Value    T
+	Degraded bool
+	Stale    bool
+
+	cause error
+}
+
+// Cause returns the dependency failure replaced by a degraded value. It is nil
+// for a normal response.
+func (result Result[T]) Cause() error {
+	return result.cause
+}
+
+// Runtime owns one concurrency-safe fallback policy. The configured Resolver
+// and Recorder must be safe for concurrent use by dependency calls.
+//
+// Runtime intentionally stays outside client.Outbound: fallback is a typed,
+// application-visible boundary after the final governed attempt, not a
+// transparent transport middleware that can manufacture an empty gRPC reply.
+type Runtime struct {
+	middleware middleware.Middleware
+}
+
+// NewRuntime validates and compiles a reusable typed fallback runtime.
+func NewRuntime(resolver Resolver, options ...Option) (*Runtime, error) {
+	fallbackMiddleware, err := New(resolver, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &Runtime{middleware: fallbackMiddleware}, nil
+}
+
+// Invoke runs one unary call and returns a type-safe, degradation-aware result.
+//
+// The invocation should already use Keelith's managed client so timeout,
+// retry/hedging, breaker, bulkhead, and routing complete before fallback is
+// considered. Business failures and cancellation are preserved. Resolver type
+// mismatches and nil reference replacements fail closed while retaining the
+// original dependency error in the returned error chain.
+func Invoke[T any](ctx context.Context, runtime *Runtime, target operation.Operation, request any, invocation Invocation[T]) (Result[T], error) {
+	if ctx == nil {
+		return Result[T]{}, fmt.Errorf("%w: context is nil", ErrInvalidInvocation)
+	}
+	if runtime == nil || runtime.middleware == nil {
+		return Result[T]{}, fmt.Errorf("%w: runtime is nil", ErrInvalidInvocation)
+	}
+	if target.Transport() == "" || target.Service() == "" ||
+		target.Method() == "" || target.Kind() != operation.KindUnary {
+		return Result[T]{}, fmt.Errorf("%w: target must be a valid unary operation", ErrInvalidInvocation)
+	}
+	if invocation == nil {
+		return Result[T]{}, fmt.Errorf("%w: invocation is nil", ErrInvalidInvocation)
+	}
+
+	handler := runtime.middleware(func(callContext context.Context, _ any) (any, error) {
+		return invocation(callContext)
+	})
+	response, invocationErr := handler(
+		operation.WithContext(ctx, target),
+		request,
+	)
+	result, decodeErr := decodeResult[T](response)
+	if decodeErr != nil {
+		if invocationErr != nil {
+			return result, errors.Join(invocationErr, decodeErr)
+		}
+		return result, decodeErr
+	}
+	return result, invocationErr
+}
+
+func decodeResult[T any](response any) (Result[T], error) {
+	if response == nil {
+		return Result[T]{}, nil
+	}
+	degraded, ok := response.(Response)
+	if !ok {
+		value, valid := response.(T)
+		if !valid {
+			return Result[T]{}, fmt.Errorf("%w: invocation returned %T", ErrInvalidInvocation, response)
+		}
+		return Result[T]{Value: value}, nil
+	}
+
+	result := Result[T]{
+		Degraded: degraded.Degraded,
+		Stale:    degraded.Stale,
+		cause:    degraded.Cause(),
+	}
+	if !degraded.Degraded || degraded.Cause() == nil {
+		return result, fmt.Errorf("%w: degraded response is incomplete", ErrInvalidReplacement)
+	}
+	if isNil(degraded.Value) {
+		return result, errors.Join(
+			degraded.Cause(),
+			fmt.Errorf("%w: replacement is nil", ErrInvalidReplacement),
+		)
+	}
+	value, valid := degraded.Value.(T)
+	if !valid {
+		return result, errors.Join(
+			degraded.Cause(),
+			fmt.Errorf("%w: replacement type %T does not match invocation result", ErrInvalidReplacement, degraded.Value),
+		)
+	}
+	result.Value = value
+	return result, nil
+}

--- a/governance/hedging/middleware.go
+++ b/governance/hedging/middleware.go
@@ -1,0 +1,194 @@
+// Package hedging provides bounded parallel attempts for idempotent methods.
+package hedging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/keelab/keelith/governance/attempt"
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+var (
+	// ErrInvalidOption reports an invalid hedging dependency or option.
+	ErrInvalidOption = errors.New("hedging: invalid option")
+	// ErrMissingOperation reports a call without a stable Operation.
+	ErrMissingOperation = errors.New("hedging: operation is missing")
+)
+
+// Clock supplies hedge-delay timer channels.
+type Clock interface {
+	After(time.Duration) <-chan time.Time
+}
+
+// Option configures hedging Middleware.
+type Option interface {
+	apply(*options) error
+}
+
+type optionFunc func(*options) error
+
+func (function optionFunc) apply(options *options) error {
+	return function(options)
+}
+
+type options struct {
+	clock Clock
+}
+
+// WithClock replaces the production timer source.
+func WithClock(clock Clock) Option {
+	return optionFunc(func(options *options) error {
+		if isNil(clock) {
+			return fmt.Errorf("clock is nil")
+		}
+		options.clock = clock
+		return nil
+	})
+}
+
+// New creates policy-resolved hedging Middleware.
+func New(resolver policy.Resolver, optionList ...Option) (middleware.Middleware, error) {
+	if isNil(resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidOption)
+	}
+	settings := options{clock: realClock{}}
+
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	return middlewareFor(resolver, settings), nil
+}
+
+func middlewareFor(resolver policy.Resolver, settings options) middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			if isStreaming(target.Kind()) {
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+			resolved := policy.Resolve(ctx, resolver, target).Hedging
+			if attempt.IsProbe(ctx) {
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+			if !resolved.Enabled ||
+				!resolved.Idempotent ||
+				resolved.MaxAttempts < 2 {
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+			if resolved.Delay <= 0 || resolved.MaxAttempts > 5 {
+				return nil, fmt.Errorf("%w: resolved hedging policy is invalid", policy.ErrInvalidPolicy)
+			}
+			return invoke(ctx, request, next, resolved, settings.clock)
+		}
+	}
+}
+
+func isStreaming(kind operation.Kind) bool {
+	switch kind {
+	case operation.KindClientStream,
+		operation.KindServerStream,
+		operation.KindBidiStream:
+		return true
+	default:
+		return false
+	}
+}
+
+type result struct {
+	response any
+	err      error
+}
+
+func invoke(ctx context.Context, request any, next middleware.Handler, resolved policy.HedgingPolicy, clock Clock) (any, error) {
+	callContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	results := make(chan result, resolved.MaxAttempts)
+	launched := 0
+	active := 0
+	launch := func() {
+		launched++
+		active++
+		number := launched
+		go func() {
+			response, err := next(
+				attempt.WithContext(callContext, number),
+				request,
+			)
+			results <- result{response: response, err: err}
+		}()
+	}
+	launch()
+	timer := clock.After(resolved.Delay)
+	failures := make([]error, 0, resolved.MaxAttempts)
+
+	for active > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, context.Cause(ctx)
+		case completed := <-results:
+			active--
+			if completed.err == nil {
+				cancel()
+				return completed.response, nil
+			}
+			if !failure.Retryable(completed.err) {
+				cancel()
+				return completed.response, completed.err
+			}
+			failures = append(failures, completed.err)
+			if active == 0 && launched < resolved.MaxAttempts {
+				launch()
+			}
+			if active == 0 && launched == resolved.MaxAttempts {
+				return nil, errors.Join(failures...)
+			}
+		case <-timer:
+			if launched < resolved.MaxAttempts {
+				launch()
+			}
+			if launched < resolved.MaxAttempts {
+				timer = clock.After(resolved.Delay)
+			} else {
+				timer = nil
+			}
+		}
+	}
+	return nil, errors.Join(failures...)
+}
+
+type realClock struct{}
+
+func (realClock) After(duration time.Duration) <-chan time.Time {
+	return time.After(duration)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	return reflected.Kind() == reflect.Pointer && reflected.IsNil()
+}

--- a/governance/idempotency/ops.go
+++ b/governance/idempotency/ops.go
@@ -1,0 +1,49 @@
+package idempotency
+
+import (
+	"context"
+
+	"github.com/keelab/keelith/ops"
+)
+
+// RuntimeStatus adapts Runtime counters to the value-free Ops catalog.
+func RuntimeStatus(runtime *Runtime) ops.RuntimeStatusProvider {
+	if runtime == nil {
+		return nil
+	}
+	return func(ctx context.Context) (ops.RuntimeStatus, error) {
+		if ctx == nil {
+			return ops.RuntimeStatus{}, ops.ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return ops.RuntimeStatus{}, cause
+		}
+		description := runtime.Describe()
+		degraded := description.BackendErrors > 0 ||
+			description.CompletionErrors > 0 ||
+			description.AbandonErrors > 0 ||
+			description.CodecErrors > 0
+		return ops.RuntimeStatus{
+			State:    "active",
+			Ready:    true,
+			Degraded: degraded,
+			Counters: []ops.RuntimeCounter{
+				{Name: "abandon_errors", Value: description.AbandonErrors},
+				{Name: "acquired", Value: description.Acquired},
+				{Name: "backend_errors", Value: description.BackendErrors},
+				{Name: "codec_errors", Value: description.CodecErrors},
+				{Name: "completion_errors", Value: description.CompletionErrors},
+				{Name: "conflicts", Value: description.Conflicts},
+				{Name: "handler_failures", Value: description.HandlerFailures},
+				{Name: "in_progress", Value: description.InProgress},
+				{Name: "replayed", Value: description.Replayed},
+			},
+			Capabilities: []string{
+				"bounded-result-replay",
+				"fail-closed",
+				"fenced-owner",
+				"operation-scoped",
+			},
+		}, nil
+	}
+}

--- a/governance/idempotency/proto.go
+++ b/governance/idempotency/proto.go
@@ -1,0 +1,107 @@
+package idempotency
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/operation"
+	"google.golang.org/protobuf/proto"
+)
+
+// DefaultMetadataKey is the standard metadata key carrying idempotency keys.
+const DefaultMetadataKey = "idempotency-key"
+
+// ProtoRequest derives a key from inbound Metadata and a deterministic
+// fingerprint from one protobuf request.
+func ProtoRequest(metadataKey string) (RequestFunc, error) {
+	metadataKey = strings.ToLower(strings.TrimSpace(metadataKey))
+	if metadataKey == "" {
+		metadataKey = DefaultMetadataKey
+	}
+	if !validMetadataKey(metadataKey) {
+		return nil, fmt.Errorf("%w: metadata key", ErrInvalidConfig)
+	}
+	return func(ctx context.Context, _ operation.Operation, request any) (RequestIdentity, error) {
+		if ctx == nil {
+			return RequestIdentity{}, ErrInvalidRequest
+		}
+		inbound, ok := metadata.Inbound(ctx)
+		if !ok {
+			return RequestIdentity{}, ErrInvalidRequest
+		}
+		values := inbound.Values(metadataKey)
+		if len(values) != 1 {
+			return RequestIdentity{}, ErrInvalidRequest
+		}
+		message, ok := request.(proto.Message)
+		if !ok || nilProto(message) {
+			return RequestIdentity{}, ErrInvalidRequest
+		}
+		encoded, err := (proto.MarshalOptions{Deterministic: true}).Marshal(message)
+		if err != nil {
+			return RequestIdentity{}, ErrInvalidRequest
+		}
+		identity := RequestIdentity{
+			Key:         values[0],
+			Fingerprint: Fingerprint(encoded),
+		}
+		if err := validateIdentity(identity); err != nil {
+			return RequestIdentity{}, err
+		}
+		return identity, nil
+	}, nil
+}
+
+// NewProtoCodec constructs an Operation-specific deterministic result codec.
+func NewProtoCodec(factory func() proto.Message) (Codec, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("%w: proto factory is nil", ErrInvalidConfig)
+	}
+	probe := factory()
+	if nilProto(probe) {
+		return nil, fmt.Errorf("%w: proto factory returned nil", ErrInvalidConfig)
+	}
+	return CodecFuncs{
+		EncodeFunc: func(value any) ([]byte, error) {
+			message, ok := value.(proto.Message)
+			if !ok || nilProto(message) {
+				return nil, fmt.Errorf("%w: result is not protobuf", ErrResultInvalid)
+			}
+			return (proto.MarshalOptions{Deterministic: true}).Marshal(message)
+		},
+		DecodeFunc: func(encoded []byte) (any, error) {
+			message := factory()
+			if nilProto(message) {
+				return nil, fmt.Errorf("%w: proto factory returned nil", ErrResultInvalid)
+			}
+			if err := proto.Unmarshal(encoded, message); err != nil {
+				return nil, fmt.Errorf("%w: protobuf decode", ErrResultInvalid)
+			}
+			return message, nil
+		},
+	}, nil
+}
+
+func nilProto(message proto.Message) bool {
+	if message == nil {
+		return true
+	}
+	value := reflect.ValueOf(message)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}
+
+func validMetadataKey(value string) bool {
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z':
+		case character >= '0' && character <= '9':
+		case character == '-' || character == '_' || character == '.':
+		default:
+			return false
+		}
+	}
+	return value != ""
+}

--- a/governance/idempotency/runtime.go
+++ b/governance/idempotency/runtime.go
@@ -1,0 +1,332 @@
+package idempotency
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/url"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// Config constructs one instance-scoped idempotency Runtime.
+type Config struct {
+	Store          Store
+	Resolver       Resolver
+	BackendTimeout time.Duration
+	MaxResultBytes int
+	Random         io.Reader
+}
+
+// Description is a value-free, low-cardinality operational snapshot.
+type Description struct {
+	Acquired         uint64
+	Replayed         uint64
+	InProgress       uint64
+	Conflicts        uint64
+	HandlerFailures  uint64
+	BackendErrors    uint64
+	CompletionErrors uint64
+	AbandonErrors    uint64
+	CodecErrors      uint64
+}
+
+// Runtime owns middleware state but not Store lifecycle.
+type Runtime struct {
+	store          Store
+	resolver       Resolver
+	backendTimeout time.Duration
+	maxResultBytes int
+	random         io.Reader
+
+	mu               sync.Mutex
+	acquired         uint64
+	replayed         uint64
+	inProgress       uint64
+	conflicts        uint64
+	handlerFailures  uint64
+	backendErrors    uint64
+	completionErrors uint64
+	abandonErrors    uint64
+	codecErrors      uint64
+}
+
+// New constructs a dormant Runtime.
+func New(config Config) (*Runtime, error) {
+	if isNil(config.Store) || isNil(config.Resolver) {
+		return nil, fmt.Errorf("%w: store and resolver are required", ErrInvalidConfig)
+	}
+	backendTimeout := config.BackendTimeout
+	if backendTimeout == 0 {
+		backendTimeout = defaultBackendTimeout
+	}
+	if backendTimeout <= 0 || backendTimeout > maximumBackendTimeout {
+		return nil, fmt.Errorf("%w: backend timeout", ErrInvalidConfig)
+	}
+	maxResultBytes := config.MaxResultBytes
+	if maxResultBytes == 0 {
+		maxResultBytes = defaultMaxResultBytes
+	}
+	if maxResultBytes <= 0 || maxResultBytes > defaultMaxResultBytes {
+		return nil, fmt.Errorf("%w: max result bytes", ErrInvalidConfig)
+	}
+	random := config.Random
+	if random == nil {
+		random = rand.Reader
+	}
+	return &Runtime{
+		store:          config.Store,
+		resolver:       config.Resolver,
+		backendTimeout: backendTimeout,
+		maxResultBytes: maxResultBytes,
+		random:         random,
+	}, nil
+}
+
+// Middleware returns the transport-neutral unary middleware.
+func (r *Runtime) Middleware() middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if r == nil || next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: runtime or handler is nil", ErrInvalidConfig)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			return r.invoke(ctx, request, next)
+		}
+	}
+}
+
+func (r *Runtime) invoke(ctx context.Context, request any, next middleware.Handler) (any, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: context is nil", ErrInvalidConfig)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	target, ok := operation.FromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: operation is missing", ErrInvalidConfig)
+	}
+	rule, enabled := r.resolver.Resolve(target)
+	if !enabled {
+		return next(ctx, request)
+	}
+	if target.Kind() != operation.KindUnary {
+		return nil, fmt.Errorf("%w: operation must be unary", ErrInvalidConfig)
+	}
+	if err := ValidateRule(rule); err != nil {
+		return nil, err
+	}
+	identity, err := rule.Request(ctx, target, request)
+	if err != nil {
+		return nil, ErrInvalidRequest
+	}
+	if err := validateIdentity(identity); err != nil {
+		return nil, err
+	}
+	owner, err := r.owner()
+	if err != nil {
+		return nil, kerrors.Wrap(err, ErrUnavailable.Code(), ErrUnavailable.Reason(), ErrUnavailable.Message())
+	}
+	claimRequest := ClaimRequest{
+		Operation:     storageOperation(target),
+		Namespace:     rule.Namespace,
+		Key:           identity.Key,
+		Fingerprint:   identity.Fingerprint,
+		Owner:         owner,
+		ProcessingTTL: rule.ProcessingTTL,
+	}
+	claimContext, cancel := context.WithTimeout(ctx, r.backendTimeout)
+	claim, err := r.store.Claim(claimContext, claimRequest)
+	cancel()
+	if err != nil {
+		r.recordBackendError()
+		return nil, unavailable(err)
+	}
+	if err := validateClaim(claim, r.maxResultBytes); err != nil {
+		r.recordBackendError()
+		return nil, unavailable(err)
+	}
+	lease := Lease{
+		Operation:   claimRequest.Operation,
+		Namespace:   claimRequest.Namespace,
+		Key:         claimRequest.Key,
+		Fingerprint: claimRequest.Fingerprint,
+		Owner:       claimRequest.Owner,
+	}
+	switch claim.State {
+	case ClaimAcquired:
+		return r.execute(ctx, request, next, rule, lease)
+	case ClaimReplayed:
+		response, decodeErr := rule.Codec.Decode(append([]byte(nil), claim.Result...))
+		if decodeErr != nil {
+			r.recordCodecError()
+			return nil, resultInvalid(decodeErr)
+		}
+		r.mu.Lock()
+		r.replayed++
+		r.mu.Unlock()
+		return response, nil
+	case ClaimInProgress:
+		r.mu.Lock()
+		r.inProgress++
+		r.mu.Unlock()
+		retryMilliseconds := claim.RetryAfter.Milliseconds()
+		if retryMilliseconds < 1 {
+			retryMilliseconds = 1
+		}
+		return nil, ErrInProgress.Clone(kerrors.WithMetadata(map[string]string{
+			"retry-after-ms": strconv.FormatInt(retryMilliseconds, 10),
+		}))
+	case ClaimConflict:
+		r.mu.Lock()
+		r.conflicts++
+		r.mu.Unlock()
+		return nil, ErrConflict
+	default:
+		r.recordBackendError()
+		return nil, unavailable(ErrInvalidDecision)
+	}
+}
+
+// storageOperation deliberately omits transport so HTTP and gRPC adapters for
+// the same logical unary method compete for one claim and replay one result.
+func storageOperation(target operation.Operation) string {
+	return url.PathEscape(target.Service()) + "/" +
+		url.PathEscape(target.Method()) + "/" +
+		url.PathEscape(string(target.Kind()))
+}
+
+func (r *Runtime) execute(ctx context.Context, request any, next middleware.Handler, rule Rule, lease Lease) (any, error) {
+	r.mu.Lock()
+	r.acquired++
+	r.mu.Unlock()
+	response, handlerErr := next(ctx, request)
+	if handlerErr != nil {
+		r.mu.Lock()
+		r.handlerFailures++
+		r.mu.Unlock()
+		r.abandon(ctx, lease)
+		return nil, handlerErr
+	}
+	encoded, err := rule.Codec.Encode(response)
+	if err != nil || len(encoded) > r.maxResultBytes {
+		r.recordCodecError()
+		r.abandon(ctx, lease)
+		if err == nil {
+			err = fmt.Errorf("result has %d bytes", len(encoded))
+		}
+		return nil, resultInvalid(err)
+	}
+	completion := Completion{
+		Lease:     lease,
+		Result:    append([]byte(nil), encoded...),
+		ResultTTL: rule.ResultTTL,
+	}
+	completeContext, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		r.backendTimeout,
+	)
+	err = r.store.Complete(completeContext, completion)
+	cancel()
+	if err != nil {
+		r.mu.Lock()
+		r.completionErrors++
+		r.mu.Unlock()
+		return nil, unavailable(err)
+	}
+	return response, nil
+}
+
+func (r *Runtime) abandon(ctx context.Context, lease Lease) {
+	abandonContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.backendTimeout)
+	err := r.store.Abandon(abandonContext, lease)
+	cancel()
+	if err == nil {
+		return
+	}
+	r.mu.Lock()
+	r.abandonErrors++
+	r.mu.Unlock()
+}
+
+func (r *Runtime) owner() (string, error) {
+	content := make([]byte, 16)
+	if _, err := io.ReadFull(r.random, content); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(content), nil
+}
+
+// Describe returns aggregate state without request identities or results.
+func (r *Runtime) Describe() Description {
+	if r == nil {
+		return Description{}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return Description{
+		Acquired:         r.acquired,
+		Replayed:         r.replayed,
+		InProgress:       r.inProgress,
+		Conflicts:        r.conflicts,
+		HandlerFailures:  r.handlerFailures,
+		BackendErrors:    r.backendErrors,
+		CompletionErrors: r.completionErrors,
+		AbandonErrors:    r.abandonErrors,
+		CodecErrors:      r.codecErrors,
+	}
+}
+
+func (r *Runtime) recordBackendError() {
+	r.mu.Lock()
+	r.backendErrors++
+	r.mu.Unlock()
+}
+
+func (r *Runtime) recordCodecError() {
+	r.mu.Lock()
+	r.codecErrors++
+	r.mu.Unlock()
+}
+
+func unavailable(cause error) error {
+	return kerrors.Wrap(
+		cause,
+		ErrUnavailable.Code(),
+		ErrUnavailable.Reason(),
+		ErrUnavailable.Message(),
+	)
+}
+
+func resultInvalid(cause error) error {
+	return kerrors.Wrap(
+		cause,
+		ErrResultInvalid.Code(),
+		ErrResultInvalid.Reason(),
+		ErrResultInvalid.Message(),
+	)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/idempotency/static.go
+++ b/governance/idempotency/static.go
@@ -1,0 +1,48 @@
+package idempotency
+
+import (
+	"fmt"
+
+	"github.com/keelab/keelith/operation"
+)
+
+// Registration binds an exact unary Operation to one Rule.
+type Registration struct {
+	Operation operation.Operation
+	Rule      Rule
+}
+
+// StaticResolver is an immutable exact-operation rule table.
+type StaticResolver struct {
+	rules map[string]Rule
+}
+
+// NewStaticResolver validates and snapshots registrations.
+func NewStaticResolver(registrations ...Registration) (*StaticResolver, error) {
+	rules := make(map[string]Rule, len(registrations))
+	for index, registration := range registrations {
+		target := registration.Operation
+		if target.Transport() == "" || target.Service() == "" ||
+			target.Method() == "" || target.Kind() != operation.KindUnary {
+			return nil, fmt.Errorf("%w: registration %d requires a unary operation", ErrInvalidConfig, index)
+		}
+		if err := ValidateRule(registration.Rule); err != nil {
+			return nil, fmt.Errorf("registration %d: %w", index, err)
+		}
+		key := target.PolicyKey()
+		if _, duplicate := rules[key]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate operation %q", ErrInvalidConfig, key)
+		}
+		rules[key] = registration.Rule
+	}
+	return &StaticResolver{rules: rules}, nil
+}
+
+// Resolve returns an exact immutable Rule.
+func (r *StaticResolver) Resolve(target operation.Operation) (Rule, bool) {
+	if r == nil {
+		return Rule{}, false
+	}
+	rule, exists := r.rules[target.PolicyKey()]
+	return rule, exists
+}

--- a/governance/idempotency/types.go
+++ b/governance/idempotency/types.go
@@ -1,0 +1,339 @@
+// Package idempotency provides transport-neutral, operation-scoped request
+// deduplication with fenced ownership and bounded result replay.
+package idempotency
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/operation"
+)
+
+const (
+	defaultBackendTimeout = 100 * time.Millisecond
+	defaultMaxResultBytes = 1024 * 1024
+	maximumBackendTimeout = 5 * time.Second
+	maximumKeyBytes       = 256
+	maximumNamespaceBytes = 128
+	maximumOwnerBytes     = 64
+	minimumProcessingTTL  = time.Second
+	maximumProcessingTTL  = 15 * time.Minute
+	minimumResultTTL      = time.Minute
+	maximumResultTTL      = 24 * time.Hour
+)
+
+var (
+	// ErrInvalidConfig reports an incomplete runtime, resolver, rule, or codec.
+	ErrInvalidConfig = errors.New("idempotency: invalid config")
+	// ErrInvalidRequest reports an absent or unsafe key/fingerprint.
+	ErrInvalidRequest = kerrors.New(
+		400,
+		"IDEMPOTENCY_KEY_INVALID",
+		"idempotency identity is invalid",
+	)
+	// ErrConflict reports reuse of a key for a different request fingerprint.
+	ErrConflict = kerrors.New(
+		409,
+		"IDEMPOTENCY_KEY_CONFLICT",
+		"idempotency key was already used for another request",
+	)
+	// ErrInProgress reports another active owner for the same request.
+	ErrInProgress = kerrors.New(
+		409,
+		"IDEMPOTENCY_IN_PROGRESS",
+		"idempotent request is already in progress",
+	)
+	// ErrUnavailable reports a fail-closed Store failure.
+	ErrUnavailable = kerrors.New(
+		503,
+		"IDEMPOTENCY_UNAVAILABLE",
+		"idempotency service is unavailable",
+	)
+	// ErrResultInvalid reports an unsafe, oversized, or undecodable replay.
+	ErrResultInvalid = kerrors.New(
+		500,
+		"IDEMPOTENCY_RESULT_INVALID",
+		"idempotency result could not be recorded or replayed",
+	)
+	// ErrInvalidDecision reports a malformed Store response.
+	ErrInvalidDecision = errors.New("idempotency: invalid store decision")
+	// ErrStaleOwner reports a Complete or Abandon after ownership changed.
+	ErrStaleOwner = errors.New("idempotency: stale owner")
+)
+
+// ClaimState is one atomic Store decision.
+type ClaimState string
+
+const (
+	// ClaimAcquired grants the caller ownership of a new request.
+	ClaimAcquired ClaimState = "acquired"
+	// ClaimInProgress reports a request currently owned by another caller.
+	ClaimInProgress ClaimState = "in-progress"
+	// ClaimReplayed returns a previously completed result.
+	ClaimReplayed ClaimState = "replayed"
+	// ClaimConflict reports an incompatible reuse of an idempotency key.
+	ClaimConflict ClaimState = "conflict"
+)
+
+// RequestIdentity binds a caller-selected key to exact request content.
+type RequestIdentity struct {
+	Key         string
+	Fingerprint string
+}
+
+// RequestFunc derives one bounded identity from transport-neutral facts.
+type RequestFunc func(
+	context.Context,
+	operation.Operation,
+	any,
+) (RequestIdentity, error)
+
+// Codec encodes and reconstructs one Operation-specific result type.
+type Codec interface {
+	Encode(any) ([]byte, error)
+	Decode([]byte) (any, error)
+}
+
+// CodecFuncs adapts functions to Codec.
+type CodecFuncs struct {
+	EncodeFunc func(any) ([]byte, error)
+	DecodeFunc func([]byte) (any, error)
+}
+
+// Encode implements Codec.
+func (codec CodecFuncs) Encode(value any) ([]byte, error) {
+	if codec.EncodeFunc == nil {
+		return nil, fmt.Errorf("%w: encode function is nil", ErrInvalidConfig)
+	}
+	return codec.EncodeFunc(value)
+}
+
+// Decode implements Codec.
+func (codec CodecFuncs) Decode(encoded []byte) (any, error) {
+	if codec.DecodeFunc == nil {
+		return nil, fmt.Errorf("%w: decode function is nil", ErrInvalidConfig)
+	}
+	return codec.DecodeFunc(encoded)
+}
+
+// Rule is the complete contract for one explicitly idempotent Operation.
+type Rule struct {
+	Namespace     string
+	ProcessingTTL time.Duration
+	ResultTTL     time.Duration
+	Request       RequestFunc
+	Codec         Codec
+}
+
+// Resolver returns an exact Rule for a unary Operation.
+type Resolver interface {
+	Resolve(operation.Operation) (Rule, bool)
+}
+
+// ClaimRequest attempts to own one request while its Handler executes.
+type ClaimRequest struct {
+	Operation     string
+	Namespace     string
+	Key           string
+	Fingerprint   string
+	Owner         string
+	ProcessingTTL time.Duration
+}
+
+// Lease is the complete fence required to mutate a processing claim.
+type Lease struct {
+	Operation   string
+	Namespace   string
+	Key         string
+	Fingerprint string
+	Owner       string
+}
+
+// Claim is an atomic Store decision. Result is set only for ClaimReplayed.
+type Claim struct {
+	State      ClaimState
+	Result     []byte
+	RetryAfter time.Duration
+}
+
+// Completion atomically publishes a successful result for one owner.
+type Completion struct {
+	Lease     Lease
+	Result    []byte
+	ResultTTL time.Duration
+}
+
+// Store provides atomic claim, fenced completion, and fenced abandon.
+type Store interface {
+	Claim(context.Context, ClaimRequest) (Claim, error)
+	Complete(context.Context, Completion) error
+	Abandon(context.Context, Lease) error
+}
+
+// Fingerprint returns a lowercase SHA-256 identity for deterministic bytes.
+func Fingerprint(content []byte) string {
+	digest := sha256.Sum256(content)
+	return hex.EncodeToString(digest[:])
+}
+
+// ValidateRule validates construction-time Rule bounds.
+func ValidateRule(rule Rule) error {
+	if !validNamespace(rule.Namespace) {
+		return fmt.Errorf("%w: namespace", ErrInvalidConfig)
+	}
+	if rule.ProcessingTTL < minimumProcessingTTL ||
+		rule.ProcessingTTL > maximumProcessingTTL ||
+		rule.ResultTTL < minimumResultTTL ||
+		rule.ResultTTL > maximumResultTTL {
+		return fmt.Errorf("%w: rule TTL", ErrInvalidConfig)
+	}
+	if rule.Request == nil || isNil(rule.Codec) {
+		return fmt.Errorf("%w: request and codec are required", ErrInvalidConfig)
+	}
+	return nil
+}
+
+// ValidateClaimRequest validates the complete Store claim input.
+func ValidateClaimRequest(request ClaimRequest) error {
+	if !validOperation(request.Operation) ||
+		!validNamespace(request.Namespace) ||
+		!validKey(request.Key) ||
+		!validFingerprint(request.Fingerprint) ||
+		!validOwner(request.Owner) ||
+		request.ProcessingTTL < minimumProcessingTTL ||
+		request.ProcessingTTL > maximumProcessingTTL {
+		return fmt.Errorf("%w: claim request", ErrInvalidConfig)
+	}
+	return nil
+}
+
+// ValidateLease validates a mutation fence.
+func ValidateLease(lease Lease) error {
+	return ValidateClaimRequest(ClaimRequest{
+		Operation:     lease.Operation,
+		Namespace:     lease.Namespace,
+		Key:           lease.Key,
+		Fingerprint:   lease.Fingerprint,
+		Owner:         lease.Owner,
+		ProcessingTTL: minimumProcessingTTL,
+	})
+}
+
+// ValidateCompletion validates a result publication request.
+func ValidateCompletion(completion Completion, maximumBytes int) error {
+	if err := ValidateLease(completion.Lease); err != nil {
+		return err
+	}
+	if maximumBytes <= 0 || maximumBytes > defaultMaxResultBytes ||
+		len(completion.Result) > maximumBytes ||
+		completion.ResultTTL < minimumResultTTL ||
+		completion.ResultTTL > maximumResultTTL {
+		return fmt.Errorf("%w: completion", ErrInvalidConfig)
+	}
+	return nil
+}
+
+func validateIdentity(identity RequestIdentity) error {
+	if !validKey(identity.Key) || !validFingerprint(identity.Fingerprint) {
+		return ErrInvalidRequest
+	}
+	return nil
+}
+
+func validateClaim(claim Claim, maximumBytes int) error {
+	switch claim.State {
+	case ClaimAcquired, ClaimConflict:
+		if len(claim.Result) != 0 || claim.RetryAfter != 0 {
+			return ErrInvalidDecision
+		}
+	case ClaimInProgress:
+		if len(claim.Result) != 0 || claim.RetryAfter < 0 ||
+			claim.RetryAfter > maximumProcessingTTL {
+			return ErrInvalidDecision
+		}
+	case ClaimReplayed:
+		if len(claim.Result) > maximumBytes || claim.RetryAfter != 0 {
+			return ErrInvalidDecision
+		}
+	default:
+		return ErrInvalidDecision
+	}
+	return nil
+}
+
+func validOperation(value string) bool {
+	return value != "" && len(value) <= 1024 && utf8.ValidString(value) &&
+		strings.TrimSpace(value) == value && !containsControl(value)
+}
+
+func validNamespace(value string) bool {
+	if value == "" || len(value) > maximumNamespaceBytes {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z':
+		case character >= 'A' && character <= 'Z':
+		case character >= '0' && character <= '9':
+		case character == '-' || character == '_' || character == '.' || character == '/':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validKey(value string) bool {
+	return value != "" && len(value) <= maximumKeyBytes &&
+		utf8.ValidString(value) && strings.TrimSpace(value) == value &&
+		!containsControl(value)
+}
+
+func validFingerprint(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= '0' && character <= '9':
+		case character >= 'a' && character <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validOwner(value string) bool {
+	if value == "" || len(value) > maximumOwnerBytes {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z':
+		case character >= 'A' && character <= 'Z':
+		case character >= '0' && character <= '9':
+		case character == '-' || character == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func containsControl(value string) bool {
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return true
+		}
+	}
+	return false
+}

--- a/governance/inbound/runtime.go
+++ b/governance/inbound/runtime.go
@@ -1,0 +1,205 @@
+// Package inbound assembles coherent server-side request governance.
+package inbound
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/keelab/keelith/governance/loadshed"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/governance/ratelimit"
+	ktimeout "github.com/keelab/keelith/governance/timeout"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+const defaultSource = "inbound-runtime"
+
+var (
+	// ErrInvalidConfig reports an incomplete or unsafe inbound runtime.
+	ErrInvalidConfig = errors.New("inbound: invalid config")
+	// ErrMissingOperation reports a server invocation without a stable
+	// transport-neutral Operation.
+	ErrMissingOperation = errors.New("inbound: operation is missing")
+)
+
+// Config defines one application-instance server governance runtime.
+type Config struct {
+	Resolver     policy.Resolver
+	RateLimits   *ratelimit.Pool
+	LoadShedders *loadshed.Pool
+	CPU          loadshed.CPU
+	Source       string
+}
+
+// Stages are the fixed server-governance insertion points.
+//
+// Policy must execute before the other three stages. ServerBundle places
+// authentication and authorization between Policy and RateLimit.
+type Stages struct {
+	Policy       middleware.Middleware
+	RateLimit    middleware.Middleware
+	LoadShedding middleware.Middleware
+	Timeout      middleware.Middleware
+}
+
+// Description is a bounded runtime snapshot. Pool entries include Operation
+// keys for application-owned diagnostics; use the Ops adapter for an
+// HTTP-safe aggregate projection.
+type Description struct {
+	Middleware   []middleware.Description
+	RateLimits   []ratelimit.Description
+	LoadShedders []loadshed.Description
+}
+
+// Runtime coordinates one policy snapshot with local admission, overload
+// protection, and request deadlines.
+//
+// Its standalone middleware order is:
+//
+//	policy snapshot -> rate limit -> load shedding -> timeout
+type Runtime struct {
+	stages       Stages
+	bundle       *middleware.Bundle
+	rateLimits   *ratelimit.Pool
+	loadShedders *loadshed.Pool
+}
+
+// New assembles an inbound Runtime without starting goroutines.
+func New(config Config) (*Runtime, error) {
+	if isNil(config.Resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidConfig)
+	}
+	rateLimits := config.RateLimits
+	if rateLimits == nil {
+		rateLimits = ratelimit.NewPool(nil)
+	}
+	loadShedders := config.LoadShedders
+	if loadShedders == nil {
+		loadShedders = loadshed.NewPool(nil, config.CPU)
+	}
+	snapshot := snapshotPolicy(config.Resolver)
+	rateLimit, err := ratelimit.New(config.Resolver, rateLimits)
+	if err != nil {
+		return nil, fmt.Errorf("%w: rate limit: %w", ErrInvalidConfig, err)
+	}
+	loadShedding, err := loadshed.New(config.Resolver, loadShedders)
+	if err != nil {
+		return nil, fmt.Errorf("%w: load shedding: %w", ErrInvalidConfig, err)
+	}
+	timeout, err := ktimeout.New(config.Resolver)
+	if err != nil {
+		return nil, fmt.Errorf("%w: timeout: %w", ErrInvalidConfig, err)
+	}
+	source := strings.TrimSpace(config.Source)
+	if source == "" {
+		source = defaultSource
+	}
+	bundle, err := middleware.NewBundle(middleware.Entry{Name: "policy-snapshot", Source: source, Middleware: snapshot},
+		middleware.Entry{
+			Name:       "rate-limit",
+			Source:     source,
+			Middleware: rateLimit,
+		},
+		middleware.Entry{
+			Name:       "load-shedding",
+			Source:     source,
+			Middleware: loadShedding,
+		},
+		middleware.Entry{
+			Name:       "timeout",
+			Source:     source,
+			Middleware: timeout,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: middleware bundle: %w", ErrInvalidConfig, err)
+	}
+	return &Runtime{
+		stages: Stages{
+			Policy:       snapshot,
+			RateLimit:    rateLimit,
+			LoadShedding: loadShedding,
+			Timeout:      timeout,
+		},
+		bundle:       bundle,
+		rateLimits:   rateLimits,
+		loadShedders: loadShedders,
+	}, nil
+}
+
+// Stages returns immutable middleware insertion points.
+func (r *Runtime) Stages() Stages {
+	if r == nil {
+		return Stages{}
+	}
+	return r.stages
+}
+
+// Middleware returns the standalone fixed-order governance bundle.
+func (r *Runtime) Middleware() *middleware.Bundle {
+	if r == nil {
+		return nil
+	}
+	return r.bundle
+}
+
+// Describe returns current admission and overload state.
+func (r *Runtime) Describe() Description {
+	if r == nil {
+		return Description{}
+	}
+	return Description{
+		Middleware:   r.bundle.Describe(),
+		RateLimits:   r.rateLimits.Describe(),
+		LoadShedders: r.loadShedders.Describe(),
+	}
+}
+
+func snapshotPolicy(resolver policy.Resolver) middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return invalidHandler("policy snapshot next handler is nil")
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidConfig)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			resolved := resolver.Resolve(target)
+			if err := policy.Validate(resolved); err != nil {
+				return nil, err
+			}
+			return next(
+				policy.WithResolved(ctx, target, resolved),
+				request,
+			)
+		}
+	}
+}
+
+func invalidHandler(message string) middleware.Handler {
+	return func(context.Context, any) (any, error) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidConfig, message)
+	}
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/loadshed/cpu.go
+++ b/governance/loadshed/cpu.go
@@ -1,0 +1,332 @@
+package loadshed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"runtime/metrics"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	defaultCPUComponentName  = "keelith.governance.runtime-cpu"
+	defaultCPUSampleInterval = 250 * time.Millisecond
+	minCPUSampleInterval     = 50 * time.Millisecond
+	maxCPUSampleInterval     = 10 * time.Second
+	totalCPUSecondsMetric    = "/cpu/classes/total:cpu-seconds"
+	idleCPUSecondsMetric     = "/cpu/classes/idle:cpu-seconds"
+)
+
+var (
+	// ErrCPUAlreadyStarted reports repeated RuntimeCPU Start.
+	ErrCPUAlreadyStarted = errors.New("loadshed: runtime CPU already started")
+	// ErrCPUUnsupported reports missing or malformed Go runtime CPU metrics.
+	ErrCPUUnsupported = errors.New("loadshed: runtime CPU metrics unsupported")
+)
+
+// CPUState is the observable sampler lifecycle.
+type CPUState string
+
+const (
+	// CPUStateNew means sampling has not started.
+	CPUStateNew CPUState = "new"
+	// CPUStateRunning means runtime CPU sampling is active.
+	CPUStateRunning CPUState = "running"
+	// CPUStateStopping means sampler shutdown is in progress.
+	CPUStateStopping CPUState = "stopping"
+	// CPUStateStopped means the sampler has exited.
+	CPUStateStopped CPUState = "stopped"
+)
+
+// RuntimeCPUConfig configures a lock-free CPU provider backed by runtime
+// scheduler metrics.
+type RuntimeCPUConfig struct {
+	Name     string
+	Interval time.Duration
+}
+
+// CPUDescription is a value-free RuntimeCPU diagnostic.
+type CPUDescription struct {
+	State    CPUState
+	Running  bool
+	Usage    float64
+	Samples  uint64
+	Failures uint64
+	Failed   bool
+}
+
+type cumulativeCPUReader func() (total float64, idle float64, err error)
+
+// RuntimeCPU periodically converts cumulative Go runtime CPU classes into a
+// normalized busy ratio. Usage performs only one atomic load.
+//
+// RuntimeCPU implements app.Component structurally.
+type RuntimeCPU struct {
+	name     string
+	interval time.Duration
+	read     cumulativeCPUReader
+
+	usage    atomic.Uint64
+	samples  atomic.Uint64
+	failures atomic.Uint64
+	failed   atomic.Bool
+
+	mu          sync.Mutex
+	state       CPUState
+	cancel      context.CancelFunc
+	done        chan struct{}
+	initialized bool
+	total       float64
+	idle        float64
+}
+
+// NewRuntimeCPU constructs a sampler without starting a goroutine.
+func NewRuntimeCPU(config RuntimeCPUConfig) (*RuntimeCPU, error) {
+	rawName := config.Name
+	name := strings.TrimSpace(config.Name)
+	if name == "" {
+		name = defaultCPUComponentName
+	}
+	if rawName != "" && rawName != name || !validCPUName(name) {
+		return nil, fmt.Errorf("%w: CPU component name is invalid", ErrInvalidOption)
+	}
+	interval := config.Interval
+	if interval == 0 {
+		interval = defaultCPUSampleInterval
+	}
+	if interval < minCPUSampleInterval || interval > maxCPUSampleInterval {
+		return nil, fmt.Errorf("%w: CPU sample interval must be between %s and %s", ErrInvalidOption, minCPUSampleInterval, maxCPUSampleInterval)
+	}
+	return &RuntimeCPU{
+		name:     name,
+		interval: interval,
+		read:     readRuntimeCPU,
+		state:    CPUStateNew,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Name returns the stable App component name.
+func (r *RuntimeCPU) Name() string {
+	if r == nil {
+		return ""
+	}
+	return r.name
+}
+
+// Dependencies returns no component prerequisites.
+func (*RuntimeCPU) Dependencies() []string {
+	return nil
+}
+
+// Start establishes a cumulative baseline before reporting Running.
+func (r *RuntimeCPU) Start(ctx context.Context) error {
+	if r == nil {
+		return fmt.Errorf("%w: runtime CPU is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	r.mu.Lock()
+	if r.state != CPUStateNew {
+		r.mu.Unlock()
+		return ErrCPUAlreadyStarted
+	}
+	total, idle, err := r.read()
+	if err != nil {
+		r.failures.Add(1)
+		r.failed.Store(true)
+		r.mu.Unlock()
+		return err
+	}
+	r.failed.Store(false)
+	runtimeCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	r.total = total
+	r.idle = idle
+	r.initialized = true
+	r.cancel = cancel
+	r.state = CPUStateRunning
+	done := r.done
+	interval := r.interval
+	r.mu.Unlock()
+
+	go r.run(runtimeCtx, interval, done)
+	return nil
+}
+
+// Stop terminates sampling and waits for the goroutine to exit.
+func (r *RuntimeCPU) Stop(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	r.mu.Lock()
+	switch r.state {
+	case CPUStateNew:
+		r.mu.Unlock()
+		return nil
+	case CPUStateRunning:
+		r.state = CPUStateStopping
+		cancel := r.cancel
+		done := r.done
+		r.mu.Unlock()
+		cancel()
+		return waitCPU(ctx, done)
+	case CPUStateStopping:
+		done := r.done
+		r.mu.Unlock()
+		return waitCPU(ctx, done)
+	case CPUStateStopped:
+		r.mu.Unlock()
+		return nil
+	default:
+		r.mu.Unlock()
+		return nil
+	}
+}
+
+// Usage returns the last normalized busy ratio in [0, 1].
+func (r *RuntimeCPU) Usage() float64 {
+	if r == nil {
+		return 0
+	}
+	return math.Float64frombits(r.usage.Load())
+}
+
+// Describe returns sampler lifecycle and aggregate health.
+func (r *RuntimeCPU) Describe() CPUDescription {
+	if r == nil {
+		return CPUDescription{State: CPUStateStopped}
+	}
+	r.mu.Lock()
+	state := r.state
+	r.mu.Unlock()
+	return CPUDescription{
+		State:    state,
+		Running:  state == CPUStateRunning,
+		Usage:    r.Usage(),
+		Samples:  r.samples.Load(),
+		Failures: r.failures.Load(),
+		Failed:   r.failed.Load(),
+	}
+}
+
+func (r *RuntimeCPU) run(
+	ctx context.Context,
+	interval time.Duration,
+	done chan struct{},
+) {
+	defer close(done)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			r.mu.Lock()
+			r.cancel = nil
+			r.state = CPUStateStopped
+			r.mu.Unlock()
+			return
+		case <-ticker.C:
+			r.sample()
+		}
+	}
+}
+
+func (r *RuntimeCPU) sample() {
+	total, idle, err := r.read()
+	if err != nil {
+		r.failures.Add(1)
+		r.failed.Store(true)
+		return
+	}
+	r.mu.Lock()
+	if !r.initialized {
+		r.total = total
+		r.idle = idle
+		r.initialized = true
+		r.mu.Unlock()
+		return
+	}
+	totalDelta := total - r.total
+	idleDelta := idle - r.idle
+	r.total = total
+	r.idle = idle
+	r.mu.Unlock()
+	if totalDelta <= 0 ||
+		math.IsNaN(totalDelta) ||
+		math.IsInf(totalDelta, 0) {
+		r.failures.Add(1)
+		r.failed.Store(true)
+		return
+	}
+	busyDelta := totalDelta - idleDelta
+	usage := busyDelta / totalDelta
+	if math.IsNaN(usage) || math.IsInf(usage, 0) {
+		r.failures.Add(1)
+		r.failed.Store(true)
+		return
+	}
+	usage = math.Max(0, math.Min(1, usage))
+	r.usage.Store(math.Float64bits(usage))
+	r.samples.Add(1)
+	r.failed.Store(false)
+}
+
+func readRuntimeCPU() (float64, float64, error) {
+	samples := []metrics.Sample{
+		{Name: totalCPUSecondsMetric},
+		{Name: idleCPUSecondsMetric},
+	}
+	metrics.Read(samples)
+	if samples[0].Value.Kind() != metrics.KindFloat64 ||
+		samples[1].Value.Kind() != metrics.KindFloat64 {
+		return 0, 0, ErrCPUUnsupported
+	}
+	total := samples[0].Value.Float64()
+	idle := samples[1].Value.Float64()
+	if total < 0 ||
+		idle < 0 ||
+		math.IsNaN(total) ||
+		math.IsInf(total, 0) ||
+		math.IsNaN(idle) ||
+		math.IsInf(idle, 0) {
+		return 0, 0, ErrCPUUnsupported
+	}
+	return total, idle, nil
+}
+
+func waitCPU(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func validCPUName(value string) bool {
+	if value == "" ||
+		len(value) > 256 ||
+		!utf8.ValidString(value) ||
+		strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}

--- a/governance/loadshed/middleware.go
+++ b/governance/loadshed/middleware.go
@@ -1,0 +1,43 @@
+package loadshed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// New creates per-Operation load-shed Middleware.
+func New(resolver policy.Resolver, pool *Pool) (middleware.Middleware, error) {
+	if isNil(resolver) || pool == nil {
+		return nil, fmt.Errorf("%w: resolver or pool is nil", ErrInvalidOption)
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, fmt.Errorf("%w: operation is missing", ErrInvalidOption)
+			}
+			config := policy.Resolve(ctx, resolver, target).LoadShedding
+			if !config.Enabled {
+				return next(ctx, request)
+			}
+			permit, err := pool.Get(target.PolicyKey()).Acquire(config)
+			if err != nil {
+				return nil, err
+			}
+			defer permit.Release()
+			return next(ctx, request)
+		}
+	}, nil
+}

--- a/governance/loadshed/shedder.go
+++ b/governance/loadshed/shedder.go
@@ -1,0 +1,296 @@
+// Package loadshed provides CPU-aware BBR-like concurrency shedding.
+package loadshed
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/policy"
+)
+
+const (
+	sampleWindow = time.Second
+	bbrGain      = 2.0
+)
+
+var (
+	// ErrOverloaded reports that the shedder rejected an invocation.
+	ErrOverloaded = kerrors.New(503, "OVERLOADED", "instance is overloaded")
+	// ErrInvalidOption reports an invalid shedder dependency or policy.
+	ErrInvalidOption = errors.New("loadshed: invalid option")
+)
+
+// Clock supplies deterministic latency/window time.
+type Clock interface {
+	Now() time.Time
+}
+
+// CPU reports normalized process or host CPU usage in [0, 1].
+type CPU interface {
+	Usage() float64
+}
+
+// Description is a low-cardinality shedder snapshot.
+type Description struct {
+	Key           string
+	Inflight      int
+	AdaptiveLimit int
+	CPUUsage      float64
+	Accepted      uint64
+	Rejected      uint64
+	MinLatency    time.Duration
+}
+
+// Shedder combines a hard concurrency cap with a CPU-gated BBR-like estimate.
+type Shedder struct {
+	clock Clock
+	cpu   CPU
+
+	mu            sync.Mutex
+	initialized   bool
+	windowStart   time.Time
+	completed     uint64
+	minLatency    time.Duration
+	adaptiveLimit int
+	inflight      int
+	accepted      uint64
+	rejected      uint64
+}
+
+// Permit records completion latency and releases one inflight slot.
+type Permit struct {
+	shedder *Shedder
+	start   time.Time
+	once    sync.Once
+}
+
+// NewShedder creates an isolated Shedder.
+func NewShedder(clock Clock, cpu CPU) *Shedder {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	if isNil(cpu) {
+		cpu = zeroCPU{}
+	}
+	return &Shedder{clock: clock, cpu: cpu}
+}
+
+// Acquire enforces hard and adaptive limits.
+func (s *Shedder) Acquire(
+	config policy.LoadSheddingPolicy,
+) (*Permit, error) {
+	if s == nil {
+		return nil, fmt.Errorf("%w: shedder is nil", ErrInvalidOption)
+	}
+	if !config.Enabled {
+		return &Permit{}, nil
+	}
+	if err := validate(config); err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+	usage := s.cpu.Usage()
+	if math.IsNaN(usage) || math.IsInf(usage, 0) {
+		usage = 1
+	}
+	usage = math.Max(0, math.Min(1, usage))
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rollWindow(now, config)
+	hardLimited := config.MaxConcurrency > 0 &&
+		s.inflight >= config.MaxConcurrency
+	adaptiveLimited := config.CPUThreshold > 0 &&
+		usage >= config.CPUThreshold &&
+		s.inflight >= s.adaptiveLimit
+	if hardLimited || adaptiveLimited {
+		s.rejected++
+		return nil, ErrOverloaded
+	}
+	s.inflight++
+	s.accepted++
+	return &Permit{shedder: s, start: now}, nil
+}
+
+// Release records completion and returns one inflight slot.
+func (permit *Permit) Release() {
+	if permit == nil || permit.shedder == nil {
+		return
+	}
+	permit.once.Do(func() {
+		now := permit.shedder.clock.Now()
+		latency := now.Sub(permit.start)
+		if latency <= 0 {
+			latency = time.Nanosecond
+		}
+		permit.shedder.mu.Lock()
+		if permit.shedder.inflight > 0 {
+			permit.shedder.inflight--
+		}
+		permit.shedder.completed++
+		if permit.shedder.minLatency == 0 ||
+			latency < permit.shedder.minLatency {
+			permit.shedder.minLatency = latency
+		}
+		permit.shedder.mu.Unlock()
+	})
+}
+
+// Describe returns a debug snapshot.
+func (s *Shedder) Describe() Description {
+	if s == nil {
+		return Description{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Description{
+		Inflight:      s.inflight,
+		AdaptiveLimit: s.adaptiveLimit,
+		CPUUsage:      s.cpu.Usage(),
+		Accepted:      s.accepted,
+		Rejected:      s.rejected,
+		MinLatency:    s.minLatency,
+	}
+}
+
+func (s *Shedder) rollWindow(now time.Time, config policy.LoadSheddingPolicy) {
+	if !s.initialized {
+		s.initialized = true
+		s.windowStart = now
+		s.adaptiveLimit = config.MaxConcurrency
+		if s.adaptiveLimit <= 0 {
+			s.adaptiveLimit = 1
+		}
+		return
+	}
+	elapsed := now.Sub(s.windowStart)
+	if elapsed < sampleWindow && elapsed >= 0 {
+		return
+	}
+	if s.completed > 0 && s.minLatency > 0 && elapsed > 0 {
+		throughput := float64(s.completed) / elapsed.Seconds()
+		estimate := int(math.Ceil(
+			throughput * s.minLatency.Seconds() * bbrGain,
+		))
+		if estimate < 1 {
+			estimate = 1
+		}
+		if config.MaxConcurrency > 0 && estimate > config.MaxConcurrency {
+			estimate = config.MaxConcurrency
+		}
+		s.adaptiveLimit = estimate
+	}
+	s.windowStart = now
+	s.completed = 0
+	s.minLatency = 0
+}
+
+func validate(config policy.LoadSheddingPolicy) error {
+	if config.MaxConcurrency < 0 ||
+		config.CPUThreshold < 0 ||
+		config.CPUThreshold > 1 ||
+		math.IsNaN(config.CPUThreshold) ||
+		math.IsInf(config.CPUThreshold, 0) ||
+		config.MaxConcurrency <= 0 && config.CPUThreshold <= 0 {
+		return fmt.Errorf("%w: resolved load-shed policy is invalid", policy.ErrInvalidPolicy)
+	}
+	return nil
+}
+
+// Pool owns shedder state by stable Operation policy key.
+type Pool struct {
+	clock Clock
+	cpu   CPU
+
+	mu       sync.Mutex
+	shedders map[string]*Shedder
+}
+
+// NewPool creates an isolated shedder pool.
+func NewPool(clock Clock, cpu CPU) *Pool {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	if isNil(cpu) {
+		cpu = zeroCPU{}
+	}
+	return &Pool{
+		clock:    clock,
+		cpu:      cpu,
+		shedders: make(map[string]*Shedder),
+	}
+}
+
+// Get returns the stable shedder for key.
+func (p *Pool) Get(key string) *Shedder {
+	if p == nil {
+		return nil
+	}
+	normalized := strings.TrimSpace(key)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	subject := p.shedders[normalized]
+	if subject == nil {
+		subject = NewShedder(p.clock, p.cpu)
+		p.shedders[normalized] = subject
+	}
+	return subject
+}
+
+// Describe returns sorted low-cardinality snapshots.
+func (p *Pool) Describe() []Description {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	entries := make(map[string]*Shedder, len(p.shedders))
+	for key, shedder := range p.shedders {
+		entries[key] = shedder
+	}
+	p.mu.Unlock()
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]Description, 0, len(keys))
+	for _, key := range keys {
+		description := entries[key].Describe()
+		description.Key = key
+		result = append(result, description)
+	}
+	return result
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+type zeroCPU struct{}
+
+func (zeroCPU) Usage() float64 {
+	return 0
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/outlier/detector.go
+++ b/governance/outlier/detector.go
@@ -1,0 +1,214 @@
+// Package outlier provides passive instance health detection for selectors.
+package outlier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/selector"
+)
+
+var (
+	// ErrInvalidConfig means an outlier detector policy is unusable.
+	ErrInvalidConfig = errors.New("outlier: invalid config")
+)
+
+// Clock supplies deterministic detector time.
+type Clock interface {
+	Now() time.Time
+}
+
+// Classifier decides whether one completed call is an instance failure.
+type Classifier func(selector.Result) bool
+
+// Config controls passive consecutive-failure ejection.
+type Config struct {
+	ConsecutiveFailures int
+	EjectionTime        time.Duration
+	Clock               Clock
+	Classifier          Classifier
+}
+
+// Status is an immutable, low-cardinality node health snapshot.
+type Status struct {
+	Service             string
+	NodeID              string
+	Endpoint            string
+	ConsecutiveFailures int
+	EjectedUntil        time.Time
+	Ejected             bool
+}
+
+type nodeState struct {
+	service      string
+	nodeID       string
+	endpoint     string
+	consecutive  int
+	ejectedUntil time.Time
+}
+
+// Detector implements selector.Observer using passive invocation results.
+//
+// Once the ejection deadline expires, the node becomes eligible for a
+// probation request. A successful result fully restores it; another instance
+// failure immediately ejects it again.
+type Detector struct {
+	threshold    int
+	ejectionTime time.Duration
+	clock        Clock
+	classify     Classifier
+
+	mu    sync.Mutex
+	nodes map[string]*nodeState
+}
+
+// New constructs a passive outlier detector.
+func New(config Config) (*Detector, error) {
+	if config.ConsecutiveFailures <= 0 {
+		return nil, fmt.Errorf(
+			"%w: consecutive failures must be positive",
+			ErrInvalidConfig,
+		)
+	}
+	if config.EjectionTime <= 0 {
+		return nil, fmt.Errorf(
+			"%w: ejection time must be positive",
+			ErrInvalidConfig,
+		)
+	}
+	clock := config.Clock
+	if clock == nil {
+		clock = systemClock{}
+	}
+	classify := config.Classifier
+	if classify == nil {
+		classify = defaultClassifier
+	}
+	return &Detector{
+		threshold:    config.ConsecutiveFailures,
+		ejectionTime: config.EjectionTime,
+		clock:        clock,
+		classify:     classify,
+		nodes:        make(map[string]*nodeState),
+	}, nil
+}
+
+// Allow reports whether a node is currently eligible.
+func (d *Detector) Allow(ctx context.Context, _ operation.Operation, node selector.Node) bool {
+	if d == nil || context.Cause(ctx) != nil {
+		return false
+	}
+	now := d.clock.Now()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	state := d.state(node)
+	return state.ejectedUntil.IsZero() || !now.Before(state.ejectedUntil)
+}
+
+// Done records one invocation result.
+func (d *Detector) Done(_ operation.Operation, node selector.Node, result selector.Result) {
+	if d == nil {
+		return
+	}
+	now := d.clock.Now()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	state := d.state(node)
+
+	if result.Canceled {
+		return
+	}
+	if !d.classify(result) {
+		state.consecutive = 0
+		state.ejectedUntil = time.Time{}
+		return
+	}
+
+	// A failure during post-ejection probation must immediately re-eject the
+	// node instead of requiring another full threshold.
+	if !state.ejectedUntil.IsZero() && !now.Before(state.ejectedUntil) {
+		state.consecutive = d.threshold
+		state.ejectedUntil = now.Add(d.ejectionTime)
+		return
+	}
+	state.consecutive++
+	if state.consecutive >= d.threshold {
+		state.ejectedUntil = now.Add(d.ejectionTime)
+	}
+}
+
+// Status returns deterministic diagnostic state.
+func (d *Detector) Status() []Status {
+	if d == nil {
+		return nil
+	}
+	now := d.clock.Now()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	result := make([]Status, 0, len(d.nodes))
+	for _, state := range d.nodes {
+		result = append(result, Status{
+			Service:             state.service,
+			NodeID:              state.nodeID,
+			Endpoint:            state.endpoint,
+			ConsecutiveFailures: state.consecutive,
+			EjectedUntil:        state.ejectedUntil,
+			Ejected:             !state.ejectedUntil.IsZero() && now.Before(state.ejectedUntil),
+		})
+	}
+	sort.Slice(result, func(first, second int) bool {
+		if result[first].Service != result[second].Service {
+			return result[first].Service < result[second].Service
+		}
+		if result[first].NodeID == result[second].NodeID {
+			return result[first].Endpoint < result[second].Endpoint
+		}
+		return result[first].NodeID < result[second].NodeID
+	})
+	return result
+}
+
+// Reset forgets all accumulated node health state.
+func (d *Detector) Reset() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.nodes = make(map[string]*nodeState)
+	d.mu.Unlock()
+}
+
+func (d *Detector) state(node selector.Node) *nodeState {
+	key := node.Service() + "\x00" + node.ID() + "\x00" + node.Endpoint()
+	state := d.nodes[key]
+	if state == nil {
+		state = &nodeState{
+			service:  node.Service(),
+			nodeID:   node.ID(),
+			endpoint: node.Endpoint(),
+		}
+		d.nodes[key] = state
+	}
+	return state
+}
+
+func defaultClassifier(result selector.Result) bool {
+	switch failure.Classify(result.Error) {
+	case failure.Transport, failure.Timeout:
+		return true
+	default:
+		return false
+	}
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}

--- a/governance/policy/config.go
+++ b/governance/policy/config.go
@@ -1,0 +1,431 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kconfig "github.com/keelab/keelith/config"
+	"github.com/keelab/keelith/operation"
+)
+
+const (
+	maxConfigServiceRules = 1024
+	maxConfigMatcherRules = 256
+	maxConfigMethodRules  = 16 * 1024
+)
+
+// RetryConfig is a partial retry policy read from typed configuration.
+type RetryConfig struct {
+	Enabled     *bool          `config:"enabled"`
+	Idempotent  *bool          `config:"idempotent"`
+	MaxAttempts *int           `config:"maxAttempts"`
+	BackoffMin  *time.Duration `config:"backoffMin"`
+	BackoffMax  *time.Duration `config:"backoffMax"`
+	BudgetRatio *float64       `config:"budgetRatio"`
+}
+
+// HedgingConfig is a partial hedging policy.
+type HedgingConfig struct {
+	Enabled     *bool          `config:"enabled"`
+	Idempotent  *bool          `config:"idempotent"`
+	MaxAttempts *int           `config:"maxAttempts"`
+	Delay       *time.Duration `config:"delay"`
+}
+
+// BreakerConfig is a partial circuit-breaker policy.
+type BreakerConfig struct {
+	Enabled        *bool          `config:"enabled"`
+	FailureRatio   *float64       `config:"failureRatio"`
+	Window         *time.Duration `config:"window"`
+	MinRequests    *int           `config:"minRequests"`
+	OpenTimeout    *time.Duration `config:"openTimeout"`
+	HalfOpenProbes *int           `config:"halfOpenProbes"`
+}
+
+// BulkheadConfig is a partial dependency-isolation policy.
+type BulkheadConfig struct {
+	Enabled        *bool          `config:"enabled"`
+	MaxConcurrency *int           `config:"maxConcurrency"`
+	MaxQueue       *int           `config:"maxQueue"`
+	QueueTimeout   *time.Duration `config:"queueTimeout"`
+}
+
+// RateLimitConfig is a partial local rate/concurrency policy.
+type RateLimitConfig struct {
+	Enabled           *bool    `config:"enabled"`
+	RequestsPerSecond *float64 `config:"requestsPerSecond"`
+	Burst             *int     `config:"burst"`
+	MaxConcurrency    *int     `config:"maxConcurrency"`
+}
+
+// LoadSheddingConfig is a partial local overload policy.
+type LoadSheddingConfig struct {
+	Enabled        *bool    `config:"enabled"`
+	MaxConcurrency *int     `config:"maxConcurrency"`
+	CPUThreshold   *float64 `config:"cpuThreshold"`
+}
+
+// StreamConfig is a partial per-stream and shared message policy.
+type StreamConfig struct {
+	Enabled            *bool    `config:"enabled"`
+	MaxSendMessages    *int     `config:"maxSendMessages"`
+	MaxReceiveMessages *int     `config:"maxReceiveMessages"`
+	MessagesPerSecond  *float64 `config:"messagesPerSecond"`
+	Burst              *int     `config:"burst"`
+	MaxConcurrency     *int     `config:"maxConcurrency"`
+}
+
+// Overrides selectively replaces fields in a base Policy.
+type Overrides struct {
+	Timeout      *time.Duration      `config:"timeout"`
+	Retry        *RetryConfig        `config:"retry"`
+	Hedging      *HedgingConfig      `config:"hedging"`
+	Breaker      *BreakerConfig      `config:"breaker"`
+	Bulkhead     *BulkheadConfig     `config:"bulkhead"`
+	RateLimit    *RateLimitConfig    `config:"rateLimit"`
+	LoadShedding *LoadSheddingConfig `config:"loadShedding"`
+	Stream       *StreamConfig       `config:"stream"`
+}
+
+// ServiceConfig applies one policy patch to a logical service.
+type ServiceConfig struct {
+	Service string    `config:"service"`
+	Policy  Overrides `config:"policy"`
+}
+
+// MethodConfig applies one policy patch to an exact Operation.
+type MethodConfig struct {
+	Transport string    `config:"transport"`
+	Service   string    `config:"service"`
+	Method    string    `config:"method"`
+	Kind      string    `config:"kind"`
+	Policy    Overrides `config:"policy"`
+}
+
+// MatcherConfig applies one policy patch to the first matching Operation.
+//
+// Transport and kind are exact optional filters. Mode applies to service and
+// method and must be exact, prefix, or regexp.
+type MatcherConfig struct {
+	Name      string    `config:"name"`
+	Mode      string    `config:"mode"`
+	Transport string    `config:"transport"`
+	Service   string    `config:"service"`
+	Method    string    `config:"method"`
+	Kind      string    `config:"kind"`
+	Policy    Overrides `config:"policy"`
+}
+
+// Config is the complete typed Method Policy subtree.
+type Config struct {
+	Global   Overrides       `config:"global"`
+	Services []ServiceConfig `config:"services"`
+	Matchers []MatcherConfig `config:"matchers"`
+	Methods  []MethodConfig  `config:"methods"`
+}
+
+// ConfigDescription is a value-free policy binding snapshot.
+type ConfigDescription struct {
+	Name         string
+	Path         string
+	Loaded       bool
+	Failed       bool
+	Revision     string
+	ServiceRules int
+	MatcherRules int
+	MethodRules  int
+}
+
+// ConfigBinding validates and atomically publishes Method Policy definitions.
+//
+// It implements config.Binding. Store is immediately usable with the safe
+// default policy and moves to the merged config Snapshot revision after Apply.
+type ConfigBinding struct {
+	component *kconfig.Component[Config]
+	store     *Store
+}
+
+// NewConfigBinding constructs a strict hot-reload binding at path.
+func NewConfigBinding(name string, path string) (*ConfigBinding, error) {
+	component, err := kconfig.NewComponent[Config](
+		name,
+		path,
+		kconfig.WithComponentDefault(Config{}),
+		kconfig.WithComponentValidator(func(value Config) error {
+			_, err := definitionFromConfig("candidate", value)
+			return err
+		}),
+		kconfig.WithReloadableFields[Config]("global", "services", "matchers", "methods"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	store, err := NewStore(Definition{
+		Revision: "bootstrap",
+		Global:   Default(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigBinding{component: component, store: store}, nil
+}
+
+// Name returns the Manager subscriber identity.
+func (binding *ConfigBinding) Name() string {
+	if binding == nil || binding.component == nil {
+		return ""
+	}
+	return binding.component.Name()
+}
+
+// Validate strictly decodes and compiles a candidate definition before
+// Manager publication.
+func (binding *ConfigBinding) Validate(snapshot kconfig.Snapshot) error {
+	if binding == nil || binding.component == nil {
+		return fmt.Errorf("%w: policy config binding is nil", ErrInvalidDefinition)
+	}
+	if !validIdentity(snapshot.Revision()) {
+		return invalidDefinition("config revision %q is invalid", snapshot.Revision())
+	}
+	return binding.component.Validate(snapshot)
+}
+
+// Apply publishes the candidate to the typed component and atomic Store.
+func (binding *ConfigBinding) Apply(
+	ctx context.Context,
+	snapshot kconfig.Snapshot,
+) error {
+	if binding == nil || binding.component == nil || binding.store == nil {
+		return fmt.Errorf("%w: policy config binding is nil", ErrInvalidDefinition)
+	}
+	if err := binding.component.Apply(ctx, snapshot); err != nil {
+		return err
+	}
+	current, ok := binding.component.Current()
+	if !ok {
+		return fmt.Errorf("%w: policy config was not published", ErrInvalidDefinition)
+	}
+	definition, err := definitionFromConfig(snapshot.Revision(), current)
+	if err != nil {
+		return err
+	}
+	_, err = binding.store.Update(definition)
+	return err
+}
+
+// Store returns the stable Resolver updated by this binding.
+func (binding *ConfigBinding) Store() *Store {
+	if binding == nil {
+		return nil
+	}
+	return binding.store
+}
+
+// Description returns policy revision and rule counts without policy values.
+func (binding *ConfigBinding) Description() ConfigDescription {
+	if binding == nil || binding.component == nil || binding.store == nil {
+		return ConfigDescription{}
+	}
+	component := binding.component.Description()
+	store := binding.store.Describe()
+	return ConfigDescription{
+		Name:         component.Name,
+		Path:         component.Path,
+		Loaded:       component.Loaded,
+		Failed:       component.Failed,
+		Revision:     store.Revision,
+		ServiceRules: store.ServiceRules,
+		MatcherRules: store.MatcherRules,
+		MethodRules:  store.MethodRules,
+	}
+}
+
+func definitionFromConfig(revision string, value Config) (Definition, error) {
+	if len(value.Services) > maxConfigServiceRules ||
+		len(value.Matchers) > maxConfigMatcherRules ||
+		len(value.Methods) > maxConfigMethodRules {
+		return Definition{}, fmt.Errorf(
+			"%w: policy config exceeds rule limits",
+			ErrInvalidDefinition,
+		)
+	}
+	globalPatch := value.Global.patch(Default())
+	global := globalPatch.apply(Default())
+	definition := Definition{
+		Revision: revision,
+		Global:   global,
+		Services: make([]ServiceRule, 0, len(value.Services)),
+		Matchers: make([]MatchRule, 0, len(value.Matchers)),
+		Methods:  make([]MethodRule, 0, len(value.Methods)),
+	}
+	servicePolicies := make(map[string]Policy, len(value.Services))
+	for _, rule := range value.Services {
+		patch := rule.Policy.patch(global)
+		definition.Services = append(definition.Services, ServiceRule{
+			Service: rule.Service,
+			Patch:   patch,
+		})
+		servicePolicies[rule.Service] = patch.apply(global)
+	}
+	for _, rule := range value.Matchers {
+		matcher, err := operation.CompileMatcher(operation.MatchPattern{
+			Mode:      operation.MatchMode(rule.Mode),
+			Transport: rule.Transport,
+			Service:   rule.Service,
+			Method:    rule.Method,
+			Kind:      operation.Kind(rule.Kind),
+		})
+		if err != nil {
+			return Definition{}, fmt.Errorf(
+				"%w: matcher %q: %w",
+				ErrInvalidDefinition,
+				rule.Name,
+				err,
+			)
+		}
+		matchRule := MatchRule{
+			Name:    rule.Name,
+			Matcher: matcher,
+			Patch:   rule.Policy.patch(global),
+		}
+		if len(servicePolicies) > 0 {
+			matchRule.servicePatches = make(
+				map[string]Patch,
+				len(servicePolicies),
+			)
+			for service, base := range servicePolicies {
+				matchRule.servicePatches[service] = rule.Policy.patch(base)
+			}
+		}
+		definition.Matchers = append(definition.Matchers, matchRule)
+	}
+	for _, rule := range value.Methods {
+		target, err := operation.New(rule.Transport, rule.Service, rule.Method, operation.Kind(rule.Kind))
+		if err != nil {
+			return Definition{}, fmt.Errorf(
+				"%w: method operation: %w",
+				ErrInvalidDefinition,
+				err,
+			)
+		}
+		base := global
+		if servicePolicy, ok := servicePolicies[target.Service()]; ok {
+			base = servicePolicy
+		}
+		definition.Methods = append(definition.Methods, MethodRule{
+			Operation: target,
+			Patch:     rule.Policy.patch(base),
+		})
+	}
+	if _, err := compile(definition); err != nil {
+		return Definition{}, err
+	}
+	return definition, nil
+}
+
+func (value Overrides) patch(base Policy) Patch {
+	var patch Patch
+	if value.Timeout != nil {
+		patch.Timeout = Some(*value.Timeout)
+	}
+	if value.Retry != nil {
+		resolved := base.Retry
+		applyRetryConfig(&resolved, *value.Retry)
+		patch.Retry = Some(resolved)
+	}
+	if value.Hedging != nil {
+		resolved := base.Hedging
+		applyHedgingConfig(&resolved, *value.Hedging)
+		patch.Hedging = Some(resolved)
+	}
+	if value.Breaker != nil {
+		resolved := base.Breaker
+		applyBreakerConfig(&resolved, *value.Breaker)
+		patch.Breaker = Some(resolved)
+	}
+	if value.Bulkhead != nil {
+		resolved := base.Bulkhead
+		applyBulkheadConfig(&resolved, *value.Bulkhead)
+		patch.Bulkhead = Some(resolved)
+	}
+	if value.RateLimit != nil {
+		resolved := base.RateLimit
+		applyRateLimitConfig(&resolved, *value.RateLimit)
+		patch.RateLimit = Some(resolved)
+	}
+	if value.LoadShedding != nil {
+		resolved := base.LoadShedding
+		applyLoadSheddingConfig(&resolved, *value.LoadShedding)
+		patch.LoadShedding = Some(resolved)
+	}
+	if value.Stream != nil {
+		resolved := base.Stream
+		applyStreamConfig(&resolved, *value.Stream)
+		patch.Stream = Some(resolved)
+	}
+	return patch
+}
+
+func applyRetryConfig(target *RetryPolicy, value RetryConfig) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.Idempotent, &target.Idempotent)
+	assign(value.MaxAttempts, &target.MaxAttempts)
+	assign(value.BackoffMin, &target.BackoffMin)
+	assign(value.BackoffMax, &target.BackoffMax)
+	assign(value.BudgetRatio, &target.BudgetRatio)
+}
+
+func applyHedgingConfig(target *HedgingPolicy, value HedgingConfig) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.Idempotent, &target.Idempotent)
+	assign(value.MaxAttempts, &target.MaxAttempts)
+	assign(value.Delay, &target.Delay)
+}
+
+func applyBreakerConfig(target *BreakerPolicy, value BreakerConfig) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.FailureRatio, &target.FailureRatio)
+	assign(value.Window, &target.Window)
+	assign(value.MinRequests, &target.MinRequests)
+	assign(value.OpenTimeout, &target.OpenTimeout)
+	assign(value.HalfOpenProbes, &target.HalfOpenProbes)
+}
+
+func applyBulkheadConfig(target *BulkheadPolicy, value BulkheadConfig) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.MaxConcurrency, &target.MaxConcurrency)
+	assign(value.MaxQueue, &target.MaxQueue)
+	assign(value.QueueTimeout, &target.QueueTimeout)
+}
+
+func applyRateLimitConfig(target *RateLimitPolicy, value RateLimitConfig) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.RequestsPerSecond, &target.RequestsPerSecond)
+	assign(value.Burst, &target.Burst)
+	assign(value.MaxConcurrency, &target.MaxConcurrency)
+}
+
+func applyLoadSheddingConfig(
+	target *LoadSheddingPolicy,
+	value LoadSheddingConfig,
+) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.MaxConcurrency, &target.MaxConcurrency)
+	assign(value.CPUThreshold, &target.CPUThreshold)
+}
+
+func applyStreamConfig(target *StreamPolicy, value StreamConfig) {
+	assign(value.Enabled, &target.Enabled)
+	assign(value.MaxSendMessages, &target.MaxSendMessages)
+	assign(value.MaxReceiveMessages, &target.MaxReceiveMessages)
+	assign(value.MessagesPerSecond, &target.MessagesPerSecond)
+	assign(value.Burst, &target.Burst)
+	assign(value.MaxConcurrency, &target.MaxConcurrency)
+}
+
+func assign[T any](source *T, target *T) {
+	if source != nil {
+		*target = *source
+	}
+}

--- a/governance/policy/context.go
+++ b/governance/policy/context.go
@@ -1,0 +1,51 @@
+package policy
+
+import (
+	"context"
+
+	"github.com/keelab/keelith/operation"
+)
+
+type resolvedContextKey struct{}
+
+type resolvedContextValue struct {
+	key   string
+	value Policy
+}
+
+// WithResolved records one immutable policy snapshot for an invocation.
+//
+// The operation key is stored with the policy so a nested call cannot
+// accidentally reuse its parent's resolved policy.
+func WithResolved(ctx context.Context, target operation.Operation, value Policy) context.Context {
+	return context.WithValue(ctx, resolvedContextKey{}, resolvedContextValue{
+		key:   target.PolicyKey(),
+		value: value,
+	})
+}
+
+// FromContext returns a matching invocation policy snapshot.
+func FromContext(ctx context.Context, target operation.Operation) (Policy, bool) {
+	if ctx == nil {
+		return Policy{}, false
+	}
+	resolved, ok := ctx.Value(resolvedContextKey{}).(resolvedContextValue)
+	if !ok || resolved.key != target.PolicyKey() {
+		return Policy{}, false
+	}
+	return resolved.value, true
+}
+
+// Resolve returns the invocation snapshot when present, otherwise it consults
+// resolver. Middleware that participates in one governance chain therefore
+// observes one coherent policy revision.
+func Resolve(
+	ctx context.Context,
+	resolver Resolver,
+	target operation.Operation,
+) Policy {
+	if resolved, ok := FromContext(ctx, target); ok {
+		return resolved
+	}
+	return resolver.Resolve(target)
+}

--- a/governance/policy/policy.go
+++ b/governance/policy/policy.go
@@ -1,0 +1,377 @@
+// Package policy defines immutable, transport-neutral method policy snapshots.
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+var (
+	// ErrInvalidPolicy means a resolved policy violates its invariants.
+	ErrInvalidPolicy = errors.New("policy: invalid policy")
+	// ErrInvalidDefinition means a policy definition is missing an identity or
+	// contains conflicting rules.
+	ErrInvalidDefinition = errors.New("policy: invalid definition")
+)
+
+const (
+	minRetryAttempts = 2
+	maxRetryAttempts = 10
+	minHedgeAttempts = 2
+	maxHedgeAttempts = 5
+)
+
+// RetryPolicy configures bounded retry behavior. It does not execute retries.
+type RetryPolicy struct {
+	Enabled     bool
+	Idempotent  bool
+	MaxAttempts int
+	BackoffMin  time.Duration
+	BackoffMax  time.Duration
+	BudgetRatio float64
+}
+
+// HedgingPolicy configures bounded parallel hedging. It does not execute
+// hedged requests.
+type HedgingPolicy struct {
+	Enabled     bool
+	Idempotent  bool
+	MaxAttempts int
+	Delay       time.Duration
+}
+
+// BreakerPolicy configures circuit-breaker thresholds. It does not maintain
+// breaker state.
+type BreakerPolicy struct {
+	Enabled        bool
+	FailureRatio   float64
+	Window         time.Duration
+	MinRequests    int
+	OpenTimeout    time.Duration
+	HalfOpenProbes int
+}
+
+// BulkheadPolicy bounds concurrent logical calls to one dependency.
+//
+// MaxQueue zero means fail fast. A positive queue must always have a bounded
+// QueueTimeout so callers without a deadline cannot wait forever.
+type BulkheadPolicy struct {
+	Enabled        bool
+	MaxConcurrency int
+	MaxQueue       int
+	QueueTimeout   time.Duration
+}
+
+// RateLimitPolicy configures local rate and concurrency limits.
+type RateLimitPolicy struct {
+	Enabled           bool
+	RequestsPerSecond float64
+	Burst             int
+	MaxConcurrency    int
+}
+
+// LoadSheddingPolicy configures local overload thresholds.
+type LoadSheddingPolicy struct {
+	Enabled        bool
+	MaxConcurrency int
+	CPUThreshold   float64
+}
+
+// StreamPolicy configures per-stream message quotas and shared message limits.
+type StreamPolicy struct {
+	Enabled            bool
+	MaxSendMessages    int
+	MaxReceiveMessages int
+	MessagesPerSecond  float64
+	Burst              int
+	MaxConcurrency     int
+}
+
+// Policy is the fully resolved policy for an operation.
+type Policy struct {
+	Timeout      time.Duration
+	Retry        RetryPolicy
+	Hedging      HedgingPolicy
+	Breaker      BreakerPolicy
+	Bulkhead     BulkheadPolicy
+	RateLimit    RateLimitPolicy
+	LoadShedding LoadSheddingPolicy
+	Stream       StreamPolicy
+}
+
+// Default returns Keelith's safe baseline policy.
+func Default() Policy {
+	return Policy{
+		Timeout: 3 * time.Second,
+		Retry: RetryPolicy{
+			MaxAttempts: 3,
+			BackoffMin:  10 * time.Millisecond,
+			BackoffMax:  time.Second,
+			BudgetRatio: 0.1,
+		},
+		Hedging: HedgingPolicy{
+			MaxAttempts: 2,
+			Delay:       50 * time.Millisecond,
+		},
+		Breaker: BreakerPolicy{
+			FailureRatio:   0.5,
+			Window:         30 * time.Second,
+			MinRequests:    20,
+			OpenTimeout:    10 * time.Second,
+			HalfOpenProbes: 2,
+		},
+		Bulkhead: BulkheadPolicy{
+			MaxConcurrency: 100,
+		},
+	}
+}
+
+// Validate checks a fully resolved policy.
+func Validate(value Policy) error {
+	if value.Timeout <= 0 {
+		return invalidPolicy("timeout must be positive")
+	}
+	if err := validateRetry(value.Retry); err != nil {
+		return err
+	}
+	if err := validateHedging(value.Hedging); err != nil {
+		return err
+	}
+	if value.Retry.Enabled && value.Hedging.Enabled {
+		return invalidPolicy("retry and hedging are mutually exclusive")
+	}
+	if err := validateBreaker(value.Breaker); err != nil {
+		return err
+	}
+	if err := validateBulkhead(value.Bulkhead); err != nil {
+		return err
+	}
+	if err := validateRateLimit(value.RateLimit); err != nil {
+		return err
+	}
+	if err := validateLoadShedding(value.LoadShedding); err != nil {
+		return err
+	}
+	if err := ValidateStream(value.Stream); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Optional distinguishes an omitted patch field from an explicit zero value.
+type Optional[T any] struct {
+	value T
+	set   bool
+}
+
+// Some returns an Optional containing value.
+func Some[T any](value T) Optional[T] {
+	return Optional[T]{value: value, set: true}
+}
+
+// Get returns the contained value and whether it was explicitly set.
+func (optional Optional[T]) Get() (T, bool) {
+	return optional.value, optional.set
+}
+
+// Patch selectively replaces fields in a Policy.
+type Patch struct {
+	Timeout      Optional[time.Duration]
+	Retry        Optional[RetryPolicy]
+	Hedging      Optional[HedgingPolicy]
+	Breaker      Optional[BreakerPolicy]
+	Bulkhead     Optional[BulkheadPolicy]
+	RateLimit    Optional[RateLimitPolicy]
+	LoadShedding Optional[LoadSheddingPolicy]
+	Stream       Optional[StreamPolicy]
+}
+
+func (patch Patch) apply(base Policy) Policy {
+	if value, ok := patch.Timeout.Get(); ok {
+		base.Timeout = value
+	}
+	if value, ok := patch.Retry.Get(); ok {
+		base.Retry = value
+	}
+	if value, ok := patch.Hedging.Get(); ok {
+		base.Hedging = value
+	}
+	if value, ok := patch.Breaker.Get(); ok {
+		base.Breaker = value
+	}
+	if value, ok := patch.Bulkhead.Get(); ok {
+		base.Bulkhead = value
+	}
+	if value, ok := patch.RateLimit.Get(); ok {
+		base.RateLimit = value
+	}
+	if value, ok := patch.LoadShedding.Get(); ok {
+		base.LoadShedding = value
+	}
+	if value, ok := patch.Stream.Get(); ok {
+		base.Stream = value
+	}
+	return base
+}
+
+func validateRetry(value RetryPolicy) error {
+	if value.MaxAttempts < 0 ||
+		value.BackoffMin < 0 ||
+		value.BackoffMax < 0 ||
+		invalidRatio(value.BudgetRatio) {
+		return invalidPolicy("retry contains a negative or non-finite value")
+	}
+	if !value.Enabled {
+		return nil
+	}
+	if !value.Idempotent {
+		return invalidPolicy("retry requires an idempotent operation")
+	}
+	if value.MaxAttempts < minRetryAttempts || value.MaxAttempts > maxRetryAttempts {
+		return invalidPolicy("retry max attempts must be between %d and %d", minRetryAttempts, maxRetryAttempts)
+	}
+	if value.BackoffMin <= 0 || value.BackoffMax < value.BackoffMin {
+		return invalidPolicy("retry backoff range is invalid")
+	}
+	if value.BudgetRatio <= 0 || value.BudgetRatio > 1 {
+		return invalidPolicy("retry budget ratio must be in (0, 1]")
+	}
+	return nil
+}
+
+func validateHedging(value HedgingPolicy) error {
+	if value.MaxAttempts < 0 || value.Delay < 0 {
+		return invalidPolicy("hedging contains a negative value")
+	}
+	if !value.Enabled {
+		return nil
+	}
+	if !value.Idempotent {
+		return invalidPolicy("hedging requires an idempotent operation")
+	}
+	if value.MaxAttempts < minHedgeAttempts || value.MaxAttempts > maxHedgeAttempts {
+		return invalidPolicy("hedging max attempts must be between %d and %d", minHedgeAttempts, maxHedgeAttempts)
+	}
+	if value.Delay <= 0 {
+		return invalidPolicy("hedging delay must be positive")
+	}
+	return nil
+}
+
+func validateBreaker(value BreakerPolicy) error {
+	if invalidRatio(value.FailureRatio) ||
+		value.Window < 0 ||
+		value.MinRequests < 0 ||
+		value.OpenTimeout < 0 ||
+		value.HalfOpenProbes < 0 {
+		return invalidPolicy("breaker contains a negative or non-finite value")
+	}
+	if !value.Enabled {
+		return nil
+	}
+	if value.FailureRatio <= 0 || value.FailureRatio > 1 {
+		return invalidPolicy("breaker failure ratio must be in (0, 1]")
+	}
+	if value.Window <= 0 ||
+		value.MinRequests <= 0 ||
+		value.OpenTimeout <= 0 ||
+		value.HalfOpenProbes <= 0 {
+		return invalidPolicy("breaker thresholds must be positive")
+	}
+	return nil
+}
+
+func validateBulkhead(value BulkheadPolicy) error {
+	if value.MaxConcurrency < 0 ||
+		value.MaxQueue < 0 ||
+		value.QueueTimeout < 0 {
+		return invalidPolicy("bulkhead contains a negative value")
+	}
+	if !value.Enabled {
+		return nil
+	}
+	if value.MaxConcurrency <= 0 {
+		return invalidPolicy("bulkhead max concurrency must be positive")
+	}
+	if value.MaxQueue > 0 && value.QueueTimeout <= 0 {
+		return invalidPolicy("bulkhead queue requires a positive timeout")
+	}
+	if value.MaxQueue == 0 && value.QueueTimeout > 0 {
+		return invalidPolicy("bulkhead queue timeout requires a queue")
+	}
+	return nil
+}
+
+func validateRateLimit(value RateLimitPolicy) error {
+	if math.IsNaN(value.RequestsPerSecond) ||
+		math.IsInf(value.RequestsPerSecond, 0) ||
+		value.RequestsPerSecond < 0 ||
+		value.Burst < 0 ||
+		value.MaxConcurrency < 0 {
+		return invalidPolicy("rate limit contains a negative or non-finite value")
+	}
+	if !value.Enabled {
+		return nil
+	}
+	hasRate := value.RequestsPerSecond > 0 || value.Burst > 0
+	if hasRate && (value.RequestsPerSecond <= 0 || value.Burst <= 0) {
+		return invalidPolicy("rate limit requires both requests per second and burst")
+	}
+	if !hasRate && value.MaxConcurrency <= 0 {
+		return invalidPolicy("rate limit requires a rate or concurrency limit")
+	}
+	return nil
+}
+
+func validateLoadShedding(value LoadSheddingPolicy) error {
+	if value.MaxConcurrency < 0 ||
+		math.IsNaN(value.CPUThreshold) ||
+		math.IsInf(value.CPUThreshold, 0) ||
+		value.CPUThreshold < 0 ||
+		value.CPUThreshold > 1 {
+		return invalidPolicy("load shedding contains an invalid threshold")
+	}
+	if value.Enabled && value.MaxConcurrency <= 0 && value.CPUThreshold <= 0 {
+		return invalidPolicy("load shedding requires a concurrency or CPU threshold")
+	}
+	return nil
+}
+
+// ValidateStream checks one resolved stream message policy.
+func ValidateStream(value StreamPolicy) error {
+	if value.MaxSendMessages < 0 ||
+		value.MaxReceiveMessages < 0 ||
+		math.IsNaN(value.MessagesPerSecond) ||
+		math.IsInf(value.MessagesPerSecond, 0) ||
+		value.MessagesPerSecond < 0 ||
+		value.Burst < 0 ||
+		value.MaxConcurrency < 0 {
+		return invalidPolicy("stream policy contains an invalid limit")
+	}
+	if !value.Enabled {
+		return nil
+	}
+	hasRate := value.MessagesPerSecond > 0 || value.Burst > 0
+	if hasRate && (value.MessagesPerSecond <= 0 || value.Burst <= 0) {
+		return invalidPolicy(
+			"stream message rate requires both messages per second and burst",
+		)
+	}
+	if value.MaxSendMessages <= 0 &&
+		value.MaxReceiveMessages <= 0 &&
+		!hasRate &&
+		value.MaxConcurrency <= 0 {
+		return invalidPolicy("stream policy requires at least one limit")
+	}
+	return nil
+}
+
+func invalidRatio(value float64) bool {
+	return math.IsNaN(value) || math.IsInf(value, 0) || value < 0
+}
+
+func invalidPolicy(format string, values ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidPolicy, fmt.Sprintf(format, values...))
+}

--- a/governance/policy/provider.go
+++ b/governance/policy/provider.go
@@ -1,0 +1,24 @@
+package policy
+
+import (
+	"context"
+
+	"github.com/keelab/keelith/operation"
+)
+
+// Resolver returns the current fully resolved policy for an Operation.
+type Resolver interface {
+	Resolve(operation.Operation) Policy
+}
+
+// Provider loads and watches complete policy definitions.
+type Provider interface {
+	Load(context.Context) (Definition, error)
+	Watch(context.Context) (Watcher, error)
+}
+
+// Watcher yields complete policy definitions.
+type Watcher interface {
+	Next(context.Context) (Definition, error)
+	Close() error
+}

--- a/governance/policy/store.go
+++ b/governance/policy/store.go
@@ -1,0 +1,352 @@
+package policy
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unicode"
+
+	"github.com/keelab/keelith/operation"
+)
+
+// ServiceRule applies a Patch to every operation in a service.
+type ServiceRule struct {
+	Service string
+	Patch   Patch
+}
+
+// MethodRule applies a Patch to one exact operation identity.
+type MethodRule struct {
+	Operation operation.Operation
+	Patch     Patch
+}
+
+// MatchRule applies Patch to the first matching non-exact Operation.
+//
+// Rules are evaluated in declaration order after exact MethodRule lookup and
+// before returning the service/global base policy.
+type MatchRule struct {
+	Name    string
+	Matcher operation.Matcher
+	Patch   Patch
+
+	servicePatches map[string]Patch
+}
+
+// Definition is a complete, versioned policy configuration.
+type Definition struct {
+	Revision string
+	Global   Policy
+	Services []ServiceRule
+	Matchers []MatchRule
+	Methods  []MethodRule
+}
+
+type compiledMatchRule struct {
+	name     string
+	matcher  operation.Matcher
+	patch    Patch
+	services map[string]Patch
+}
+
+// Snapshot is an immutable compiled policy definition.
+type Snapshot struct {
+	revision string
+	global   Policy
+	services map[string]Policy
+	matchers []compiledMatchRule
+	methods  map[string]Policy
+}
+
+// Revision returns the source revision of the Snapshot.
+func (snapshot Snapshot) Revision() string {
+	return snapshot.revision
+}
+
+// Global returns the validated global policy.
+func (snapshot Snapshot) Global() Policy {
+	return snapshot.global
+}
+
+// Resolve applies exact method, ordered matcher, service, and global precedence.
+func (snapshot Snapshot) Resolve(target operation.Operation) Policy {
+	key := target.PolicyKey()
+	if value, ok := snapshot.methods[key]; ok {
+		return value
+	}
+	base := snapshot.global
+	if value, ok := snapshot.services[target.Service()]; ok {
+		base = value
+	}
+	resolved := base
+	for _, rule := range snapshot.matchers {
+		if safeMatch(rule.matcher, target) {
+			patch := rule.patch
+			if servicePatch, ok := rule.services[target.Service()]; ok {
+				patch = servicePatch
+			}
+			resolved = patch.apply(base)
+			break
+		}
+	}
+	return resolved
+}
+
+// Store atomically publishes immutable policy snapshots.
+type Store struct {
+	updateMu sync.Mutex
+	current  atomic.Pointer[Snapshot]
+}
+
+// Description is a value-free Store snapshot.
+type Description struct {
+	Revision     string
+	ServiceRules int
+	MatcherRules int
+	MethodRules  int
+}
+
+// NewStore validates definition and creates a Store.
+func NewStore(definition Definition) (*Store, error) {
+	snapshot, err := compile(definition)
+	if err != nil {
+		return nil, err
+	}
+	store := &Store{}
+	store.current.Store(&snapshot)
+	return store, nil
+}
+
+// Update atomically publishes a new revision. A duplicate revision is ignored.
+func (store *Store) Update(definition Definition) (bool, error) {
+	store.updateMu.Lock()
+	defer store.updateMu.Unlock()
+
+	current := store.current.Load()
+	if current != nil && current.revision == definition.Revision {
+		return false, nil
+	}
+	next, err := compile(definition)
+	if err != nil {
+		return false, err
+	}
+	store.current.Store(&next)
+	return true, nil
+}
+
+// Resolve returns the complete policy for target.
+func (store *Store) Resolve(target operation.Operation) Policy {
+	return store.current.Load().Resolve(target)
+}
+
+// Current returns the current immutable Snapshot.
+func (store *Store) Current() Snapshot {
+	return *store.current.Load()
+}
+
+// Describe returns revision and rule cardinality without policy values.
+func (store *Store) Describe() Description {
+	if store == nil {
+		return Description{}
+	}
+	current := store.current.Load()
+	if current == nil {
+		return Description{}
+	}
+	return Description{
+		Revision:     current.revision,
+		ServiceRules: len(current.services),
+		MatcherRules: len(current.matchers),
+		MethodRules:  len(current.methods),
+	}
+}
+
+func compile(definition Definition) (Snapshot, error) {
+	if !validIdentity(definition.Revision) {
+		return Snapshot{}, invalidDefinition("revision %q is invalid", definition.Revision)
+	}
+	if err := Validate(definition.Global); err != nil {
+		return Snapshot{}, fmt.Errorf("%w: global: %w", ErrInvalidDefinition, err)
+	}
+
+	snapshot := Snapshot{
+		revision: definition.Revision,
+		global:   definition.Global,
+		services: make(map[string]Policy, len(definition.Services)),
+		matchers: make([]compiledMatchRule, 0, len(definition.Matchers)),
+		methods:  make(map[string]Policy, len(definition.Methods)),
+	}
+	for _, rule := range definition.Services {
+		if !validIdentity(rule.Service) {
+			return Snapshot{}, invalidDefinition("service %q is invalid", rule.Service)
+		}
+		if _, exists := snapshot.services[rule.Service]; exists {
+			return Snapshot{}, invalidDefinition("service %q is duplicated", rule.Service)
+		}
+		resolved := rule.Patch.apply(definition.Global)
+		if err := Validate(resolved); err != nil {
+			return Snapshot{}, fmt.Errorf(
+				"%w: service %q: %w",
+				ErrInvalidDefinition,
+				rule.Service,
+				err,
+			)
+		}
+		snapshot.services[rule.Service] = resolved
+	}
+	matcherNames := make(map[string]struct{}, len(definition.Matchers))
+	for _, rule := range definition.Matchers {
+		if !validIdentity(rule.Name) {
+			return Snapshot{}, invalidDefinition(
+				"matcher name %q is invalid",
+				rule.Name,
+			)
+		}
+		if _, duplicate := matcherNames[rule.Name]; duplicate {
+			return Snapshot{}, invalidDefinition(
+				"matcher name %q is duplicated",
+				rule.Name,
+			)
+		}
+		if isNilMatcher(rule.Matcher) {
+			return Snapshot{}, invalidDefinition(
+				"matcher %q is nil",
+				rule.Name,
+			)
+		}
+		if err := validateMatchPatch(
+			rule.Name,
+			rule.Patch,
+			rule.servicePatches,
+			definition.Global,
+			snapshot.services,
+		); err != nil {
+			return Snapshot{}, err
+		}
+		matcherNames[rule.Name] = struct{}{}
+		snapshot.matchers = append(snapshot.matchers, compiledMatchRule{
+			name:     rule.Name,
+			matcher:  rule.Matcher,
+			patch:    rule.Patch,
+			services: cloneMatchPatches(rule.servicePatches),
+		})
+	}
+	for _, rule := range definition.Methods {
+		if !validOperation(rule.Operation) {
+			return Snapshot{}, invalidDefinition("method operation %q is invalid", rule.Operation.PolicyKey())
+		}
+		key := rule.Operation.PolicyKey()
+		if _, exists := snapshot.methods[key]; exists {
+			return Snapshot{}, invalidDefinition("method %q is duplicated", key)
+		}
+		base := definition.Global
+		if service, ok := snapshot.services[rule.Operation.Service()]; ok {
+			base = service
+		}
+		resolved := rule.Patch.apply(base)
+		if err := Validate(resolved); err != nil {
+			return Snapshot{}, fmt.Errorf(
+				"%w: method %q: %w",
+				ErrInvalidDefinition,
+				key,
+				err,
+			)
+		}
+		snapshot.methods[key] = resolved
+	}
+	return snapshot, nil
+}
+
+func validateMatchPatch(
+	name string,
+	patch Patch,
+	servicePatches map[string]Patch,
+	global Policy,
+	services map[string]Policy,
+) error {
+	if err := Validate(patch.apply(global)); err != nil {
+		return fmt.Errorf(
+			"%w: matcher %q with global base: %w",
+			ErrInvalidDefinition,
+			name,
+			err,
+		)
+	}
+	for service, base := range services {
+		servicePatch := patch
+		if configured, ok := servicePatches[service]; ok {
+			servicePatch = configured
+		}
+		if err := Validate(servicePatch.apply(base)); err != nil {
+			return fmt.Errorf(
+				"%w: matcher %q with service %q: %w",
+				ErrInvalidDefinition,
+				name,
+				service,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func cloneMatchPatches(source map[string]Patch) map[string]Patch {
+	if len(source) == 0 {
+		return nil
+	}
+	cloned := make(map[string]Patch, len(source))
+	for service, patch := range source {
+		cloned[service] = patch
+	}
+	return cloned
+}
+
+func safeMatch(matcher operation.Matcher, target operation.Operation) (
+	matched bool,
+) {
+	defer func() {
+		if recover() != nil {
+			matched = false
+		}
+	}()
+	return matcher.Match(target)
+}
+
+func isNilMatcher(matcher operation.Matcher) bool {
+	if matcher == nil {
+		return true
+	}
+	value := reflect.ValueOf(matcher)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func validIdentity(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validOperation(target operation.Operation) bool {
+	return target.Transport() != "" &&
+		validIdentity(target.Service()) &&
+		validIdentity(target.Method()) &&
+		target.Kind() != ""
+}
+
+func invalidDefinition(format string, values ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidDefinition, fmt.Sprintf(format, values...))
+}

--- a/governance/ratelimit/distributed.go
+++ b/governance/ratelimit/distributed.go
@@ -1,0 +1,429 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/operation"
+)
+
+const (
+	defaultBackendTimeout = 50 * time.Millisecond
+	maxSubjectBytes       = 256
+)
+
+var (
+	// ErrUnavailable reports a fail-closed shared quota backend failure.
+	ErrUnavailable = kerrors.New(
+		503,
+		"RATE_LIMIT_UNAVAILABLE",
+		"distributed rate limit is unavailable",
+	)
+	// ErrInvalidSubject reports an unsafe quota key or cost.
+	ErrInvalidSubject = errors.New("ratelimit: invalid distributed subject")
+	// ErrInvalidDecision reports a malformed backend result.
+	ErrInvalidDecision = errors.New("ratelimit: invalid distributed decision")
+)
+
+// FailureMode defines behavior when the shared quota backend fails.
+type FailureMode uint8
+
+const (
+	// FailClosed rejects requests when the backend cannot decide.
+	FailClosed FailureMode = iota
+	// FailOpen allows requests with only local concurrency protection.
+	FailOpen
+	// LocalFallback applies the complete policy using a per-process limiter.
+	LocalFallback
+)
+
+// Degradation identifies an admitted request whose global quota was not
+// enforced.
+type Degradation string
+
+const (
+	// DegradationNone means the shared quota backend decided successfully.
+	DegradationNone Degradation = ""
+	// DegradationFailOpen means the backend failed and the call was admitted.
+	DegradationFailOpen Degradation = "fail-open"
+	// DegradationLocalFallback means a per-process token bucket replaced the
+	// shared quota.
+	DegradationLocalFallback Degradation = "local-fallback"
+)
+
+// Subject is one explicit quota identity and weighted request cost.
+type Subject struct {
+	Key  string
+	Cost int
+}
+
+// SubjectFunc derives a quota subject from transport-neutral call facts.
+type SubjectFunc func(
+	context.Context,
+	operation.Operation,
+	any,
+) (Subject, error)
+
+// Quota is one backend-neutral token bucket request.
+type Quota struct {
+	Key   string
+	Rate  float64
+	Burst int
+	Cost  int
+}
+
+// Decision is one shared quota result.
+type Decision struct {
+	Allowed    bool
+	Remaining  float64
+	RetryAfter time.Duration
+}
+
+// DistributedBackend atomically checks and consumes shared quota.
+type DistributedBackend interface {
+	Allow(context.Context, Quota) (Decision, error)
+}
+
+// DistributedConfig configures shared quota and explicit failure behavior.
+type DistributedConfig struct {
+	Backend        DistributedBackend
+	Mode           FailureMode
+	LocalPool      *Pool
+	Subject        SubjectFunc
+	BackendTimeout time.Duration
+}
+
+// DistributedDescription is a low-cardinality operational snapshot.
+type DistributedDescription struct {
+	Mode           FailureMode
+	Accepted       uint64
+	Rejected       uint64
+	BackendErrors  uint64
+	FailOpen       uint64
+	LocalFallback  uint64
+	LastError      string
+	BackendTimeout time.Duration
+}
+
+// DistributedLimiter combines a shared rate with local concurrency.
+type DistributedLimiter struct {
+	backend        DistributedBackend
+	mode           FailureMode
+	local          *Pool
+	subject        SubjectFunc
+	backendTimeout time.Duration
+
+	mu            sync.Mutex
+	accepted      uint64
+	rejected      uint64
+	backendErrors uint64
+	failOpen      uint64
+	localFallback uint64
+	lastError     string
+}
+
+// DistributedPermit owns one local concurrency slot.
+type DistributedPermit struct {
+	local       *Permit
+	decision    Decision
+	degradation Degradation
+}
+
+// NewDistributedLimiter constructs an instance-scoped shared quota
+// controller.
+func NewDistributedLimiter(config DistributedConfig) (*DistributedLimiter, error) {
+	if isNil(config.Backend) {
+		return nil, fmt.Errorf("%w: distributed backend is nil", ErrInvalidOption)
+	}
+	if config.Mode != FailClosed && config.Mode != FailOpen && config.Mode != LocalFallback {
+		return nil, fmt.Errorf("%w: failure mode %d", ErrInvalidOption, config.Mode)
+	}
+	local := config.LocalPool
+	if local == nil {
+		local = NewPool(nil)
+	}
+	subject := config.Subject
+	if subject == nil {
+		subject = func(_ context.Context, target operation.Operation, _ any) (Subject, error) {
+			return Subject{Key: target.PolicyKey(), Cost: 1}, nil
+		}
+	}
+	backendTimeout := config.BackendTimeout
+	if backendTimeout == 0 {
+		backendTimeout = defaultBackendTimeout
+	}
+	if backendTimeout <= 0 {
+		return nil, fmt.Errorf("%w: backend timeout must be positive", ErrInvalidOption)
+	}
+	return &DistributedLimiter{
+		backend:        config.Backend,
+		mode:           config.Mode,
+		local:          local,
+		subject:        subject,
+		backendTimeout: backendTimeout,
+	}, nil
+}
+
+// Acquire checks shared rate and obtains a local concurrency permit.
+func (l *DistributedLimiter) Acquire(ctx context.Context, target operation.Operation, request any, config policy.RateLimitPolicy) (*DistributedPermit, error) {
+	if l == nil || ctx == nil {
+		return nil, fmt.Errorf("%w: limiter or context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	if target.Transport() == "" || target.Service() == "" || target.Method() == "" {
+		return nil, fmt.Errorf("%w: operation is invalid", ErrInvalidSubject)
+	}
+	if !config.Enabled {
+		return &DistributedPermit{}, nil
+	}
+	if err := validate(config); err != nil {
+		return nil, err
+	}
+	hasRate := config.RequestsPerSecond > 0
+	if !hasRate {
+		return l.acquireLocal(target.PolicyKey(), concurrencyPolicy(config), Decision{Allowed: true}, DegradationNone)
+	}
+
+	subject, err := l.subject(ctx, target, request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSubject, err)
+	}
+	if err := validateSubject(subject); err != nil {
+		return nil, err
+	}
+	if subject.Cost > config.Burst {
+		l.recordRejected()
+		return nil, ErrLimited
+	}
+	quota := Quota{
+		Key:   subject.Key,
+		Rate:  config.RequestsPerSecond,
+		Burst: config.Burst,
+		Cost:  subject.Cost,
+	}
+	backendCtx, cancel := context.WithTimeout(ctx, l.backendTimeout)
+	decision, backendErr := l.backend.Allow(backendCtx, quota)
+	cancel()
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	if backendErr == nil {
+		if decisionErr := validateDecision(decision); decisionErr != nil {
+			backendErr = decisionErr
+		} else {
+			l.clearLastError()
+			if !decision.Allowed {
+				l.recordRejected()
+				return nil, limitedError(decision)
+			}
+			return l.acquireLocal(target.PolicyKey(), concurrencyPolicy(config), decision, DegradationNone)
+		}
+	}
+
+	l.recordBackendError(backendErr)
+	switch l.mode {
+	case FailClosed:
+		l.recordRejected()
+		return nil, kerrors.Wrap(backendErr, ErrUnavailable.Code(), ErrUnavailable.Reason(), ErrUnavailable.Message())
+	case FailOpen:
+		l.recordFailOpen()
+		return l.acquireLocal(target.PolicyKey(), concurrencyPolicy(config), Decision{Allowed: true}, DegradationFailOpen)
+	case LocalFallback:
+		l.recordLocalFallback()
+		return l.acquireLocal(target.PolicyKey(), config, Decision{Allowed: true}, DegradationLocalFallback)
+	default:
+		return nil, fmt.Errorf("%w: failure mode %d", ErrInvalidOption, l.mode)
+	}
+}
+
+// Release returns the local concurrency slot exactly once.
+func (p *DistributedPermit) Release() {
+	if p == nil {
+		return
+	}
+	p.local.Release()
+}
+
+// Decision returns the shared backend decision, or the admitted degraded
+// decision.
+func (p *DistributedPermit) Decision() Decision {
+	if p == nil {
+		return Decision{}
+	}
+	return p.decision
+}
+
+// Degraded reports whether shared quota enforcement was bypassed.
+func (p *DistributedPermit) Degraded() bool {
+	return p != nil && p.degradation != DegradationNone
+}
+
+// Degradation returns the explicit fallback path.
+func (p *DistributedPermit) Degradation() Degradation {
+	if p == nil {
+		return DegradationNone
+	}
+	return p.degradation
+}
+
+// Describe returns low-cardinality counters without Subject keys.
+func (l *DistributedLimiter) Describe() DistributedDescription {
+	if l == nil {
+		return DistributedDescription{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return DistributedDescription{
+		Mode:           l.mode,
+		Accepted:       l.accepted,
+		Rejected:       l.rejected,
+		BackendErrors:  l.backendErrors,
+		FailOpen:       l.failOpen,
+		LocalFallback:  l.localFallback,
+		LastError:      l.lastError,
+		BackendTimeout: l.backendTimeout,
+	}
+}
+
+// LocalDescriptions returns sorted local concurrency/fallback state.
+func (l *DistributedLimiter) LocalDescriptions() []Description {
+	if l == nil {
+		return nil
+	}
+	return l.local.Describe()
+}
+
+func (l *DistributedLimiter) acquireLocal(key string, config policy.RateLimitPolicy, decision Decision, degradation Degradation) (*DistributedPermit, error) {
+	if !config.Enabled {
+		l.recordAccepted()
+		return &DistributedPermit{
+			decision:    decision,
+			degradation: degradation,
+		}, nil
+	}
+	local, err := l.local.Get(key).Acquire(config)
+	if err != nil {
+		l.recordRejected()
+		return nil, err
+	}
+	l.recordAccepted()
+	return &DistributedPermit{
+		local:       local,
+		decision:    decision,
+		degradation: degradation,
+	}, nil
+}
+
+func (l *DistributedLimiter) recordAccepted() {
+	l.mu.Lock()
+	l.accepted++
+	l.mu.Unlock()
+}
+
+func (l *DistributedLimiter) recordRejected() {
+	l.mu.Lock()
+	l.rejected++
+	l.mu.Unlock()
+}
+
+func (l *DistributedLimiter) recordBackendError(err error) {
+	l.mu.Lock()
+	l.backendErrors++
+	l.lastError = boundedError(err, 512)
+	l.mu.Unlock()
+}
+
+func (l *DistributedLimiter) recordFailOpen() {
+	l.mu.Lock()
+	l.failOpen++
+	l.mu.Unlock()
+}
+
+func (l *DistributedLimiter) recordLocalFallback() {
+	l.mu.Lock()
+	l.localFallback++
+	l.mu.Unlock()
+}
+
+func (l *DistributedLimiter) clearLastError() {
+	l.mu.Lock()
+	l.lastError = ""
+	l.mu.Unlock()
+}
+
+func concurrencyPolicy(config policy.RateLimitPolicy) policy.RateLimitPolicy {
+	if config.MaxConcurrency <= 0 {
+		return policy.RateLimitPolicy{}
+	}
+	return policy.RateLimitPolicy{
+		Enabled:        true,
+		MaxConcurrency: config.MaxConcurrency,
+	}
+}
+
+func validateSubject(subject Subject) error {
+	if strings.TrimSpace(subject.Key) != subject.Key ||
+		subject.Key == "" ||
+		len(subject.Key) > maxSubjectBytes ||
+		!utf8.ValidString(subject.Key) ||
+		subject.Cost <= 0 {
+		return fmt.Errorf("%w: key or cost is invalid", ErrInvalidSubject)
+	}
+	for _, character := range subject.Key {
+		if unicode.IsControl(character) {
+			return fmt.Errorf("%w: key contains control characters", ErrInvalidSubject)
+		}
+	}
+	return nil
+}
+
+func validateDecision(decision Decision) error {
+	if decision.Remaining < 0 ||
+		math.IsNaN(decision.Remaining) ||
+		math.IsInf(decision.Remaining, 0) ||
+		decision.RetryAfter < 0 {
+		return fmt.Errorf("%w: negative or non-finite value", ErrInvalidDecision)
+	}
+	return nil
+}
+
+func limitedError(decision Decision) error {
+	if decision.RetryAfter <= 0 {
+		return ErrLimited
+	}
+	milliseconds := decision.RetryAfter.Milliseconds()
+	if milliseconds <= 0 {
+		milliseconds = 1
+	}
+	return ErrLimited.Clone(kerrors.WithMetadata(map[string]string{
+		"retry-after-ms": strconv.FormatInt(milliseconds, 10),
+	}))
+}
+
+func boundedError(err error, limit int) string {
+	if err == nil {
+		return ""
+	}
+	value := strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return ' '
+		}
+		return character
+	}, err.Error())
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}

--- a/governance/ratelimit/distributed_middleware.go
+++ b/governance/ratelimit/distributed_middleware.go
@@ -1,0 +1,47 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// NewDistributedMiddleware creates transport-neutral shared quota
+// Middleware.
+func NewDistributedMiddleware(resolver policy.Resolver, limiter *DistributedLimiter) (middleware.Middleware, error) {
+	if isNil(resolver) || limiter == nil {
+		return nil, fmt.Errorf(
+			"%w: resolver or distributed limiter is nil",
+			ErrInvalidOption,
+		)
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, fmt.Errorf("%w: operation is missing", ErrInvalidOption)
+			}
+			config := policy.Resolve(ctx, resolver, target).RateLimit
+			if !config.Enabled {
+				return next(ctx, request)
+			}
+			permit, err := limiter.Acquire(ctx, target, request, config)
+			if err != nil {
+				return nil, err
+			}
+			defer permit.Release()
+			return next(ctx, request)
+		}
+	}, nil
+}

--- a/governance/ratelimit/limiter.go
+++ b/governance/ratelimit/limiter.go
@@ -1,0 +1,243 @@
+// Package ratelimit provides per-Operation token and concurrency limits.
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/policy"
+)
+
+var (
+	// ErrLimited reports that a rate or concurrency limit rejected a call.
+	ErrLimited = kerrors.New(429, "RATE_LIMITED", "request rate is limited")
+	// ErrInvalidOption reports an invalid limiter dependency or policy.
+	ErrInvalidOption = errors.New("ratelimit: invalid option")
+)
+
+// Clock supplies deterministic token refill time.
+type Clock interface {
+	Now() time.Time
+}
+
+// Description is a low-cardinality limiter snapshot.
+type Description struct {
+	Key      string
+	Tokens   float64
+	Inflight int
+	Accepted uint64
+	Rejected uint64
+}
+
+// Limiter combines a token bucket with a concurrency gate.
+type Limiter struct {
+	clock Clock
+
+	mu          sync.Mutex
+	initialized bool
+	rate        float64
+	burst       int
+	last        time.Time
+	tokens      float64
+	inflight    int
+	accepted    uint64
+	rejected    uint64
+}
+
+// Permit releases one concurrency slot.
+type Permit struct {
+	limiter *Limiter
+	once    sync.Once
+}
+
+// NewLimiter creates an isolated Limiter.
+func NewLimiter(clock Clock) *Limiter {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	return &Limiter{clock: clock}
+}
+
+// Acquire consumes one token and concurrency slot.
+func (l *Limiter) Acquire(config policy.RateLimitPolicy) (*Permit, error) {
+	if l == nil {
+		return nil, fmt.Errorf("%w: limiter is nil", ErrInvalidOption)
+	}
+	if !config.Enabled {
+		return &Permit{}, nil
+	}
+	if err := validate(config); err != nil {
+		return nil, err
+	}
+	now := l.clock.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.configure(now, config)
+	l.refill(now)
+	if config.MaxConcurrency > 0 && l.inflight >= config.MaxConcurrency {
+		l.rejected++
+		return nil, ErrLimited
+	}
+	if config.RequestsPerSecond > 0 && l.tokens < 1 {
+		l.rejected++
+		return nil, ErrLimited
+	}
+	if config.RequestsPerSecond > 0 {
+		l.tokens--
+	}
+	l.inflight++
+	l.accepted++
+	return &Permit{limiter: l}, nil
+}
+
+// Release returns one concurrency slot. Repeated calls are ignored.
+func (p *Permit) Release() {
+	if p == nil || p.limiter == nil {
+		return
+	}
+	p.once.Do(func() {
+		p.limiter.mu.Lock()
+		if p.limiter.inflight > 0 {
+			p.limiter.inflight--
+		}
+		p.limiter.mu.Unlock()
+	})
+}
+
+// Describe returns a debug snapshot.
+func (l *Limiter) Describe() Description {
+	if l == nil {
+		return Description{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return Description{
+		Tokens:   l.tokens,
+		Inflight: l.inflight,
+		Accepted: l.accepted,
+		Rejected: l.rejected,
+	}
+}
+
+func (l *Limiter) configure(now time.Time, config policy.RateLimitPolicy) {
+	if l.initialized && l.rate == config.RequestsPerSecond && l.burst == config.Burst {
+		return
+	}
+	l.initialized = true
+	l.rate = config.RequestsPerSecond
+	l.burst = config.Burst
+	l.last = now
+	l.tokens = float64(config.Burst)
+}
+
+func (l *Limiter) refill(now time.Time) {
+	if l.rate <= 0 || now.Before(l.last) {
+		l.last = now
+		return
+	}
+	elapsed := now.Sub(l.last).Seconds()
+	l.tokens = math.Min(
+		float64(l.burst),
+		l.tokens+elapsed*l.rate,
+	)
+	l.last = now
+}
+
+func validate(config policy.RateLimitPolicy) error {
+	hasRate := config.RequestsPerSecond > 0 || config.Burst > 0
+	if config.RequestsPerSecond < 0 ||
+		math.IsNaN(config.RequestsPerSecond) ||
+		math.IsInf(config.RequestsPerSecond, 0) ||
+		config.Burst < 0 ||
+		config.MaxConcurrency < 0 ||
+		hasRate && (config.RequestsPerSecond <= 0 || config.Burst <= 0) ||
+		!hasRate && config.MaxConcurrency <= 0 {
+		return fmt.Errorf("%w: resolved rate-limit policy is invalid", policy.ErrInvalidPolicy)
+	}
+	return nil
+}
+
+// Pool owns limiter state by stable Operation policy key.
+type Pool struct {
+	clock Clock
+
+	mu       sync.Mutex
+	limiters map[string]*Limiter
+}
+
+// NewPool creates an isolated limiter pool.
+func NewPool(clock Clock) *Pool {
+	if isNil(clock) {
+		clock = systemClock{}
+	}
+	return &Pool{clock: clock, limiters: make(map[string]*Limiter)}
+}
+
+// Get returns the stable limiter for key.
+func (p *Pool) Get(key string) *Limiter {
+	if p == nil {
+		return nil
+	}
+	normalized := strings.TrimSpace(key)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	subject := p.limiters[normalized]
+	if subject == nil {
+		subject = NewLimiter(p.clock)
+		p.limiters[normalized] = subject
+	}
+	return subject
+}
+
+// Describe returns sorted low-cardinality snapshots.
+func (p *Pool) Describe() []Description {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	entries := make(map[string]*Limiter, len(p.limiters))
+	for key, limiter := range p.limiters {
+		entries[key] = limiter
+	}
+	p.mu.Unlock()
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]Description, 0, len(keys))
+
+	for _, key := range keys {
+		description := entries[key].Describe()
+		description.Key = key
+		result = append(result, description)
+	}
+	return result
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/ratelimit/middleware.go
+++ b/governance/ratelimit/middleware.go
@@ -1,0 +1,43 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+// New creates per-Operation rate-limit Middleware.
+func New(resolver policy.Resolver, pool *Pool) (middleware.Middleware, error) {
+	if isNil(resolver) || pool == nil {
+		return nil, fmt.Errorf("%w: resolver or pool is nil", ErrInvalidOption)
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, fmt.Errorf("%w: operation is missing", ErrInvalidOption)
+			}
+			config := policy.Resolve(ctx, resolver, target).RateLimit
+			if !config.Enabled {
+				return next(ctx, request)
+			}
+			permit, err := pool.Get(target.PolicyKey()).Acquire(config)
+			if err != nil {
+				return nil, err
+			}
+			defer permit.Release()
+			return next(ctx, request)
+		}
+	}, nil
+}

--- a/governance/retry/budget.go
+++ b/governance/retry/budget.go
@@ -1,0 +1,89 @@
+package retry
+
+import (
+	"math"
+	"sort"
+	"sync"
+)
+
+// BudgetDescription is one stable Operation budget snapshot.
+type BudgetDescription struct {
+	Operation       string
+	Primary         uint64
+	Retries         uint64
+	RejectedRetries uint64
+}
+
+// Budget bounds retry amplification per stable Operation.
+//
+// burst grants a small startup allowance. Long-term additional retries are
+// limited by Policy.BudgetRatio relative to primary requests.
+type Budget struct {
+	burst uint64
+
+	mu      sync.Mutex
+	buckets map[string]budgetBucket
+}
+
+type budgetBucket struct {
+	primary  uint64
+	retries  uint64
+	rejected uint64
+}
+
+// NewBudget creates a ratio budget with burst initial retries per Operation.
+func NewBudget(burst uint64) *Budget {
+	return &Budget{
+		burst:   burst,
+		buckets: make(map[string]budgetBucket),
+	}
+}
+
+func (b *Budget) begin(key string) {
+	b.mu.Lock()
+	bucket := b.buckets[key]
+	bucket.primary++
+	b.buckets[key] = bucket
+	b.mu.Unlock()
+}
+
+func (b *Budget) take(key string, ratio float64) bool {
+	if b == nil || ratio <= 0 || math.IsNaN(ratio) || math.IsInf(ratio, 0) {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	bucket := b.buckets[key]
+	ratioAllowance := uint64(math.Floor(float64(bucket.primary) * ratio))
+	allowed := b.burst + ratioAllowance
+	if bucket.retries >= allowed {
+		bucket.rejected++
+		b.buckets[key] = bucket
+		return false
+	}
+	bucket.retries++
+	b.buckets[key] = bucket
+	return true
+}
+
+// Describe returns sorted, immutable low-cardinality budget state.
+func (b *Budget) Describe() []BudgetDescription {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	result := make([]BudgetDescription, 0, len(b.buckets))
+	for key, bucket := range b.buckets {
+		result = append(result, BudgetDescription{
+			Operation:       key,
+			Primary:         bucket.primary,
+			Retries:         bucket.retries,
+			RejectedRetries: bucket.rejected,
+		})
+	}
+	b.mu.Unlock()
+	sort.Slice(result, func(first, second int) bool {
+		return result[first].Operation < result[second].Operation
+	})
+	return result
+}

--- a/governance/retry/middleware.go
+++ b/governance/retry/middleware.go
@@ -1,0 +1,229 @@
+// Package retry provides deadline-aware, budgeted full-jitter retries.
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"time"
+
+	"github.com/keelab/keelith/governance/attempt"
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+var (
+	// ErrInvalidOption reports an invalid retry dependency or option.
+	ErrInvalidOption = errors.New("retry: invalid option")
+	// ErrMissingOperation reports a call without a stable Operation.
+	ErrMissingOperation = errors.New("retry: operation is missing")
+)
+
+// Clock supplies cancelable backoff timer channels.
+type Clock interface {
+	After(time.Duration) <-chan time.Time
+}
+
+// Random supplies a value in [0, limit) for full jitter.
+type Random interface {
+	Uint64N(limit uint64) uint64
+}
+
+// Option configures retry Middleware.
+type Option interface {
+	apply(*options) error
+}
+
+type optionFunc func(*options) error
+
+func (function optionFunc) apply(options *options) error {
+	return function(options)
+}
+
+type options struct {
+	clock  Clock
+	random Random
+	budget *Budget
+}
+
+// WithClock replaces the production timer source.
+func WithClock(clock Clock) Option {
+	return optionFunc(func(options *options) error {
+		if isNil(clock) {
+			return fmt.Errorf("clock is nil")
+		}
+		options.clock = clock
+		return nil
+	})
+}
+
+// WithRandom replaces the production full-jitter source.
+func WithRandom(random Random) Option {
+	return optionFunc(func(options *options) error {
+		if isNil(random) {
+			return fmt.Errorf("random source is nil")
+		}
+		options.random = random
+		return nil
+	})
+}
+
+// WithBudget replaces the shared ratio budget.
+func WithBudget(budget *Budget) Option {
+	return optionFunc(func(options *options) error {
+		if budget == nil {
+			return fmt.Errorf("budget is nil")
+		}
+		options.budget = budget
+		return nil
+	})
+}
+
+// New creates policy-resolved retry Middleware.
+func New(
+	resolver policy.Resolver,
+	optionList ...Option,
+) (middleware.Middleware, error) {
+	if isNil(resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidOption)
+	}
+	settings := options{
+		clock:  realClock{},
+		random: packageRandom{},
+		budget: NewBudget(1),
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	return middlewareFor(resolver, settings), nil
+}
+
+func middlewareFor(resolver policy.Resolver, settings options) middleware.Middleware {
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			if isStreaming(target.Kind()) {
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+			resolved := policy.Resolve(ctx, resolver, target).Retry
+			if attempt.IsProbe(ctx) {
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+			if !resolved.Enabled ||
+				!resolved.Idempotent ||
+				resolved.MaxAttempts < 2 {
+				return next(attempt.WithContext(ctx, 1), request)
+			}
+			if err := validate(resolved); err != nil {
+				return nil, err
+			}
+
+			key := target.PolicyKey()
+			settings.budget.begin(key)
+			var lastErr error
+			for number := 1; number <= resolved.MaxAttempts; number++ {
+				if cause := context.Cause(ctx); cause != nil {
+					return nil, cause
+				}
+				response, err := next(attempt.WithContext(ctx, number), request)
+				if err == nil {
+					return response, nil
+				}
+				lastErr = err
+				if !failure.Retryable(err) || number == resolved.MaxAttempts {
+					return response, err
+				}
+				if cause := context.Cause(ctx); cause != nil {
+					return nil, cause
+				}
+				if !settings.budget.take(key, resolved.BudgetRatio) {
+					return response, err
+				}
+				delay := fullJitter(
+					resolved,
+					number+1,
+					settings.random,
+				)
+				select {
+				case <-ctx.Done():
+					return nil, context.Cause(ctx)
+				case <-settings.clock.After(delay):
+				}
+			}
+			return nil, lastErr
+		}
+	}
+}
+
+func isStreaming(kind operation.Kind) bool {
+	switch kind {
+	case operation.KindClientStream,
+		operation.KindServerStream,
+		operation.KindBidiStream:
+		return true
+	default:
+		return false
+	}
+}
+
+func validate(value policy.RetryPolicy) error {
+	if value.MaxAttempts < 2 || value.BackoffMin <= 0 || value.BackoffMax < value.BackoffMin || value.BudgetRatio <= 0 || value.BudgetRatio > 1 {
+		return fmt.Errorf("%w: resolved retry policy is invalid", policy.ErrInvalidPolicy)
+	}
+	return nil
+}
+
+func fullJitter(value policy.RetryPolicy, nextAttempt int, random Random) time.Duration {
+	limit := value.BackoffMin
+	for exponent := 2; exponent < nextAttempt; exponent++ {
+		if limit >= value.BackoffMax/2 {
+			limit = value.BackoffMax
+			break
+		}
+		limit *= 2
+	}
+	if limit > value.BackoffMax {
+		limit = value.BackoffMax
+	}
+	return time.Duration(random.Uint64N(uint64(limit) + 1))
+}
+
+type realClock struct{}
+
+func (realClock) After(duration time.Duration) <-chan time.Time {
+	return time.After(duration)
+}
+
+type packageRandom struct{}
+
+func (packageRandom) Uint64N(limit uint64) uint64 {
+	return rand.Uint64N(limit)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	return reflected.Kind() == reflect.Pointer && reflected.IsNil()
+}

--- a/governance/streamlimit/streamlimit.go
+++ b/governance/streamlimit/streamlimit.go
@@ -1,0 +1,311 @@
+// Package streamlimit provides per-stream quotas and shared message limits.
+package streamlimit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/governance/ratelimit"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+var (
+	// ErrLimited reports a per-stream or shared message limit rejection.
+	ErrLimited = kerrors.New(
+		429,
+		"STREAM_MESSAGE_LIMITED",
+		"stream message limit is exceeded",
+	)
+	// ErrInvalidOption reports a missing dependency or invalid event sequence.
+	ErrInvalidOption = errors.New("streamlimit: invalid option")
+)
+
+// Description is a bounded aggregate stream limiter snapshot.
+type Description struct {
+	ActiveStreams    int64
+	StartedStreams   uint64
+	FinishedStreams  uint64
+	SentMessages     uint64
+	ReceivedMessages uint64
+	RejectedMessages uint64
+}
+
+// Limiter creates per-stream state while sharing rate/concurrency pools.
+type Limiter struct {
+	resolver policy.Resolver
+	pool     *ratelimit.Pool
+
+	activeStreams    atomic.Int64
+	startedStreams   atomic.Uint64
+	finishedStreams  atomic.Uint64
+	sentMessages     atomic.Uint64
+	receivedMessages atomic.Uint64
+	rejectedMessages atomic.Uint64
+}
+
+// New creates an isolated stream message Limiter.
+func New(resolver policy.Resolver, pool *ratelimit.Pool) (*Limiter, error) {
+	if isNil(resolver) || pool == nil {
+		return nil, fmt.Errorf("%w: resolver or rate-limit pool is nil", ErrInvalidOption)
+	}
+	return &Limiter{resolver: resolver, pool: pool}, nil
+}
+
+// Middleware returns a factory whose mutable state is scoped to one stream.
+func (l *Limiter) Middleware() middleware.StreamMiddleware {
+	return func(next middleware.StreamHandler) middleware.StreamHandler {
+		if next == nil {
+			return func(context.Context, middleware.StreamEvent) error {
+				return fmt.Errorf("%w: next stream handler is nil", ErrInvalidOption)
+			}
+		}
+
+		var (
+			mu        sync.Mutex
+			created   bool
+			finished  bool
+			config    policy.StreamPolicy
+			sharedKey string
+			sent      int
+			received  int
+		)
+		return func(ctx context.Context, event middleware.StreamEvent) error {
+			if l == nil {
+				return fmt.Errorf("%w: limiter is nil", ErrInvalidOption)
+			}
+			if ctx == nil {
+				return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			switch event.Phase {
+			case middleware.StreamPhaseCreate:
+				target, ok := operation.FromContext(ctx)
+				if !ok {
+					return fmt.Errorf("%w: operation is missing", ErrInvalidOption)
+				}
+				resolved := policy.Resolve(
+					ctx,
+					l.resolver,
+					target,
+				).Stream
+				if err := policy.ValidateStream(resolved); err != nil {
+					return err
+				}
+				mu.Lock()
+				if created {
+					mu.Unlock()
+					return fmt.Errorf("%w: duplicate create event", ErrInvalidOption)
+				}
+				config = resolved
+				sharedKey = target.PolicyKey() + "/stream-messages"
+				mu.Unlock()
+				if err := next(ctx, event); err != nil {
+					return err
+				}
+				mu.Lock()
+				created = true
+				enabled := config.Enabled
+				mu.Unlock()
+				if enabled {
+					l.activeStreams.Add(1)
+					l.startedStreams.Add(1)
+				}
+				return nil
+
+			case middleware.StreamPhaseSend,
+				middleware.StreamPhaseReceive:
+				mu.Lock()
+				if !created || finished {
+					mu.Unlock()
+					return fmt.Errorf("%w: message outside active stream", ErrInvalidOption)
+				}
+				current := config
+				key := sharedKey
+				mu.Unlock()
+				if !current.Enabled {
+					return next(ctx, event)
+				}
+				if event.Phase == middleware.StreamPhaseSend {
+					mu.Lock()
+					if current.MaxSendMessages > 0 &&
+						sent >= current.MaxSendMessages {
+						mu.Unlock()
+						l.rejectedMessages.Add(1)
+						return limitError(nil, event.Phase)
+					}
+					sent++
+					mu.Unlock()
+					permits, err := l.acquireBeforeMessage(
+						key,
+						current,
+					)
+					if err != nil {
+						mu.Lock()
+						sent--
+						mu.Unlock()
+						l.rejectedMessages.Add(1)
+						return limitError(err, event.Phase)
+					}
+					defer releasePermits(permits)
+					if err := next(ctx, event); err != nil {
+						mu.Lock()
+						sent--
+						mu.Unlock()
+						return err
+					}
+					l.sentMessages.Add(1)
+					return nil
+				}
+
+				concurrencyPermit, err := l.acquireConcurrency(
+					key,
+					current.MaxConcurrency,
+				)
+				if err != nil {
+					l.rejectedMessages.Add(1)
+					return limitError(err, event.Phase)
+				}
+				if err := next(ctx, event); err != nil {
+					concurrencyPermit.Release()
+					return err
+				}
+				concurrencyPermit.Release()
+				mu.Lock()
+				if current.MaxReceiveMessages > 0 &&
+					received >= current.MaxReceiveMessages {
+					mu.Unlock()
+					l.rejectedMessages.Add(1)
+					return limitError(nil, event.Phase)
+				}
+				received++
+				mu.Unlock()
+				ratePermit, err := l.acquireRate(key, current)
+				if err != nil {
+					mu.Lock()
+					received--
+					mu.Unlock()
+					l.rejectedMessages.Add(1)
+					return limitError(err, event.Phase)
+				}
+				ratePermit.Release()
+				l.receivedMessages.Add(1)
+				return nil
+
+			case middleware.StreamPhaseFinish:
+				mu.Lock()
+				if !created || finished {
+					mu.Unlock()
+					return next(ctx, event)
+				}
+				finished = true
+				enabled := config.Enabled
+				mu.Unlock()
+				if enabled {
+					defer func() {
+						l.activeStreams.Add(-1)
+						l.finishedStreams.Add(1)
+					}()
+				}
+				return next(ctx, event)
+
+			default:
+				return fmt.Errorf("%w: unsupported phase %q", ErrInvalidOption, event.Phase)
+			}
+		}
+	}
+}
+
+// Describe returns low-cardinality aggregate counters.
+func (l *Limiter) Describe() Description {
+	if l == nil {
+		return Description{}
+	}
+	return Description{
+		ActiveStreams:    l.activeStreams.Load(),
+		StartedStreams:   l.startedStreams.Load(),
+		FinishedStreams:  l.finishedStreams.Load(),
+		SentMessages:     l.sentMessages.Load(),
+		ReceivedMessages: l.receivedMessages.Load(),
+		RejectedMessages: l.rejectedMessages.Load(),
+	}
+}
+
+func (l *Limiter) acquireBeforeMessage(key string, config policy.StreamPolicy) ([]*ratelimit.Permit, error) {
+	permits := make([]*ratelimit.Permit, 0, 2)
+	concurrencyPermit, err := l.acquireConcurrency(
+		key,
+		config.MaxConcurrency,
+	)
+	if err != nil {
+		return nil, err
+	}
+	permits = append(permits, concurrencyPermit)
+	ratePermit, err := l.acquireRate(key, config)
+	if err != nil {
+		releasePermits(permits)
+		return nil, err
+	}
+	permits = append(permits, ratePermit)
+	return permits, nil
+}
+
+func (l *Limiter) acquireConcurrency(key string, maximum int) (*ratelimit.Permit, error) {
+	if maximum <= 0 {
+		return &ratelimit.Permit{}, nil
+	}
+	return l.pool.Get(key + "/concurrency").Acquire(
+		policy.RateLimitPolicy{
+			Enabled:        true,
+			MaxConcurrency: maximum,
+		},
+	)
+}
+
+func (l *Limiter) acquireRate(key string, config policy.StreamPolicy) (*ratelimit.Permit, error) {
+	if config.MessagesPerSecond <= 0 {
+		return &ratelimit.Permit{}, nil
+	}
+	return l.pool.Get(key + "/rate").Acquire(policy.RateLimitPolicy{
+		Enabled:           true,
+		RequestsPerSecond: config.MessagesPerSecond,
+		Burst:             config.Burst,
+	})
+}
+
+func releasePermits(permits []*ratelimit.Permit) {
+	for index := len(permits) - 1; index >= 0; index-- {
+		permits[index].Release()
+	}
+}
+
+func limitError(cause error, phase middleware.StreamPhase) error {
+	message := "stream " + string(phase) + " message limit is exceeded"
+	if cause == nil {
+		return ErrLimited.Clone(kerrors.WithMessage(message))
+	}
+	return kerrors.Wrap(
+		cause,
+		ErrLimited.Code(),
+		ErrLimited.Reason(),
+		message,
+	)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/governance/timeout/middleware.go
+++ b/governance/timeout/middleware.go
@@ -1,0 +1,68 @@
+// Package timeout applies Method Policy deadlines.
+package timeout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+var (
+	// ErrInvalidOption reports an invalid timeout dependency.
+	ErrInvalidOption = errors.New("timeout: invalid option")
+	// ErrMissingOperation reports a call without a stable Operation.
+	ErrMissingOperation = errors.New("timeout: operation is missing")
+)
+
+// New creates policy-resolved timeout Middleware.
+func New(resolver policy.Resolver) (middleware.Middleware, error) {
+	if isNilResolver(resolver) {
+		return nil, fmt.Errorf("%w: resolver is nil", ErrInvalidOption)
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		if next == nil {
+			return func(context.Context, any) (any, error) {
+				return nil, fmt.Errorf("%w: next handler is nil", ErrInvalidOption)
+			}
+		}
+		return func(ctx context.Context, request any) (any, error) {
+			if ctx == nil {
+				return nil, fmt.Errorf("%w: context is nil", ErrInvalidOption)
+			}
+			target, ok := operation.FromContext(ctx)
+			if !ok {
+				return nil, ErrMissingOperation
+			}
+			duration := policy.Resolve(ctx, resolver, target).Timeout
+			if duration <= 0 {
+				return nil, fmt.Errorf("%w: resolved timeout must be positive", policy.ErrInvalidPolicy)
+			}
+
+			callContext, cancel := context.WithTimeout(ctx, duration)
+			defer cancel()
+			response, err := next(callContext, request)
+			if err != nil {
+				return response, err
+			}
+			select {
+			case <-callContext.Done():
+				return nil, context.Cause(callContext)
+			default:
+				return response, nil
+			}
+		}
+	}, nil
+}
+
+func isNilResolver(resolver policy.Resolver) bool {
+	if resolver == nil {
+		return true
+	}
+	value := reflect.ValueOf(resolver)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}

--- a/middleware/stream.go
+++ b/middleware/stream.go
@@ -1,0 +1,178 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	// ErrInvalidStreamEntry means a StreamBundle entry is incomplete.
+	ErrInvalidStreamEntry = errors.New("middleware: invalid stream bundle entry")
+)
+
+// StreamSide identifies which side of a transport emits a lifecycle event.
+type StreamSide string
+
+const (
+	// StreamSideClient identifies an outbound client stream.
+	StreamSideClient StreamSide = "client"
+	// StreamSideServer identifies an inbound server stream.
+	StreamSideServer StreamSide = "server"
+)
+
+// StreamPhase identifies one transport-neutral stream lifecycle boundary.
+type StreamPhase string
+
+const (
+	// StreamPhaseCreate occurs once before the stream becomes usable.
+	StreamPhaseCreate StreamPhase = "create"
+	// StreamPhaseSend surrounds one outgoing message attempt.
+	StreamPhaseSend StreamPhase = "send"
+	// StreamPhaseReceive surrounds one incoming message attempt.
+	StreamPhaseReceive StreamPhase = "receive"
+	// StreamPhaseFinish occurs once when the stream reaches a terminal state.
+	StreamPhaseFinish StreamPhase = "finish"
+)
+
+// StreamEvent describes one lifecycle boundary without transport types.
+//
+// Sequence starts at one independently for Send and Receive; Create and
+// Finish use zero. Message is the caller-owned value passed to the transport.
+// Middleware must not retain or log it unless the application explicitly
+// authorizes that behavior. Error is populated for Finish.
+type StreamEvent struct {
+	Side     StreamSide
+	Phase    StreamPhase
+	Sequence uint64
+	Message  any
+	Error    error
+}
+
+// StreamHandler executes one stream lifecycle boundary.
+type StreamHandler func(context.Context, StreamEvent) error
+
+// StreamMiddleware wraps lifecycle boundaries for one stream instance.
+//
+// A StreamBundle chain is instantiated separately for every stream, so the
+// returned closure may safely hold state scoped to that stream.
+type StreamMiddleware func(StreamHandler) StreamHandler
+
+// StreamEntry names one stream middleware and its configuration source.
+type StreamEntry struct {
+	Name       string
+	Source     string
+	Middleware StreamMiddleware
+}
+
+// StreamDescription is an immutable StreamBundle diagnostic entry.
+type StreamDescription struct {
+	Position int
+	Name     string
+	Source   string
+}
+
+// StreamBundle is an immutable, inspectable stream middleware chain.
+type StreamBundle struct {
+	entries []StreamEntry
+}
+
+// NewStreamBundle validates and copies stream middleware entries.
+func NewStreamBundle(entries ...StreamEntry) (*StreamBundle, error) {
+	snapshot := make([]StreamEntry, 0, len(entries))
+	names := make(map[string]struct{}, len(entries))
+	for index, entry := range entries {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			return nil, fmt.Errorf(
+				"%w: entry %d has an empty name",
+				ErrInvalidStreamEntry,
+				index,
+			)
+		}
+		if entry.Middleware == nil {
+			return nil, fmt.Errorf(
+				"%w: entry %q has nil middleware",
+				ErrInvalidStreamEntry,
+				name,
+			)
+		}
+		if _, duplicate := names[name]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate name %q",
+				ErrInvalidStreamEntry,
+				name,
+			)
+		}
+		names[name] = struct{}{}
+		source := strings.TrimSpace(entry.Source)
+		if source == "" {
+			source = explicitSource
+		}
+		snapshot = append(snapshot, StreamEntry{
+			Name:       name,
+			Source:     source,
+			Middleware: entry.Middleware,
+		})
+	}
+	return &StreamBundle{entries: snapshot}, nil
+}
+
+// CombineStreamBundles creates one auditable StreamBundle by concatenating
+// entries in argument order. Nil bundles are ignored and duplicate names are
+// rejected.
+func CombineStreamBundles(
+	bundles ...*StreamBundle,
+) (*StreamBundle, error) {
+	entries := make([]StreamEntry, 0)
+	for _, bundle := range bundles {
+		if bundle == nil {
+			continue
+		}
+		entries = append(entries, bundle.entries...)
+	}
+	return NewStreamBundle(entries...)
+}
+
+// Chain composes stream middleware in declaration order.
+//
+// Call Chain once per stream to preserve stream-scoped middleware state.
+func (bundle *StreamBundle) Chain() StreamMiddleware {
+	if bundle == nil {
+		return ChainStream()
+	}
+	middlewares := make([]StreamMiddleware, len(bundle.entries))
+	for index, entry := range bundle.entries {
+		middlewares[index] = entry.Middleware
+	}
+	return ChainStream(middlewares...)
+}
+
+// Describe returns entries in final stream execution order.
+func (bundle *StreamBundle) Describe() []StreamDescription {
+	if bundle == nil {
+		return nil
+	}
+	result := make([]StreamDescription, len(bundle.entries))
+	for index, entry := range bundle.entries {
+		result[index] = StreamDescription{
+			Position: index,
+			Name:     entry.Name,
+			Source:   entry.Source,
+		}
+	}
+	return result
+}
+
+// ChainStream composes stream middleware in declaration order.
+func ChainStream(middlewares ...StreamMiddleware) StreamMiddleware {
+	snapshot := append([]StreamMiddleware(nil), middlewares...)
+	return func(final StreamHandler) StreamHandler {
+		handler := final
+		for index := len(snapshot) - 1; index >= 0; index-- {
+			handler = snapshot[index](handler)
+		}
+		return handler
+	}
+}

--- a/operation/matcher.go
+++ b/operation/matcher.go
@@ -1,0 +1,162 @@
+package operation
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const maxMatcherExpressionBytes = 512
+
+// MatchMode controls how non-empty service and method expressions match.
+type MatchMode string
+
+const (
+	// MatchExact requires complete field equality.
+	MatchExact MatchMode = "exact"
+	// MatchPrefix requires the operation field to start with the expression.
+	MatchPrefix MatchMode = "prefix"
+	// MatchRegexp evaluates the expression as a regular expression.
+	MatchRegexp MatchMode = "regexp"
+)
+
+// Matcher decides whether one immutable Operation belongs to a policy group.
+//
+// Implementations must be deterministic, concurrency-safe, and fast. Match
+// must not mutate target or depend on request payload.
+type Matcher interface {
+	Match(Operation) bool
+}
+
+// MatcherFunc adapts a deterministic function to Matcher.
+type MatcherFunc func(Operation) bool
+
+// Match invokes function.
+func (function MatcherFunc) Match(target Operation) bool {
+	return function != nil && function(target)
+}
+
+// MatchPattern describes a bounded field-level Operation matcher.
+//
+// Transport and Kind are optional exact filters. Mode applies independently
+// to non-empty Service and Method expressions. At least one field must be set.
+type MatchPattern struct {
+	Mode      MatchMode
+	Transport string
+	Service   string
+	Method    string
+	Kind      Kind
+}
+
+type compiledMatcher struct {
+	mode      MatchMode
+	transport string
+	service   string
+	method    string
+	kind      Kind
+	serviceRE *regexp.Regexp
+	methodRE  *regexp.Regexp
+}
+
+// CompileMatcher validates and compiles a field-level matcher.
+func CompileMatcher(pattern MatchPattern) (Matcher, error) {
+	mode := pattern.Mode
+	if mode == "" {
+		mode = MatchExact
+	}
+	if mode != MatchExact && mode != MatchPrefix && mode != MatchRegexp {
+		return nil, fmt.Errorf("%w: matcher mode %q is invalid", ErrInvalid, pattern.Mode)
+	}
+	transport := strings.ToLower(pattern.Transport)
+	if pattern.Transport != "" &&
+		(transport != pattern.Transport || !validTransport(transport)) {
+		return nil, fmt.Errorf("%w: matcher transport %q is invalid", ErrInvalid, pattern.Transport)
+	}
+	if pattern.Kind != "" && !validKind(pattern.Kind) {
+		return nil, fmt.Errorf("%w: matcher kind %q is invalid", ErrInvalid, pattern.Kind)
+	}
+	if pattern.Service == "" &&
+		pattern.Method == "" &&
+		transport == "" &&
+		pattern.Kind == "" {
+		return nil, fmt.Errorf("%w: matcher has no filters", ErrInvalid)
+	}
+	if err := validateMatcherExpression(pattern.Service); err != nil {
+		return nil, fmt.Errorf("%w: service matcher: %w", ErrInvalid, err)
+	}
+	if err := validateMatcherExpression(pattern.Method); err != nil {
+		return nil, fmt.Errorf("%w: method matcher: %w", ErrInvalid, err)
+	}
+	matcher := &compiledMatcher{
+		mode:      mode,
+		transport: transport,
+		service:   pattern.Service,
+		method:    pattern.Method,
+		kind:      pattern.Kind,
+	}
+	if mode == MatchRegexp {
+		var err error
+		if matcher.service != "" {
+			matcher.serviceRE, err = regexp.Compile(matcher.service)
+			if err != nil {
+				return nil, fmt.Errorf("%w: service regexp: %w", ErrInvalid, err)
+			}
+		}
+		if matcher.method != "" {
+			matcher.methodRE, err = regexp.Compile(matcher.method)
+			if err != nil {
+				return nil, fmt.Errorf("%w: method regexp: %w", ErrInvalid, err)
+			}
+		}
+	}
+	return matcher, nil
+}
+
+func (matcher *compiledMatcher) Match(target Operation) bool {
+	if matcher == nil {
+		return false
+	}
+	if matcher.transport != "" && target.transport != matcher.transport {
+		return false
+	}
+	if matcher.kind != "" && target.kind != matcher.kind {
+		return false
+	}
+	switch matcher.mode {
+	case MatchExact:
+		return matchExact(matcher.service, target.service) &&
+			matchExact(matcher.method, target.method)
+	case MatchPrefix:
+		return matchPrefix(matcher.service, target.service) &&
+			matchPrefix(matcher.method, target.method)
+	case MatchRegexp:
+		return matchRegexp(matcher.serviceRE, target.service) &&
+			matchRegexp(matcher.methodRE, target.method)
+	default:
+		return false
+	}
+}
+
+func validateMatcherExpression(value string) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > maxMatcherExpressionBytes ||
+		strings.TrimSpace(value) != value ||
+		!validComponent(value) {
+		return fmt.Errorf("expression is oversized or malformed")
+	}
+	return nil
+}
+
+func matchExact(expression, value string) bool {
+	return expression == "" || expression == value
+}
+
+func matchPrefix(expression, value string) bool {
+	return expression == "" || strings.HasPrefix(value, expression)
+}
+
+func matchRegexp(expression *regexp.Regexp, value string) bool {
+	return expression == nil || expression.MatchString(value)
+}

--- a/ops/contracts.go
+++ b/ops/contracts.go
@@ -1,0 +1,67 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/keelab/keelith/contract"
+)
+
+// ContractStatusProvider obtains a bounded static contract/dependency graph.
+type ContractStatusProvider func(context.Context) (contract.Description, error)
+
+// WithContractStatus exposes generated contract topology at
+// GET /debug/contracts.
+func WithContractStatus(provider ContractStatusProvider) Option {
+	return optionFunc(func(options *options) error {
+		if provider == nil {
+			return fmt.Errorf("contract status provider is nil")
+		}
+		options.contractStatus = provider
+		return nil
+	})
+}
+
+// ContractCatalogStatus adapts an immutable generated-manifest Catalog.
+func ContractCatalogStatus(catalog *contract.Catalog) ContractStatusProvider {
+	if catalog == nil {
+		return nil
+	}
+	return func(ctx context.Context) (contract.Description, error) {
+		if ctx == nil {
+			return contract.Description{}, fmt.Errorf(
+				"ops: contract status context is nil",
+			)
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return contract.Description{}, cause
+		}
+		return catalog.Describe(), nil
+	}
+}
+
+func contractStatusHandler(provider ContractStatusProvider) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		status, err := readContractStatus(request.Context(), provider)
+		if err != nil || contract.ValidateDescription(status) != nil {
+			writeDiagnosticError(
+				writer,
+				http.StatusServiceUnavailable,
+				"unavailable",
+			)
+			return
+		}
+		writeDiagnosticJSON(writer, http.StatusOK, status)
+	})
+}
+
+func readContractStatus(ctx context.Context, provider ContractStatusProvider) (status contract.Description, err error) {
+	defer func() {
+		if recover() != nil {
+			status = contract.Description{}
+			err = fmt.Errorf("ops: contract status provider panic")
+		}
+	}()
+	return provider(ctx)
+}

--- a/ops/diagnostics.go
+++ b/ops/diagnostics.go
@@ -1,0 +1,284 @@
+package ops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/keelab/keelith/config"
+)
+
+const maxDiagnosticStringBytes = 4 * 1024
+
+// AccessPolicy authorizes one optional diagnostic request.
+//
+// Returned errors are never exposed to the caller.
+type AccessPolicy func(*http.Request) error
+
+// BuildInfo is the bounded application build identity exposed by Ops.
+type BuildInfo struct {
+	Module    string `json:"module,omitempty"`
+	Version   string `json:"version,omitempty"`
+	GoVersion string `json:"goVersion,omitempty"`
+	VCS       string `json:"vcs,omitempty"`
+	Revision  string `json:"revision,omitempty"`
+	BuildTime string `json:"buildTime,omitempty"`
+	Modified  bool   `json:"modified"`
+}
+
+// ConfigStatus is a value-free snapshot of configuration runtime health.
+type ConfigStatus struct {
+	Loaded            bool   `json:"loaded"`
+	Revision          string `json:"revision,omitempty"`
+	Subscribers       int    `json:"subscribers"`
+	FailedSubscribers int    `json:"failedSubscribers"`
+	RestartRequired   int    `json:"restartRequired"`
+	Rejected          bool   `json:"rejected"`
+}
+
+// ConfigStatusProvider obtains one bounded configuration diagnostic snapshot.
+type ConfigStatusProvider func(context.Context) (ConfigStatus, error)
+
+// WithAccessPolicy protects every enabled optional diagnostic endpoint.
+func WithAccessPolicy(policy AccessPolicy) Option {
+	return optionFunc(func(options *options) error {
+		if policy == nil {
+			return fmt.Errorf("access policy is nil")
+		}
+		options.accessPolicy = policy
+		return nil
+	})
+}
+
+// WithBuildInfo explicitly exposes info at GET /debug/build.
+func WithBuildInfo(info BuildInfo) Option {
+	return optionFunc(func(options *options) error {
+		if err := validateBuildInfo(info); err != nil {
+			return err
+		}
+		snapshot := info
+		options.buildInfo = &snapshot
+		return nil
+	})
+}
+
+// WithConfigStatus exposes a value-free provider at GET /debug/config.
+func WithConfigStatus(provider ConfigStatusProvider) Option {
+	return optionFunc(func(options *options) error {
+		if provider == nil {
+			return fmt.Errorf("config status provider is nil")
+		}
+		options.configStatus = provider
+		return nil
+	})
+}
+
+// CurrentBuildInfo returns bounded Go module and VCS settings for this binary.
+func CurrentBuildInfo() BuildInfo {
+	result := BuildInfo{GoVersion: runtime.Version()}
+	build, ok := debug.ReadBuildInfo()
+	if !ok {
+		return result
+	}
+	result.Module = build.Main.Path
+	result.Version = build.Main.Version
+	if build.GoVersion != "" {
+		result.GoVersion = build.GoVersion
+	}
+	for _, setting := range build.Settings {
+		switch setting.Key {
+		case "vcs":
+			result.VCS = setting.Value
+		case "vcs.revision":
+			result.Revision = setting.Value
+		case "vcs.time":
+			result.BuildTime = setting.Value
+		case "vcs.modified":
+			result.Modified, _ = strconv.ParseBool(setting.Value)
+		}
+	}
+	return result
+}
+
+// ConfigManagerStatus adapts Manager diagnostics without exposing values or
+// error text.
+func ConfigManagerStatus(manager *config.Manager) ConfigStatusProvider {
+	if manager == nil {
+		return nil
+	}
+	return func(ctx context.Context) (ConfigStatus, error) {
+		if ctx == nil {
+			return ConfigStatus{}, fmt.Errorf("ops: config status context is nil")
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return ConfigStatus{}, cause
+		}
+		snapshot, loaded := manager.Current()
+		statuses := manager.SubscriberStatuses()
+		failed := 0
+		restartRequired := 0
+		for _, status := range statuses {
+			if status.LastError != "" {
+				failed++
+			}
+			if status.RestartRequired {
+				restartRequired++
+			}
+		}
+		result := ConfigStatus{
+			Loaded:            loaded,
+			Subscribers:       len(statuses),
+			FailedSubscribers: failed,
+			RestartRequired:   restartRequired,
+			Rejected:          manager.LastRejected() != "",
+		}
+		if loaded {
+			result.Revision = snapshot.Revision()
+		}
+		return result, nil
+	}
+}
+
+func validateBuildInfo(info BuildInfo) error {
+	if info.Module == "" &&
+		info.Version == "" &&
+		info.GoVersion == "" &&
+		info.Revision == "" {
+		return fmt.Errorf("build identity is empty")
+	}
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{name: "module", value: info.Module},
+		{name: "version", value: info.Version},
+		{name: "Go version", value: info.GoVersion},
+		{name: "VCS", value: info.VCS},
+		{name: "revision", value: info.Revision},
+		{name: "build time", value: info.BuildTime},
+	}
+	for _, field := range fields {
+		if !validDiagnosticString(field.value) {
+			return fmt.Errorf("%s is malformed or too large", field.name)
+		}
+	}
+	if info.BuildTime != "" {
+		if _, err := time.Parse(time.RFC3339, info.BuildTime); err != nil {
+			return fmt.Errorf("build time is not RFC3339")
+		}
+	}
+	return nil
+}
+
+func validDiagnosticString(value string) bool {
+	if len(value) > maxDiagnosticStringBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateConfigStatus(status ConfigStatus) error {
+	if status.Subscribers < 0 ||
+		status.FailedSubscribers < 0 ||
+		status.FailedSubscribers > status.Subscribers ||
+		status.RestartRequired < 0 ||
+		status.RestartRequired > status.FailedSubscribers {
+		return fmt.Errorf("invalid subscriber counts")
+	}
+	if status.Loaded && status.Revision == "" {
+		return fmt.Errorf("loaded config status has no revision")
+	}
+	if !status.Loaded && status.Revision != "" {
+		return fmt.Errorf("unloaded config status has a revision")
+	}
+	if !validDiagnosticString(status.Revision) {
+		return fmt.Errorf("config revision is malformed or too large")
+	}
+	return nil
+}
+
+func protectDiagnostic(
+	policy AccessPolicy,
+	handler http.Handler,
+) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		setDiagnosticHeaders(writer.Header())
+		if policy != nil {
+			if err := authorizeDiagnostic(policy, request); err != nil {
+				writeDiagnosticError(writer, http.StatusForbidden, "forbidden")
+				return
+			}
+		}
+		handler.ServeHTTP(writer, request)
+	})
+}
+
+func buildInfoHandler(info BuildInfo) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writeDiagnosticJSON(writer, http.StatusOK, info)
+	})
+}
+
+func configStatusHandler(provider ConfigStatusProvider) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		status, err := readConfigStatus(request.Context(), provider)
+		if err != nil || validateConfigStatus(status) != nil {
+			writeDiagnosticError(
+				writer,
+				http.StatusServiceUnavailable,
+				"unavailable",
+			)
+			return
+		}
+		writeDiagnosticJSON(writer, http.StatusOK, status)
+	})
+}
+
+func authorizeDiagnostic(policy AccessPolicy, request *http.Request) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = fmt.Errorf("ops: access policy panic")
+		}
+	}()
+	return policy(request)
+}
+
+func readConfigStatus(ctx context.Context, provider ConfigStatusProvider) (status ConfigStatus, err error) {
+	defer func() {
+		if recover() != nil {
+			status = ConfigStatus{}
+			err = fmt.Errorf("ops: config status provider panic")
+		}
+	}()
+	return provider(ctx)
+}
+
+func writeDiagnosticError(writer http.ResponseWriter, status int, value string) {
+	writeDiagnosticJSON(writer, status, struct {
+		Status string `json:"status"`
+	}{Status: value})
+}
+
+func writeDiagnosticJSON(writer http.ResponseWriter, status int, value any) {
+	setDiagnosticHeaders(writer.Header())
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(value)
+}
+
+func setDiagnosticHeaders(header http.Header) {
+	header.Set("Cache-Control", "no-store")
+	header.Set("X-Content-Type-Options", "nosniff")
+}

--- a/ops/pprof.go
+++ b/ops/pprof.go
@@ -1,0 +1,52 @@
+package ops
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func registerPprof(mux *http.ServeMux) {
+	mux.HandleFunc("GET /debug/pprof/", runtimeProfile)
+}
+
+func runtimeProfile(writer http.ResponseWriter, request *http.Request) {
+	name := strings.TrimPrefix(request.URL.Path, "/debug/pprof/")
+	if name == "" {
+		profiles := pprof.Profiles()
+		sort.Slice(profiles, func(first, second int) bool {
+			return profiles[first].Name() < profiles[second].Name()
+		})
+		writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		for _, profile := range profiles {
+			_, _ = fmt.Fprintf(writer, "%s\t%d\n", profile.Name(), profile.Count())
+		}
+		return
+	}
+	if strings.Contains(name, "/") {
+		http.NotFound(writer, request)
+		return
+	}
+
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		http.NotFound(writer, request)
+		return
+	}
+	debug := 0
+	if raw := request.URL.Query().Get("debug"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			http.Error(writer, "invalid debug value", http.StatusBadRequest)
+			return
+		}
+		debug = parsed
+	}
+	writer.Header().Set("Content-Type", "application/octet-stream")
+	if err := profile.WriteTo(writer, debug); err != nil {
+		http.Error(writer, "profile unavailable", http.StatusInternalServerError)
+	}
+}

--- a/ops/principal.go
+++ b/ops/principal.go
@@ -1,0 +1,47 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type principalContextKey struct{}
+
+// Principal is the authenticated, bounded identity of one Ops caller.
+type Principal struct {
+	Subject string
+}
+
+// PrincipalPolicy authenticates an Ops request and returns its trusted actor.
+type PrincipalPolicy func(*http.Request) (Principal, error)
+
+// WithPrincipalAccessPolicy protects diagnostics and attaches the authenticated
+// Principal to the request context for audit consumers.
+func WithPrincipalAccessPolicy(policy PrincipalPolicy) Option {
+	if policy == nil {
+		return optionFunc(func(*options) error { return fmt.Errorf("principal policy is nil") })
+	}
+	return WithAccessPolicy(func(request *http.Request) error {
+		principal, err := policy(request)
+		if err != nil {
+			return err
+		}
+		principal.Subject = strings.TrimSpace(principal.Subject)
+		if principal.Subject == "" || !validDiagnosticString(principal.Subject) {
+			return fmt.Errorf("principal subject is invalid")
+		}
+		*request = *request.WithContext(context.WithValue(request.Context(), principalContextKey{}, principal))
+		return nil
+	})
+}
+
+// PrincipalFromContext returns the trusted identity established by Ops auth.
+func PrincipalFromContext(ctx context.Context) (Principal, bool) {
+	if ctx == nil {
+		return Principal{}, false
+	}
+	principal, ok := ctx.Value(principalContextKey{}).(Principal)
+	return principal, ok && principal.Subject != ""
+}

--- a/ops/runtime.go
+++ b/ops/runtime.go
@@ -1,0 +1,372 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	maxRuntimeComponents   = 256
+	maxRuntimeCounters     = 64
+	maxRuntimeCapabilities = 32
+	maxRuntimeTokenBytes   = 256
+)
+
+// RuntimeCounter is one low-cardinality, monotonically interpreted component
+// counter. Names are stable schema, never user or resource identifiers.
+type RuntimeCounter struct {
+	Name  string `json:"name"`
+	Value uint64 `json:"value"`
+}
+
+// RuntimeStatus is the constrained value-free snapshot returned by one
+// component provider.
+type RuntimeStatus struct {
+	State        string           `json:"state"`
+	Ready        bool             `json:"ready"`
+	Degraded     bool             `json:"degraded"`
+	Active       int              `json:"active"`
+	Counters     []RuntimeCounter `json:"counters,omitempty"`
+	Capabilities []string         `json:"capabilities,omitempty"`
+}
+
+// RuntimeComponent is one named component in the Ops runtime catalog.
+type RuntimeComponent struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	Available bool   `json:"available"`
+	RuntimeStatus
+}
+
+// RuntimeDescription is the bounded output exposed at /debug/runtime.
+type RuntimeDescription struct {
+	Components []RuntimeComponent `json:"components"`
+}
+
+// RuntimeStatusProvider returns one bounded component status.
+type RuntimeStatusProvider func(context.Context) (RuntimeStatus, error)
+
+// RuntimeStatusRegistration describes one component status without coupling
+// the component owner to RuntimeCatalog mutation.
+type RuntimeStatusRegistration struct {
+	Name     string
+	Kind     string
+	Provider RuntimeStatusProvider
+}
+
+// RuntimeDescriptionProvider obtains one complete runtime catalog.
+type RuntimeDescriptionProvider func(context.Context) (RuntimeDescription, error)
+
+type runtimeEntry struct {
+	name     string
+	kind     string
+	provider RuntimeStatusProvider
+}
+
+// RuntimeCatalog collects heterogeneous component status through one
+// value-free schema.
+type RuntimeCatalog struct {
+	mu      sync.RWMutex
+	entries map[string]runtimeEntry
+}
+
+// NewRuntimeCatalog creates an empty component catalog.
+func NewRuntimeCatalog() *RuntimeCatalog {
+	return &RuntimeCatalog{entries: make(map[string]runtimeEntry)}
+}
+
+// Register adds one stable component identity and its status provider.
+func (catalog *RuntimeCatalog) Register(
+	name string,
+	kind string,
+	provider RuntimeStatusProvider,
+) error {
+	return catalog.RegisterAll(RuntimeStatusRegistration{
+		Name:     name,
+		Kind:     kind,
+		Provider: provider,
+	})
+}
+
+// RegisterAll validates and installs a component-owned registration batch
+// atomically. A rejected batch leaves the catalog unchanged.
+func (catalog *RuntimeCatalog) RegisterAll(
+	registrations ...RuntimeStatusRegistration,
+) error {
+	if catalog == nil {
+		return fmt.Errorf("%w: runtime catalog is nil", ErrInvalidOption)
+	}
+	normalized := make(
+		[]RuntimeStatusRegistration,
+		len(registrations),
+	)
+	batchKeys := make(map[string]struct{}, len(registrations))
+	for index, registration := range registrations {
+		registration.Name = strings.TrimSpace(registration.Name)
+		registration.Kind = strings.TrimSpace(registration.Kind)
+		if !validRuntimeToken(registration.Name) ||
+			!validRuntimeToken(registration.Kind) {
+			return fmt.Errorf(
+				"%w: runtime component name or kind is invalid",
+				ErrInvalidOption,
+			)
+		}
+		if registration.Provider == nil {
+			return fmt.Errorf(
+				"%w: runtime status provider is nil",
+				ErrInvalidOption,
+			)
+		}
+		key := registration.Kind + "\x00" + registration.Name
+		if _, duplicate := batchKeys[key]; duplicate {
+			return fmt.Errorf(
+				"%w: runtime component %s/%s is duplicated",
+				ErrInvalidOption,
+				registration.Kind,
+				registration.Name,
+			)
+		}
+		batchKeys[key] = struct{}{}
+		normalized[index] = registration
+	}
+	catalog.mu.Lock()
+	defer catalog.mu.Unlock()
+	if len(catalog.entries)+len(normalized) > maxRuntimeComponents {
+		return fmt.Errorf(
+			"%w: runtime component count exceeds %d",
+			ErrInvalidOption,
+			maxRuntimeComponents,
+		)
+	}
+	for _, registration := range normalized {
+		key := registration.Kind + "\x00" + registration.Name
+		if _, duplicate := catalog.entries[key]; duplicate {
+			return fmt.Errorf(
+				"%w: runtime component %s/%s is duplicated",
+				ErrInvalidOption,
+				registration.Kind,
+				registration.Name,
+			)
+		}
+	}
+	for _, registration := range normalized {
+		key := registration.Kind + "\x00" + registration.Name
+		catalog.entries[key] = runtimeEntry{
+			name:     registration.Name,
+			kind:     registration.Kind,
+			provider: registration.Provider,
+		}
+	}
+	return nil
+}
+
+// Describe returns a deterministic snapshot. A failed, panicking, or invalid
+// provider is represented as unavailable without exposing its error.
+func (catalog *RuntimeCatalog) Describe(
+	ctx context.Context,
+) (RuntimeDescription, error) {
+	if catalog == nil {
+		return RuntimeDescription{}, fmt.Errorf(
+			"ops: runtime catalog is nil",
+		)
+	}
+	if ctx == nil {
+		return RuntimeDescription{}, fmt.Errorf(
+			"ops: runtime catalog context is nil",
+		)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return RuntimeDescription{}, cause
+	}
+	catalog.mu.RLock()
+	entries := make([]runtimeEntry, 0, len(catalog.entries))
+	for _, entry := range catalog.entries {
+		entries = append(entries, entry)
+	}
+	catalog.mu.RUnlock()
+	sort.Slice(entries, func(first, second int) bool {
+		if entries[first].kind == entries[second].kind {
+			return entries[first].name < entries[second].name
+		}
+		return entries[first].kind < entries[second].kind
+	})
+	description := RuntimeDescription{
+		Components: make([]RuntimeComponent, 0, len(entries)),
+	}
+	for _, entry := range entries {
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeDescription{}, cause
+		}
+		status, err := readRuntimeComponent(ctx, entry.provider)
+		component := RuntimeComponent{
+			Name:      entry.name,
+			Kind:      entry.kind,
+			Available: err == nil && validateRuntimeStatus(status) == nil,
+		}
+		if component.Available {
+			component.RuntimeStatus = cloneRuntimeStatus(status)
+		} else {
+			component.RuntimeStatus = RuntimeStatus{State: "unavailable"}
+		}
+		description.Components = append(description.Components, component)
+	}
+	return description, nil
+}
+
+// RuntimeCatalogStatus adapts a catalog to an Ops endpoint provider.
+func RuntimeCatalogStatus(
+	catalog *RuntimeCatalog,
+) RuntimeDescriptionProvider {
+	if catalog == nil {
+		return nil
+	}
+	return catalog.Describe
+}
+
+// WithRuntimeStatus exposes a bounded component catalog at GET /debug/runtime.
+func WithRuntimeStatus(provider RuntimeDescriptionProvider) Option {
+	return optionFunc(func(options *options) error {
+		if provider == nil {
+			return fmt.Errorf("runtime status provider is nil")
+		}
+		options.runtimeStatus = provider
+		return nil
+	})
+}
+
+func runtimeStatusHandler(provider RuntimeDescriptionProvider) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		description, err := readRuntimeDescription(request.Context(), provider)
+		if err != nil || validateRuntimeDescription(description) != nil {
+			writeDiagnosticError(
+				writer,
+				http.StatusServiceUnavailable,
+				"unavailable",
+			)
+			return
+		}
+		writeDiagnosticJSON(writer, http.StatusOK, description)
+	})
+}
+
+func readRuntimeDescription(
+	ctx context.Context,
+	provider RuntimeDescriptionProvider,
+) (description RuntimeDescription, err error) {
+	defer func() {
+		if recover() != nil {
+			description = RuntimeDescription{}
+			err = fmt.Errorf("ops: runtime status provider panic")
+		}
+	}()
+	return provider(ctx)
+}
+
+func readRuntimeComponent(
+	ctx context.Context,
+	provider RuntimeStatusProvider,
+) (status RuntimeStatus, err error) {
+	defer func() {
+		if recover() != nil {
+			status = RuntimeStatus{}
+			err = fmt.Errorf("ops: runtime component provider panic")
+		}
+	}()
+	return provider(ctx)
+}
+
+func validateRuntimeDescription(description RuntimeDescription) error {
+	if len(description.Components) > maxRuntimeComponents {
+		return fmt.Errorf("runtime component count exceeds %d", maxRuntimeComponents)
+	}
+	seen := make(map[string]struct{}, len(description.Components))
+	previous := ""
+	for _, component := range description.Components {
+		if !validRuntimeToken(component.Name) ||
+			!validRuntimeToken(component.Kind) {
+			return fmt.Errorf("runtime component identity is invalid")
+		}
+		key := component.Kind + "\x00" + component.Name
+		if _, duplicate := seen[key]; duplicate {
+			return fmt.Errorf("runtime component is duplicated")
+		}
+		seen[key] = struct{}{}
+		if previous != "" && key < previous {
+			return fmt.Errorf("runtime components are not sorted")
+		}
+		previous = key
+		if component.Available {
+			if err := validateRuntimeStatus(component.RuntimeStatus); err != nil {
+				return err
+			}
+		} else if component.State != "unavailable" ||
+			component.Ready ||
+			component.Degraded ||
+			component.Active != 0 ||
+			len(component.Counters) != 0 ||
+			len(component.Capabilities) != 0 {
+			return fmt.Errorf("unavailable runtime component has status data")
+		}
+	}
+	return nil
+}
+
+func validateRuntimeStatus(status RuntimeStatus) error {
+	if !validRuntimeToken(status.State) || status.Active < 0 {
+		return fmt.Errorf("runtime status state or active count is invalid")
+	}
+	if len(status.Counters) > maxRuntimeCounters ||
+		len(status.Capabilities) > maxRuntimeCapabilities {
+		return fmt.Errorf("runtime status exceeds item limits")
+	}
+	previous := ""
+	for _, counter := range status.Counters {
+		if !validRuntimeToken(counter.Name) ||
+			previous != "" && counter.Name <= previous {
+			return fmt.Errorf("runtime counters are invalid or not sorted")
+		}
+		previous = counter.Name
+	}
+	previous = ""
+	for _, capability := range status.Capabilities {
+		if !validRuntimeToken(capability) ||
+			previous != "" && capability <= previous {
+			return fmt.Errorf("runtime capabilities are invalid or not sorted")
+		}
+		previous = capability
+	}
+	return nil
+}
+
+func validRuntimeToken(value string) bool {
+	if value == "" ||
+		len(value) > maxRuntimeTokenBytes ||
+		strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z',
+			character >= 'A' && character <= 'Z',
+			character >= '0' && character <= '9',
+			character == '.',
+			character == '_',
+			character == '-',
+			character == '/',
+			character == ':':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func cloneRuntimeStatus(status RuntimeStatus) RuntimeStatus {
+	status.Counters = append([]RuntimeCounter(nil), status.Counters...)
+	status.Capabilities = append([]string(nil), status.Capabilities...)
+	return status
+}

--- a/ops/server.go
+++ b/ops/server.go
@@ -1,0 +1,512 @@
+// Package ops provides an isolated operational HTTP server.
+package ops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/health"
+)
+
+const (
+	defaultAddress      = "127.0.0.1:0"
+	defaultCheckTimeout = 2 * time.Second
+)
+
+var (
+	// ErrAlreadyStarted means Start was called more than once.
+	ErrAlreadyStarted = errors.New("ops: server has already been started")
+	// ErrInvalidOption means New received an unsafe or incomplete option.
+	ErrInvalidOption = errors.New("ops: invalid option")
+	// ErrNilContext means Start or Stop received a nil context.
+	ErrNilContext = errors.New("ops: nil context")
+)
+
+type state uint8
+
+const (
+	stateNew state = iota
+	stateStarting
+	stateRunning
+	stateStopping
+	stateStopped
+)
+
+// Option configures an operational Server.
+type Option interface {
+	apply(*options) error
+}
+
+type optionFunc func(*options) error
+
+func (function optionFunc) apply(options *options) error {
+	return function(options)
+}
+
+type options struct {
+	address           string
+	checkTimeout      time.Duration
+	metrics           http.Handler
+	pprof             bool
+	cpuProfile        http.Handler
+	accessPolicy      AccessPolicy
+	buildInfo         *BuildInfo
+	configStatus      ConfigStatusProvider
+	contractStatus    ContractStatusProvider
+	runtimeStatus     RuntimeDescriptionProvider
+	programmableAdmin http.Handler
+	serviceProfiles   http.Handler
+	loggingAdmin      http.Handler
+}
+
+// WithAddress sets the dedicated operational listen address.
+func WithAddress(address string) Option {
+	return optionFunc(func(options *options) error {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil || host == "" || port == "" {
+			return fmt.Errorf("invalid listen address %q", address)
+		}
+		options.address = address
+		return nil
+	})
+}
+
+// WithCheckTimeout sets a per-request health check deadline.
+func WithCheckTimeout(timeout time.Duration) Option {
+	return optionFunc(func(options *options) error {
+		if timeout <= 0 {
+			return fmt.Errorf("check timeout must be positive")
+		}
+		options.checkTimeout = timeout
+		return nil
+	})
+}
+
+// WithMetrics explicitly exposes handler at /metrics.
+func WithMetrics(handler http.Handler) Option {
+	return optionFunc(func(options *options) error {
+		if isNilHandler(handler) {
+			return fmt.Errorf("metrics handler is nil")
+		}
+		options.metrics = handler
+		return nil
+	})
+}
+
+// WithPprof explicitly exposes runtime profiles below /debug/pprof/.
+func WithPprof() Option {
+	return optionFunc(func(options *options) error {
+		options.pprof = true
+		return nil
+	})
+}
+
+// WithCPUProfile explicitly exposes a bounded CPU capture handler at
+// /debug/pprof/profile. The handler shares the Ops diagnostic AccessPolicy but
+// is independent from WithPprof so callers cannot accidentally enable CPU
+// capture by requesting heap/goroutine snapshots.
+func WithCPUProfile(handler http.Handler) Option {
+	return optionFunc(func(options *options) error {
+		if isNilHandler(handler) {
+			return fmt.Errorf("CPU profile handler is nil")
+		}
+		options.cpuProfile = handler
+		return nil
+	})
+}
+
+// WithServiceProfiles explicitly exposes a bounded static service topology at
+// GET /debug/service-profiles. It shares the Ops diagnostic AccessPolicy.
+func WithServiceProfiles(handler http.Handler) Option {
+	return optionFunc(func(options *options) error {
+		if isNilHandler(handler) {
+			return fmt.Errorf("service profiles handler is nil")
+		}
+		options.serviceProfiles = handler
+		return nil
+	})
+}
+
+// Server is an isolated health, metrics, and diagnostics HTTP server.
+type Server struct {
+	address string
+
+	mu            sync.Mutex
+	state         state
+	listener      net.Listener
+	httpServer    *http.Server
+	serveErr      error
+	stopErr       error
+	stopInitiated bool
+
+	startDone chan struct{}
+	done      chan struct{}
+	stopDone  chan struct{}
+	doneOnce  sync.Once
+	stopOnce  sync.Once
+}
+
+// New constructs a Server. Only health endpoints are enabled by default.
+func New(registry *health.Registry, optionList ...Option) (*Server, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("%w: health registry is nil", ErrInvalidOption)
+	}
+	settings := options{
+		address:      defaultAddress,
+		checkTimeout: defaultCheckTimeout,
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&settings); err != nil {
+			return nil, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	if hasOptionalDiagnostics(settings) &&
+		!isLoopbackAddress(settings.address) &&
+		settings.accessPolicy == nil {
+		return nil, fmt.Errorf(
+			"%w: non-loopback diagnostics require an access policy",
+			ErrInvalidOption,
+		)
+	}
+	if settings.programmableAdmin != nil && settings.accessPolicy == nil {
+		return nil, fmt.Errorf(
+			"%w: programmable admin requires an access policy",
+			ErrInvalidOption,
+		)
+	}
+	if settings.loggingAdmin != nil && settings.accessPolicy == nil {
+		return nil, fmt.Errorf(
+			"%w: logging admin requires an access policy",
+			ErrInvalidOption,
+		)
+	}
+
+	mux := http.NewServeMux()
+	registerHealth(mux, registry, settings.checkTimeout)
+	if settings.metrics != nil {
+		mux.Handle(
+			"GET /metrics",
+			protectDiagnostic(settings.accessPolicy, settings.metrics),
+		)
+	}
+	if settings.pprof {
+		pprofMux := http.NewServeMux()
+		registerPprof(pprofMux)
+		mux.Handle(
+			"GET /debug/pprof/",
+			protectDiagnostic(settings.accessPolicy, pprofMux),
+		)
+	}
+	if settings.cpuProfile != nil {
+		mux.Handle(
+			"GET /debug/pprof/profile",
+			protectDiagnostic(
+				settings.accessPolicy,
+				settings.cpuProfile,
+			),
+		)
+	}
+	if settings.buildInfo != nil {
+		mux.Handle(
+			"GET /debug/build",
+			protectDiagnostic(
+				settings.accessPolicy,
+				buildInfoHandler(*settings.buildInfo),
+			),
+		)
+	}
+	if settings.configStatus != nil {
+		mux.Handle(
+			"GET /debug/config",
+			protectDiagnostic(
+				settings.accessPolicy,
+				configStatusHandler(settings.configStatus),
+			),
+		)
+	}
+	if settings.contractStatus != nil {
+		mux.Handle(
+			"GET /debug/contracts",
+			protectDiagnostic(
+				settings.accessPolicy,
+				contractStatusHandler(settings.contractStatus),
+			),
+		)
+	}
+	if settings.runtimeStatus != nil {
+		mux.Handle(
+			"GET /debug/runtime",
+			protectDiagnostic(
+				settings.accessPolicy,
+				runtimeStatusHandler(settings.runtimeStatus),
+			),
+		)
+	}
+	if settings.serviceProfiles != nil {
+		mux.Handle(
+			"GET /debug/service-profiles",
+			protectDiagnostic(settings.accessPolicy, settings.serviceProfiles),
+		)
+	}
+	if settings.programmableAdmin != nil {
+		protected := protectDiagnostic(settings.accessPolicy, settings.programmableAdmin)
+		mux.Handle("POST /admin/programmable/continuation/collect", protected)
+		mux.Handle("POST /admin/programmable/projection/compact", protected)
+		mux.Handle("POST /admin/programmable/projection/force-snapshot", protected)
+	}
+	if settings.loggingAdmin != nil {
+		protected := protectDiagnostic(settings.accessPolicy, settings.loggingAdmin)
+		mux.Handle("GET /debug/logging", protected)
+		mux.Handle("PUT /admin/logging/level", protected)
+	}
+
+	return &Server{
+		address:   settings.address,
+		state:     stateNew,
+		startDone: make(chan struct{}),
+		done:      make(chan struct{}),
+		stopDone:  make(chan struct{}),
+		httpServer: &http.Server{
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		},
+	}, nil
+}
+
+// Name returns the stable App diagnostic name.
+func (server *Server) Name() string {
+	return "keelith.ops"
+}
+
+// Start listens synchronously and then serves in the background.
+func (server *Server) Start(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	server.mu.Lock()
+	if server.state != stateNew {
+		server.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	server.state = stateStarting
+	server.mu.Unlock()
+	defer close(server.startDone)
+
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "tcp", server.address)
+	if err != nil {
+		server.completeServe(fmt.Errorf("ops: listen %q: %w", server.address, err))
+		return fmt.Errorf("ops: listen %q: %w", server.address, err)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		closeErr := listener.Close()
+		result := errors.Join(cause, closeErr)
+		server.completeServe(result)
+		return result
+	}
+
+	server.mu.Lock()
+	server.listener = listener
+	server.state = stateRunning
+	server.mu.Unlock()
+
+	go server.serve(listener)
+	return nil
+}
+
+// Stop gracefully shuts down the operational listener. It is concurrent-safe
+// and idempotent.
+func (server *Server) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	for {
+		server.mu.Lock()
+		current := server.state
+		switch current {
+		case stateNew:
+			server.mu.Unlock()
+			return nil
+		case stateStarting:
+			startDone := server.startDone
+			server.mu.Unlock()
+			select {
+			case <-startDone:
+				continue
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		case stateRunning, stateStopped:
+			if !server.stopInitiated {
+				server.stopInitiated = true
+				server.state = stateStopping
+				go server.shutdown(ctx)
+			}
+			stopDone := server.stopDone
+			server.mu.Unlock()
+			return waitForStop(ctx, stopDone, server.stopError)
+		case stateStopping:
+			stopDone := server.stopDone
+			server.mu.Unlock()
+			return waitForStop(ctx, stopDone, server.stopError)
+		default:
+			server.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// Wait blocks until the listener terminates and returns its runtime error.
+func (server *Server) Wait() error {
+	<-server.done
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	return server.serveErr
+}
+
+// Address returns the allocated listener address after Start succeeds.
+func (server *Server) Address() (string, bool) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.listener == nil {
+		return "", false
+	}
+	return server.listener.Addr().String(), true
+}
+
+func (server *Server) serve(listener net.Listener) {
+	err := server.httpServer.Serve(listener)
+	if errors.Is(err, http.ErrServerClosed) {
+		err = nil
+	}
+	server.completeServe(err)
+}
+
+func (server *Server) completeServe(err error) {
+	server.mu.Lock()
+	server.serveErr = err
+	if server.state == stateStarting || server.state == stateRunning {
+		server.state = stateStopped
+	}
+	server.doneOnce.Do(func() {
+		close(server.done)
+	})
+	server.mu.Unlock()
+}
+
+func (server *Server) shutdown(ctx context.Context) {
+	shutdownErr := server.httpServer.Shutdown(ctx)
+	if shutdownErr != nil {
+		shutdownErr = errors.Join(shutdownErr, server.httpServer.Close())
+	}
+	<-server.done
+
+	server.mu.Lock()
+	server.stopErr = shutdownErr
+	server.state = stateStopped
+	server.stopOnce.Do(func() {
+		close(server.stopDone)
+	})
+	server.mu.Unlock()
+}
+
+func (server *Server) stopError() error {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	return server.stopErr
+}
+
+func waitForStop(
+	ctx context.Context,
+	stopDone <-chan struct{},
+	result func() error,
+) error {
+	select {
+	case <-stopDone:
+		return result()
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func registerHealth(
+	mux *http.ServeMux,
+	registry *health.Registry,
+	timeout time.Duration,
+) {
+	endpoints := map[string]health.Kind{
+		"GET /health/startup":      health.KindStartup,
+		"GET /health/live":         health.KindLiveness,
+		"GET /health/ready":        health.KindReadiness,
+		"GET /health/dependencies": health.KindDependency,
+	}
+	for pattern, kind := range endpoints {
+		mux.Handle(pattern, healthHandler(registry, kind, timeout))
+	}
+}
+
+func healthHandler(
+	registry *health.Registry,
+	kind health.Kind,
+	timeout time.Duration,
+) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		ctx, cancel := context.WithTimeout(request.Context(), timeout)
+		defer cancel()
+		report := registry.Check(ctx, kind)
+
+		writer.Header().Set("Content-Type", "application/json")
+		if report.Status != health.StatusPass {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_ = json.NewEncoder(writer).Encode(report)
+	})
+}
+
+func isNilHandler(handler http.Handler) bool {
+	if handler == nil {
+		return true
+	}
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func hasOptionalDiagnostics(settings options) bool {
+	return settings.metrics != nil ||
+		settings.pprof ||
+		settings.cpuProfile != nil ||
+		settings.buildInfo != nil ||
+		settings.configStatus != nil ||
+		settings.contractStatus != nil ||
+		settings.runtimeStatus != nil ||
+		settings.serviceProfiles != nil ||
+		settings.loggingAdmin != nil ||
+		settings.programmableAdmin != nil
+}
+
+func isLoopbackAddress(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return false
+	}
+	addressIP := net.ParseIP(host)
+	return addressIP != nil && addressIP.IsLoopback()
+}

--- a/selector/node.go
+++ b/selector/node.go
@@ -1,0 +1,59 @@
+package selector
+
+import (
+	"maps"
+	"time"
+
+	"github.com/keelab/keelith/registry"
+)
+
+// Node is an immutable selectable endpoint.
+type Node struct {
+	id       string
+	service  string
+	endpoint string
+	metadata map[string]string
+}
+
+// ID returns the source instance ID.
+func (n Node) ID() string {
+	return n.id
+}
+
+// Service returns the logical service.
+func (n Node) Service() string {
+	return n.service
+}
+
+// Endpoint returns the selected standard endpoint URL.
+func (n Node) Endpoint() string {
+	return n.endpoint
+}
+
+// Metadata returns an independent metadata map.
+func (n Node) Metadata() map[string]string {
+	clone := make(map[string]string, len(n.metadata))
+	maps.Copy(clone, n.metadata)
+	return clone
+}
+
+func (n Node) key() string {
+	return n.id + "\x00" + n.endpoint
+}
+
+func newNode(instance registry.Instance, endpoint string) Node {
+	return Node{
+		id:       instance.ID(),
+		service:  instance.Service(),
+		endpoint: endpoint,
+		metadata: instance.Metadata(),
+	}
+}
+
+// NodeStats is an immutable diagnostic P2C state snapshot.
+type NodeStats struct {
+	Node           Node
+	EWMALatency    time.Duration
+	Inflight       int64
+	FailurePenalty float64
+}

--- a/selector/roundrobin.go
+++ b/selector/roundrobin.go
@@ -1,0 +1,85 @@
+package selector
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/registry"
+)
+
+// RoundRobin selects eligible Nodes in stable rotation.
+type RoundRobin struct {
+	scheme   string
+	settings settings
+
+	mu       sync.RWMutex
+	service  string
+	revision string
+	nodes    []Node
+	next     atomic.Uint64
+}
+
+// NewRoundRobin constructs a RoundRobin selector.
+func NewRoundRobin(scheme string, options ...Option) (*RoundRobin, error) {
+	normalizedScheme, err := validateScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	settings, err := newSettings(options)
+	if err != nil {
+		return nil, err
+	}
+	return &RoundRobin{scheme: normalizedScheme, settings: settings}, nil
+}
+
+// PreferenceTierCount reports the configured bounded preference depth.
+func (roundRobin *RoundRobin) PreferenceTierCount() int {
+	if roundRobin == nil {
+		return 0
+	}
+	return roundRobin.settings.preferenceTierCount()
+}
+
+// Update atomically replaces the current full Snapshot.
+func (roundRobin *RoundRobin) Update(snapshot registry.Snapshot) error {
+	nodes, err := nodesFromSnapshot(snapshot, roundRobin.scheme)
+	if err != nil {
+		return err
+	}
+	roundRobin.mu.Lock()
+	defer roundRobin.mu.Unlock()
+	if roundRobin.service == snapshot.Service() &&
+		roundRobin.revision == snapshot.Revision() {
+		return nil
+	}
+	roundRobin.service = snapshot.Service()
+	roundRobin.revision = snapshot.Revision()
+	roundRobin.nodes = nodes
+	return nil
+}
+
+// Select returns the next eligible Node.
+func (roundRobin *RoundRobin) Select(
+	ctx context.Context,
+	operationID operation.Operation,
+) (Node, Done, error) {
+	roundRobin.mu.RLock()
+	service := roundRobin.service
+	nodes := append([]Node(nil), roundRobin.nodes...)
+	roundRobin.mu.RUnlock()
+
+	if service != "" && operationID.Service() != service {
+		return Node{}, nil, ErrServiceMismatch
+	}
+	eligible, err := eligibleNodes(ctx, operationID, nodes, roundRobin.settings)
+	if err != nil {
+		return Node{}, nil, err
+	}
+	index := (roundRobin.next.Add(1) - 1) % uint64(len(eligible))
+	node := eligible[index]
+	return node, idempotentDone(func(result Result) {
+		observeResult(roundRobin.settings, operationID, node, result)
+	}), nil
+}

--- a/selector/selector.go
+++ b/selector/selector.go
@@ -1,0 +1,339 @@
+// Package selector provides feedback-aware service node selection.
+package selector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/registry"
+)
+
+const (
+	maximumPreferenceTiers   = 8
+	maximumPreferencesInTier = 8
+
+	// MetadataRegion is the provider-neutral service region metadata key.
+	MetadataRegion = "cloud.region"
+	// MetadataZone is the provider-neutral service availability-zone key.
+	MetadataZone = "cloud.availability_zone"
+)
+
+var (
+	// ErrInvalidOption means a selector option is malformed.
+	ErrInvalidOption = errors.New("selector: invalid option")
+	// ErrInvalidWeight means a node advertises an unusable selection weight.
+	ErrInvalidWeight = errors.New("selector: invalid weight")
+	// ErrHashKey means a rendezvous selector cannot obtain a routing key.
+	ErrHashKey = errors.New("selector: invalid hash key")
+	// ErrNoNodes means no endpoint satisfies required constraints.
+	ErrNoNodes = errors.New("selector: no eligible nodes")
+	// ErrServiceMismatch means an Operation targets another service.
+	ErrServiceMismatch = errors.New("selector: service mismatch")
+)
+
+// Result reports one completed node invocation.
+type Result struct {
+	Latency  time.Duration
+	Error    error
+	Canceled bool
+	Retried  bool
+}
+
+// Done records a Result. Implementations must make Done idempotent.
+type Done func(Result)
+
+// Selector consumes full discovery Snapshots and selects Nodes.
+type Selector interface {
+	Update(registry.Snapshot) error
+	Select(context.Context, operation.Operation) (Node, Done, error)
+}
+
+// PreferenceDescriber is implemented by built-in selectors that expose only
+// the number of configured preference tiers. Metadata values remain private.
+type PreferenceDescriber interface {
+	PreferenceTierCount() int
+}
+
+// Filter is a mandatory node constraint.
+type Filter func(context.Context, operation.Operation, Node) bool
+
+// Observer can exclude unhealthy nodes and observe completed invocations.
+//
+// Implementations must be safe for concurrent use. Allow should be cheap and
+// must not retain ctx.
+type Observer interface {
+	Allow(context.Context, operation.Operation, Node) bool
+	Done(operation.Operation, Node, Result)
+}
+
+// Preference is one exact metadata match inside a preference tier.
+type Preference struct {
+	Key   string
+	Value string
+}
+
+// PreferenceTier is an AND set of preferred metadata values. Tiers are tried
+// in caller order after mandatory filters and health observers have run.
+type PreferenceTier []Preference
+
+// Locality is the local service topology used by WithLocality.
+type Locality struct {
+	Region string
+	Zone   string
+}
+
+// Option configures selectors.
+type Option interface {
+	apply(*settings) error
+}
+
+type optionFunc func(*settings) error
+
+func (f optionFunc) apply(settings *settings) error {
+	return f(settings)
+}
+
+type settings struct {
+	filters         []Filter
+	preferenceTiers []map[string]string
+	observers       []Observer
+	seed            uint64
+}
+
+// WithFilter adds a mandatory node Filter.
+func WithFilter(filter Filter) Option {
+	return optionFunc(func(settings *settings) error {
+		if filter == nil {
+			return fmt.Errorf("filter is nil")
+		}
+		settings.filters = append(settings.filters, filter)
+		return nil
+	})
+}
+
+// WithObserver adds a selection health/result observer.
+func WithObserver(observer Observer) Option {
+	return optionFunc(func(settings *settings) error {
+		if observer == nil {
+			return fmt.Errorf("observer is nil")
+		}
+		settings.observers = append(settings.observers, observer)
+		return nil
+	})
+}
+
+// MatchMetadata creates a mandatory metadata Filter.
+func MatchMetadata(key, value string) Filter {
+	return func(_ context.Context, _ operation.Operation, node Node) bool {
+		return node.metadata[key] == value
+	}
+}
+
+// WithPreferenceTiers adds ordered best-effort metadata preferences.
+//
+// Every matcher inside a tier must match. The first non-empty tier wins; if
+// every tier is empty, selection falls back to all otherwise eligible nodes.
+func WithPreferenceTiers(tiers ...PreferenceTier) Option {
+	copied := make([]PreferenceTier, len(tiers))
+	for index, tier := range tiers {
+		copied[index] = append(PreferenceTier(nil), tier...)
+	}
+	return optionFunc(func(settings *settings) error {
+		if len(copied) == 0 ||
+			len(settings.preferenceTiers)+len(copied) > maximumPreferenceTiers {
+			return fmt.Errorf("preference tier count must be within 1..%d", maximumPreferenceTiers)
+		}
+		for tierIndex, tier := range copied {
+			if len(tier) == 0 || len(tier) > maximumPreferencesInTier {
+				return fmt.Errorf("preference tier %d size must be within 1..%d", tierIndex, maximumPreferencesInTier)
+			}
+			matches := make(map[string]string, len(tier))
+			for matchIndex, match := range tier {
+				if !validPreferenceKey(match.Key) || !validPreferenceValue(match.Value) {
+					return fmt.Errorf("preference tier %d matcher %d is malformed", tierIndex, matchIndex)
+				}
+				if _, duplicate := matches[match.Key]; duplicate {
+					return fmt.Errorf("preference tier %d key %q is duplicated", tierIndex, match.Key)
+				}
+				matches[match.Key] = match.Value
+			}
+			settings.preferenceTiers = append(settings.preferenceTiers, matches)
+		}
+		return nil
+	})
+}
+
+// WithLocality prefers the local availability zone, then the local region,
+// then any otherwise eligible node. Empty topology levels are omitted.
+func WithLocality(locality Locality) Option {
+	tiers := make([]PreferenceTier, 0, 2)
+	if locality.Zone != "" {
+		tiers = append(tiers, PreferenceTier{{
+			Key:   MetadataZone,
+			Value: locality.Zone,
+		}})
+	}
+	if locality.Region != "" {
+		tiers = append(tiers, PreferenceTier{{
+			Key:   MetadataRegion,
+			Value: locality.Region,
+		}})
+	}
+	return WithPreferenceTiers(tiers...)
+}
+
+// WithSeed sets deterministic P2C sampling state.
+func WithSeed(seed uint64) Option {
+	return optionFunc(func(settings *settings) error {
+		settings.seed = seed
+		return nil
+	})
+}
+
+func newSettings(options []Option) (settings, error) {
+	result := settings{seed: 0x9e3779b97f4a7c15}
+	for index, option := range options {
+		if option == nil {
+			return settings{}, fmt.Errorf("%w: option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.apply(&result); err != nil {
+			return settings{}, fmt.Errorf("%w: option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	if result.seed == 0 {
+		result.seed = 0x9e3779b97f4a7c15
+	}
+	return result, nil
+}
+
+func validateScheme(scheme string) (string, error) {
+	normalized := strings.ToLower(scheme)
+	parsed, err := url.Parse(normalized + "://endpoint")
+	if err != nil || parsed.Scheme != normalized || normalized == "" {
+		return "", fmt.Errorf("%w: endpoint scheme %q", ErrInvalidOption, scheme)
+	}
+	return normalized, nil
+}
+
+func nodesFromSnapshot(snapshot registry.Snapshot, scheme string) ([]Node, error) {
+	if err := snapshot.Validate(); err != nil {
+		return nil, err
+	}
+	nodes := make([]Node, 0)
+	for _, instance := range snapshot.Instances() {
+		for _, endpoint := range instance.Endpoints() {
+			parsed, err := url.Parse(endpoint)
+			if err == nil && parsed.Scheme == scheme {
+				nodes = append(nodes, newNode(instance, endpoint))
+			}
+		}
+	}
+	sort.Slice(nodes, func(first, second int) bool {
+		return nodes[first].key() < nodes[second].key()
+	})
+	return nodes, nil
+}
+
+func eligibleNodes(ctx context.Context, operationID operation.Operation, nodes []Node, settings settings) ([]Node, error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	filtered := make([]Node, 0, len(nodes))
+	for _, node := range nodes {
+		eligible := true
+		for _, filter := range settings.filters {
+			if !filter(ctx, operationID, node) {
+				eligible = false
+				break
+			}
+		}
+		if eligible {
+			for _, observer := range settings.observers {
+				if !observer.Allow(ctx, operationID, node) {
+					eligible = false
+					break
+				}
+			}
+		}
+		if eligible {
+			filtered = append(filtered, node)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, ErrNoNodes
+	}
+	return preferredNodes(filtered, settings.preferenceTiers), nil
+}
+
+func preferredNodes(nodes []Node, tiers []map[string]string) []Node {
+	for _, tier := range tiers {
+		preferred := make([]Node, 0, len(nodes))
+		for _, node := range nodes {
+			matches := true
+			for key, value := range tier {
+				if node.metadata[key] != value {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				preferred = append(preferred, node)
+			}
+		}
+		if len(preferred) != 0 {
+			return preferred
+		}
+	}
+	return nodes
+}
+
+func (s settings) preferenceTierCount() int {
+	return len(s.preferenceTiers)
+}
+
+func validPreferenceKey(value string) bool {
+	if !validPreferenceValue(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsSpace(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validPreferenceValue(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func observeResult(settings settings, operationID operation.Operation, node Node, result Result) {
+	for _, observer := range settings.observers {
+		observer.Done(operationID, node, result)
+	}
+}
+
+func idempotentDone(record func(Result)) Done {
+	var once sync.Once
+	return func(result Result) {
+		once.Do(func() {
+			record(result)
+		})
+	}
+}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -1,0 +1,201 @@
+// Package validation defines transport-neutral request validation and stable
+// field violation errors.
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/middleware"
+)
+
+const (
+	// Reason is the stable machine-readable reason used for validation
+	// failures.
+	Reason = "VALIDATION_FAILED"
+	// Code is the transport-neutral invalid-argument code.
+	Code int32 = 400
+
+	maxViolations   = 100
+	maxFieldBytes   = 512
+	maxRuleBytes    = 256
+	maxMessageBytes = 1024
+)
+
+var (
+	// ErrInvalidViolation reports a malformed field violation.
+	ErrInvalidViolation = errors.New("validation: invalid violation")
+	// ErrInvalidValidator reports a nil validator in a middleware chain.
+	ErrInvalidValidator = errors.New("validation: invalid validator")
+)
+
+// Violation describes one field rule failure without retaining the rejected
+// value.
+type Violation struct {
+	Field   string `json:"field"`
+	Rule    string `json:"rule"`
+	Message string `json:"message"`
+}
+
+// Error is an immutable collection of field violations.
+type Error struct {
+	violations []Violation
+}
+
+// New validates and snapshots field violations.
+func New(violations ...Violation) (*Error, error) {
+	if len(violations) == 0 {
+		return nil, fmt.Errorf("%w: at least one violation is required", ErrInvalidViolation)
+	}
+	if len(violations) > maxViolations {
+		return nil, fmt.Errorf("%w: violation count exceeds %d", ErrInvalidViolation, maxViolations)
+	}
+	snapshot := make([]Violation, len(violations))
+	for index, violation := range violations {
+		violation.Field = strings.TrimSpace(violation.Field)
+		violation.Rule = strings.TrimSpace(violation.Rule)
+		violation.Message = strings.TrimSpace(violation.Message)
+
+		if !validViolationText(violation.Field, maxFieldBytes) || !validViolationText(violation.Rule, maxRuleBytes) || !validViolationText(violation.Message, maxMessageBytes) {
+			return nil, fmt.Errorf("%w: violation %d is empty, oversized, or malformed", ErrInvalidViolation, index)
+		}
+		snapshot[index] = violation
+	}
+	return &Error{violations: snapshot}, nil
+}
+
+// Error returns the first field message and a count for remaining violations.
+func (e *Error) Error() string {
+	if e == nil || len(e.violations) == 0 {
+		return "validation failed"
+	}
+	first := e.violations[0]
+	if len(e.violations) == 1 {
+		return first.Field + ": " + first.Message
+	}
+	return fmt.Sprintf("%s: %s (and %d more)", first.Field, first.Message, len(e.violations)-1)
+}
+
+// Violations returns an independent ordered snapshot.
+func (e *Error) Violations() []Violation {
+	if e == nil {
+		return nil
+	}
+	return append([]Violation(nil), e.violations...)
+}
+
+// Validator validates one request value.
+type Validator interface {
+	Validate(context.Context, any) error
+}
+
+// Func adapts a function to Validator.
+type Func func(context.Context, any) error
+
+// Validate calls function.
+func (function Func) Validate(ctx context.Context, request any) error {
+	return function(ctx, request)
+}
+
+// ContextValidatable is implemented by request values that validate with a
+// cancellation-aware context.
+type ContextValidatable interface {
+	ValidateContext(context.Context) error
+}
+
+// Validatable is implemented by generated or hand-written request values.
+type Validatable interface {
+	Validate() error
+}
+
+// Self validates values implementing ContextValidatable or Validatable.
+func Self() Validator {
+	return Func(func(ctx context.Context, request any) error {
+		switch value := request.(type) {
+		case ContextValidatable:
+			return value.ValidateContext(ctx)
+		case Validatable:
+			return value.Validate()
+		default:
+			return nil
+		}
+	})
+}
+
+// Middleware validates requests in order before invoking the next handler.
+func Middleware(validators ...Validator) (middleware.Middleware, error) {
+	snapshot := append([]Validator(nil), validators...)
+	for index, validator := range snapshot {
+		if isNilValidator(validator) {
+			return nil, fmt.Errorf("%w: validator %d is nil", ErrInvalidValidator, index)
+		}
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		return func(ctx context.Context, request any) (any, error) {
+			for _, validator := range snapshot {
+				if err := validator.Validate(ctx, request); err != nil {
+					return nil, FrameworkError(err)
+				}
+			}
+			return next(ctx, request)
+		}
+	}, nil
+}
+
+func isNilValidator(validator Validator) bool {
+	if validator == nil {
+		return true
+	}
+	value := reflect.ValueOf(validator)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// FrameworkError converts any validation failure to the common Keelith error
+// shape while preserving its cause.
+func FrameworkError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if _, ok := errors.AsType[*kerrors.Error](err); ok {
+		return err
+	}
+
+	message := "request validation failed"
+	metadata := map[string]string(nil)
+
+	if validationError, ok := errors.AsType[*Error](err); ok {
+		message = validationError.Error()
+		content, encodeErr := json.Marshal(validationError.Violations())
+		if encodeErr == nil {
+			metadata = map[string]string{"violations": string(content)}
+		}
+	}
+	return kerrors.Wrap(err, Code, Reason, message, kerrors.WithMetadata(metadata))
+}
+
+func validViolationText(value string, maxBytes int) bool {
+	if value == "" || len(value) > maxBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## 变更说明

新增服务运行时契约与治理基础能力：

- 增加配置加载、合并、热更新与版本化配置支持
- 增加入站和出站治理，包括超时、重试、熔断、限流、负载保护、幂等和故障隔离
- 增加客户端路由、节点变更监听、Round Robin 选择器与请求校验
- 增加生成契约清单、统一错误模型以及运维诊断服务
- 将 Go 补丁版本升级至 1.26.6，修复标准库可达漏洞

关联 Issue：无

## 变更类型

- [ ] 缺陷修复
- [x] 新功能
- [ ] 破坏性变更
- [ ] 重构或性能优化
- [ ] 测试、文档或工程配置

## 验证

- `GOTOOLCHAIN=go1.26.6 go test -race -shuffle=on ./...`
- `GOTOOLCHAIN=go1.26.6 golangci-lint run --timeout=5m ./...`
- `GOTOOLCHAIN=go1.26.6 govulncheck ./...`
- `GOTOOLCHAIN=go1.26.6 go mod verify`

以上检查均已通过。

## 兼容性与风险

新增公共 API，未删除现有 API。构建所需 Go 补丁版本由 1.26.3 升级为 1.26.6。当前仓库暂无测试文件，本次以 race 构建、lint 和漏洞扫描作为主要验证。

## 检查清单

- [x] 我已阅读并遵循 `CONTRIBUTING.md`。
- [ ] 我已补充或更新相关测试。
- [ ] 我已补充或更新相关文档。
- [x] 本地测试和静态检查已通过。
- [x] 变更中不包含凭据、Token 或其他敏感信息。