### PR TITLE
feat: 添加核心传输适配能力

### DIFF
--- a/api/continuation/v1/protocol.keelith.gen.go
+++ b/api/continuation/v1/protocol.keelith.gen.go
@@ -13,7 +13,7 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
-const ContinuationServiceKeelithGeneratorProtocol = "v20"
+const ContinuationServiceKeelithGeneratorProtocol = "v1"
 
 // ContinuationServiceKeelithServer is the transport-neutral implementation contract.
 type ContinuationServiceKeelithServer interface {

--- a/api/continuation/v1/protocol.keelith.manifest.json
+++ b/api/continuation/v1/protocol.keelith.manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "v3",
-  "generatorProtocol": "v20",
+  "generatorProtocol": "v1",
   "source": "continuation/v1/protocol.proto",
   "package": "keelith.continuation.v1",
   "goImportPath": "github.com/keelab/keelith/api/continuation/v1",

--- a/api/projection/v1/protocol.keelith.gen.go
+++ b/api/projection/v1/protocol.keelith.gen.go
@@ -13,7 +13,7 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
-const ProjectionServiceKeelithGeneratorProtocol = "v20"
+const ProjectionServiceKeelithGeneratorProtocol = "v1"
 
 // ProjectionServiceKeelithServer is the transport-neutral implementation contract.
 type ProjectionServiceKeelithServer interface {

--- a/api/projection/v1/protocol.keelith.manifest.json
+++ b/api/projection/v1/protocol.keelith.manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "v3",
-  "generatorProtocol": "v20",
+  "generatorProtocol": "v1",
   "source": "projection/v1/protocol.proto",
   "package": "keelith.projection.v1",
   "goImportPath": "github.com/keelab/keelith/api/projection/v1",

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -12,23 +12,26 @@ import (
 )
 
 // ProtocolVersion identifies the generated adapter contract.
-const ProtocolVersion = "v20"
+const ProtocolVersion = "v1"
 
 var (
-	contextPackage     = protogen.GoImportPath("context")
-	fmtPackage         = protogen.GoImportPath("fmt")
-	ioPackage          = protogen.GoImportPath("io")
-	timePackage        = protogen.GoImportPath("time")
-	protoPackage       = protogen.GoImportPath("google.golang.org/protobuf/proto")
-	grpcPackage        = protogen.GoImportPath("google.golang.org/grpc")
-	errorsPackage      = protogen.GoImportPath("github.com/keelab/keelith/errors")
-	middlewarePackage  = protogen.GoImportPath("github.com/keelab/keelith/middleware")
-	operationPackage   = protogen.GoImportPath("github.com/keelab/keelith/operation")
-	servicePackage     = protogen.GoImportPath("github.com/keelab/keelith/service")
-	idempotencyPackage = protogen.GoImportPath("github.com/keelab/keelith/governance/idempotency")
-	httpPackage        = protogen.GoImportPath("github.com/keelab/keelith/transport/http")
-	ssePackage         = protogen.GoImportPath("github.com/keelab/keelith/transport/sse")
-	hertzPackage       = protogen.GoImportPath("github.com/keelab/keelith/x/transport/hertz")
+	contextPackage          = protogen.GoImportPath("context")
+	fmtPackage              = protogen.GoImportPath("fmt")
+	ioPackage               = protogen.GoImportPath("io")
+	timePackage             = protogen.GoImportPath("time")
+	protoPackage            = protogen.GoImportPath("google.golang.org/protobuf/proto")
+	grpcPackage             = protogen.GoImportPath("google.golang.org/grpc")
+	errorsPackage           = protogen.GoImportPath("github.com/keelab/keelith/errors")
+	middlewarePackage       = protogen.GoImportPath("github.com/keelab/keelith/middleware")
+	operationPackage        = protogen.GoImportPath("github.com/keelab/keelith/operation")
+	servicePackage          = protogen.GoImportPath("github.com/keelab/keelith/service")
+	idempotencyPackage      = protogen.GoImportPath("github.com/keelab/keelith/governance/idempotency")
+	httpPackage             = protogen.GoImportPath("github.com/keelab/keelith/transport/http")
+	continuationHTTPPackage = protogen.GoImportPath(
+		"github.com/keelab/keelith/transport/http/continuation",
+	)
+	ssePackage   = protogen.GoImportPath("github.com/keelab/keelith/transport/sse")
+	hertzPackage = protogen.GoImportPath("github.com/keelab/keelith/x/transport/hertz")
 )
 
 // Options controls opt-in generated adapters.

--- a/internal/generator/programmable.go
+++ b/internal/generator/programmable.go
@@ -178,7 +178,7 @@ func generateContinuationHelper(
 		"func ", callName, "(",
 		"ctx ", output.QualifiedGoIdent(contextPackage.Ident("Context")), ", ",
 		"client *", output.QualifiedGoIdent(
-			httpPackage.Ident("ContinuationClient"),
+			continuationHTTPPackage.Ident("ContinuationClient"),
 		), ", ",
 		"callID ", output.QualifiedGoIdent(
 			continuationPackage.Ident("CallID"),

--- a/ops/runtime_adapters.go
+++ b/ops/runtime_adapters.go
@@ -1,0 +1,765 @@
+package ops
+
+import (
+	"context"
+	"math"
+
+	kapp "github.com/keelab/keelith/app"
+	kclient "github.com/keelab/keelith/client"
+	"github.com/keelab/keelith/governance/breaker"
+	"github.com/keelab/keelith/governance/inbound"
+	"github.com/keelab/keelith/governance/loadshed"
+	"github.com/keelab/keelith/governance/policy"
+	"github.com/keelab/keelith/programmable/projection"
+	"github.com/keelab/keelith/registry/configured"
+	"github.com/keelab/keelith/saga"
+	"github.com/keelab/keelith/security/authz"
+	kgrpc "github.com/keelab/keelith/transport/grpc"
+	"github.com/keelab/keelith/transport/grpcauth"
+	khttp "github.com/keelab/keelith/transport/http"
+	"github.com/keelab/keelith/transport/tlsconfig"
+)
+
+// ApplicationRuntimeStatus adapts an App lifecycle without exposing terminal
+// errors, server identities, resource addresses, or hook details.
+func ApplicationRuntimeStatus(
+	instance *kapp.App,
+) RuntimeStatusProvider {
+	if instance == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := instance.Description()
+		return RuntimeStatus{
+			State:    description.State.String(),
+			Ready:    description.State == kapp.StateReady,
+			Degraded: description.Failed,
+			Capabilities: []string{
+				"explicit-drain",
+				"failure-terminal-state",
+				"single-run",
+			},
+		}, nil
+	}
+}
+
+// ProjectionRuntimeStatus adapts one projection shard without exposing row
+// keys, values, cursor contents, tenant identities, or source errors.
+func ProjectionRuntimeStatus(
+	admin projection.OwnerAdmin,
+	shard projection.ShardID,
+) RuntimeStatusProvider {
+	if admin == nil || shard.Validate() != nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		stats, err := admin.ProjectionStats(ctx, shard)
+		if err != nil {
+			return RuntimeStatus{}, err
+		}
+		if err := stats.Validate(); err != nil {
+			return RuntimeStatus{}, err
+		}
+		lag := stats.HeadOffset - stats.ProtectedOffset
+		gap := uint64(0)
+		if stats.FloorOffset > 0 {
+			gap = 1
+		}
+		active := stats.ActiveSubscribers
+		if active > uint64(math.MaxInt) {
+			active = uint64(math.MaxInt)
+		}
+		return RuntimeStatus{
+			State:    "active",
+			Ready:    true,
+			Degraded: lag > stats.HeadOffset/2 && lag > 100,
+			Active:   int(active),
+			Counters: []RuntimeCounter{
+				{Name: "floor", Value: stats.FloorOffset},
+				{Name: "gap", Value: gap},
+				{Name: "head", Value: stats.HeadOffset},
+				{Name: "lag", Value: lag},
+				{Name: "log_bytes", Value: stats.LogBytes},
+				{Name: "row_bytes", Value: stats.RowBytes},
+				{Name: "rows", Value: stats.Rows},
+				{Name: "subscribers", Value: stats.ActiveSubscribers},
+			},
+			Capabilities: []string{
+				"bounded-compaction",
+				"forced-snapshot",
+				"protected-checkpoint",
+			},
+		}, nil
+	}
+}
+
+// AuthorizationRuntimeStatus adapts dynamic RBAC without exposing revisions,
+// operation matchers, roles, scopes, principals, or decision reasons.
+func AuthorizationRuntimeStatus(
+	binding *authz.ConfigBinding,
+) RuntimeStatusProvider {
+	if binding == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := binding.Description()
+		state := "bootstrap"
+		if description.Loaded {
+			state = "active"
+		}
+		return RuntimeStatus{
+			State:    state,
+			Ready:    description.Loaded,
+			Degraded: description.Failed,
+			Active:   description.Rules,
+			Counters: []RuntimeCounter{
+				{Name: "allowed", Value: description.Allowed},
+				{Name: "denied", Value: description.Denied},
+				{Name: "evaluations", Value: description.Evaluations},
+				{Name: "rules", Value: uint64(description.Rules)},
+				{Name: "updates", Value: description.Updates},
+			},
+			Capabilities: []string{
+				"atomic-reload",
+				"deny-by-default",
+				"last-good",
+				"rbac",
+			},
+		}, nil
+	}
+}
+
+// PolicyConfigRuntimeStatus adapts a dynamic Method Policy binding to the
+// value-free runtime catalog schema.
+//
+// The provider exposes only lifecycle state and bounded rule counts. It never
+// exposes policy values, operation identities, configuration paths, revisions,
+// or validation errors.
+func PolicyConfigRuntimeStatus(
+	binding *policy.ConfigBinding,
+) RuntimeStatusProvider {
+	if binding == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := binding.Description()
+		state := "bootstrap"
+		if description.Loaded {
+			state = "active"
+		}
+		return RuntimeStatus{
+			State:    state,
+			Ready:    description.Loaded,
+			Degraded: description.Failed,
+			Active: description.ServiceRules +
+				description.MatcherRules +
+				description.MethodRules,
+			Counters: []RuntimeCounter{
+				{
+					Name:  "matcher_rules",
+					Value: uint64(description.MatcherRules),
+				},
+				{
+					Name:  "method_rules",
+					Value: uint64(description.MethodRules),
+				},
+				{
+					Name:  "service_rules",
+					Value: uint64(description.ServiceRules),
+				},
+			},
+			Capabilities: []string{
+				"atomic-reload",
+				"hierarchical-resolution",
+			},
+		}, nil
+	}
+}
+
+// ConfiguredDiscoveryRuntimeStatus adapts configured discovery to a bounded,
+// value-free runtime status.
+//
+// Service names, instance IDs, endpoints, metadata, configuration paths, and
+// revisions are intentionally omitted.
+func ConfiguredDiscoveryRuntimeStatus(
+	binding *configured.ConfigBinding,
+) RuntimeStatusProvider {
+	if binding == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := binding.Description()
+		state := "bootstrap"
+		if description.Loaded {
+			state = "active"
+		}
+		return RuntimeStatus{
+			State:    state,
+			Ready:    description.Loaded,
+			Degraded: description.Failed,
+			Active:   description.Watchers,
+			Counters: []RuntimeCounter{
+				{
+					Name:  "instances",
+					Value: uint64(description.Instances),
+				},
+				{
+					Name:  "services",
+					Value: uint64(description.Services),
+				},
+				{
+					Name:  "updates",
+					Value: description.Updates,
+				},
+				{
+					Name:  "watchers",
+					Value: uint64(description.Watchers),
+				},
+			},
+			Capabilities: []string{
+				"atomic-reload",
+				"full-snapshot-watch",
+			},
+		}, nil
+	}
+}
+
+// InboundRuntimeStatus adapts server admission and overload governance to a
+// bounded aggregate status.
+//
+// Operation keys and resolved policy values are never copied.
+func InboundRuntimeStatus(
+	runtime *inbound.Runtime,
+) RuntimeStatusProvider {
+	if runtime == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := runtime.Describe()
+		rateAccepted := uint64(0)
+		rateRejected := uint64(0)
+		rateInflight := 0
+		for _, limiter := range description.RateLimits {
+			rateAccepted += limiter.Accepted
+			rateRejected += limiter.Rejected
+			rateInflight += limiter.Inflight
+		}
+		shedAccepted := uint64(0)
+		shedRejected := uint64(0)
+		shedInflight := 0
+		for _, shedder := range description.LoadShedders {
+			shedAccepted += shedder.Accepted
+			shedRejected += shedder.Rejected
+			shedInflight += shedder.Inflight
+		}
+		active := rateInflight
+		if shedInflight > active {
+			active = shedInflight
+		}
+		return RuntimeStatus{
+			State:    "active",
+			Ready:    true,
+			Degraded: rateRejected > 0 || shedRejected > 0,
+			Active:   active,
+			Counters: []RuntimeCounter{
+				{
+					Name:  "load_shed_accepted",
+					Value: shedAccepted,
+				},
+				{
+					Name:  "load_shed_rejected",
+					Value: shedRejected,
+				},
+				{
+					Name:  "load_shedders",
+					Value: uint64(len(description.LoadShedders)),
+				},
+				{
+					Name:  "rate_limit_accepted",
+					Value: rateAccepted,
+				},
+				{
+					Name:  "rate_limit_rejected",
+					Value: rateRejected,
+				},
+				{
+					Name:  "rate_limiters",
+					Value: uint64(len(description.RateLimits)),
+				},
+			},
+			Capabilities: []string{
+				"adaptive-load-shedding",
+				"local-rate-limit",
+				"policy-snapshot",
+				"request-timeout",
+			},
+		}, nil
+	}
+}
+
+// RuntimeCPURuntimeStatus adapts the runtime CPU sampler without exposing
+// scheduler internals or raw runtime metrics.
+func RuntimeCPURuntimeStatus(
+	cpu *loadshed.RuntimeCPU,
+) RuntimeStatusProvider {
+	if cpu == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := cpu.Describe()
+		usage := math.Round(description.Usage * 10_000)
+		usage = math.Max(0, math.Min(10_000, usage))
+		return RuntimeStatus{
+			State:    string(description.State),
+			Ready:    description.Running,
+			Degraded: description.Failed,
+			Counters: []RuntimeCounter{
+				{
+					Name:  "failures",
+					Value: description.Failures,
+				},
+				{
+					Name:  "samples",
+					Value: description.Samples,
+				},
+				{
+					Name:  "usage_basis_points",
+					Value: uint64(usage),
+				},
+			},
+			Capabilities: []string{
+				"lock-free-read",
+				"runtime-cpu-sampling",
+			},
+		}, nil
+	}
+}
+
+// GRPCManagedDependencyRuntimeStatus adapts one lifecycle-owned dynamic gRPC
+// dependency to bounded, value-free runtime diagnostics.
+//
+// Service identity, endpoints, topology revision, and provider errors are not
+// copied from the detailed Description.
+func GRPCManagedDependencyRuntimeStatus(
+	dependency *kgrpc.ManagedDependency,
+) RuntimeStatusProvider {
+	if dependency == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := dependency.Describe()
+		routerRunning := description.Router.State == kclient.StateRunning
+		connectionRunning := description.Connection.State ==
+			kgrpc.DiscoveryStateRunning
+		degraded := description.Router.Stale ||
+			routerRunning && !description.Router.Connected ||
+			routerRunning && description.Router.Instances == 0 ||
+			description.Connection.DialFailures > 0
+		counters := []RuntimeCounter{
+			{
+				Name:  "connections",
+				Value: uint64(description.Connection.Connections),
+			},
+			{
+				Name:  "dial_failures",
+				Value: description.Connection.DialFailures,
+			},
+			{
+				Name:  "dialing",
+				Value: uint64(description.Connection.Dialing),
+			},
+			{
+				Name:  "instances",
+				Value: uint64(description.Router.Instances),
+			},
+			{
+				Name:  "locality_tiers",
+				Value: uint64(description.PreferenceTiers),
+			},
+			{
+				Name:  "reconnects",
+				Value: description.Router.Reconnects,
+			},
+			{
+				Name:  "retired",
+				Value: uint64(description.Connection.Retired),
+			},
+		}
+		capabilities := []string{
+			"dynamic-discovery",
+			"latest-topology",
+			"pooled-connections",
+			"selector-feedback",
+		}
+		if description.PreferenceTiers != 0 {
+			capabilities = append(capabilities, "ordered-locality")
+		}
+		return RuntimeStatus{
+			State:        string(description.Connection.State),
+			Ready:        routerRunning && connectionRunning,
+			Degraded:     degraded,
+			Active:       description.Connection.Active,
+			Counters:     counters,
+			Capabilities: capabilities,
+		}, nil
+	}
+}
+
+// HTTPBearerRuntimeStatus exposes the shared Secret-backed bearer lifecycle
+// under an HTTP-specific profile name without exposing token material.
+func HTTPBearerRuntimeStatus(
+	bearer *grpcauth.Bearer,
+) RuntimeStatusProvider {
+	return GRPCBearerRuntimeStatus(bearer)
+}
+
+// HTTPManagedDependencyRuntimeStatus adapts one lifecycle-owned dynamic HTTP
+// dependency to bounded, value-free runtime diagnostics.
+//
+// Service identity, endpoint values, topology revision, and provider errors
+// are intentionally omitted.
+func HTTPManagedDependencyRuntimeStatus(
+	dependency *khttp.ManagedDependency,
+) RuntimeStatusProvider {
+	if dependency == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := dependency.Describe()
+		routerRunning := description.Router.State == kclient.StateRunning
+		degraded := description.Router.Stale ||
+			routerRunning && !description.Router.Connected ||
+			routerRunning && description.Router.Instances == 0
+		capabilities := []string{
+			"dynamic-discovery",
+			"http-connection-pooling",
+			"selector-feedback",
+		}
+		if description.Schemes > 1 {
+			capabilities = append(capabilities, "multi-scheme")
+		}
+		if description.PreferenceTiers != 0 {
+			capabilities = append(capabilities, "ordered-locality")
+		}
+		return RuntimeStatus{
+			State:    string(description.State),
+			Ready:    description.State == khttp.ManagedDependencyRunning && routerRunning,
+			Degraded: degraded,
+			Active:   description.ActiveRequests,
+			Counters: []RuntimeCounter{
+				{
+					Name:  "instances",
+					Value: uint64(description.Router.Instances),
+				},
+				{
+					Name:  "locality_tiers",
+					Value: uint64(description.PreferenceTiers),
+				},
+				{
+					Name:  "reconnects",
+					Value: description.Router.Reconnects,
+				},
+				{
+					Name:  "schemes",
+					Value: uint64(description.Schemes),
+				},
+			},
+			Capabilities: capabilities,
+		}, nil
+	}
+}
+
+// OutboundRuntimeStatus adapts a client Outbound to bounded, value-free
+// runtime diagnostics.
+//
+// Dependency identities, operation keys, endpoints, policy values, revisions,
+// and errors are intentionally reduced to aggregate counters.
+func OutboundRuntimeStatus(
+	outbound *kclient.Outbound,
+) RuntimeStatusProvider {
+	if outbound == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := outbound.Describe()
+		unhealthyBreakers := 0
+		for _, item := range description.Dependency.Breakers {
+			if item.State != breaker.StateClosed {
+				unhealthyBreakers++
+			}
+		}
+		bulkheadInflight := 0
+		bulkheadQueued := 0
+		for _, item := range description.Dependency.Bulkheads {
+			bulkheadInflight += item.Inflight
+			bulkheadQueued += item.Queued
+		}
+		ejectedInstances := 0
+		for _, item := range description.Dependency.Instances {
+			if item.Ejected {
+				ejectedInstances++
+			}
+		}
+		counters := []RuntimeCounter{
+			{
+				Name:  "breaker_unhealthy",
+				Value: uint64(unhealthyBreakers),
+			},
+			{
+				Name:  "breakers",
+				Value: uint64(len(description.Dependency.Breakers)),
+			},
+			{
+				Name:  "bulkhead_inflight",
+				Value: uint64(bulkheadInflight),
+			},
+			{
+				Name:  "bulkhead_queued",
+				Value: uint64(bulkheadQueued),
+			},
+			{
+				Name:  "bulkheads",
+				Value: uint64(len(description.Dependency.Bulkheads)),
+			},
+			{
+				Name:  "ejected_instances",
+				Value: uint64(ejectedInstances),
+			},
+			{
+				Name:  "instances",
+				Value: uint64(len(description.Dependency.Instances)),
+			},
+			{
+				Name:  "middleware",
+				Value: uint64(len(description.Middleware)),
+			},
+			{
+				Name:  "retry_budgets",
+				Value: uint64(len(description.Dependency.Retry)),
+			},
+			{
+				Name:  "stream_middleware",
+				Value: uint64(len(description.StreamMiddleware)),
+			},
+		}
+		capabilities := []string{
+			"instance-outlier",
+			"logical-call-timeout",
+			"policy-snapshot",
+			"retry-hedging",
+			"service-breaker",
+		}
+		if description.Dependency.Admission.Enabled {
+			counters = append(counters,
+				RuntimeCounter{
+					Name:  "admission_accepted",
+					Value: description.Dependency.Admission.Accepted,
+				},
+				RuntimeCounter{
+					Name:  "admission_categories",
+					Value: uint64(description.Dependency.Admission.Categories),
+				},
+				RuntimeCounter{
+					Name:  "admission_dropped",
+					Value: description.Dependency.Admission.Dropped,
+				},
+				RuntimeCounter{
+					Name:  "admission_services",
+					Value: uint64(description.Dependency.Admission.Services),
+				},
+				RuntimeCounter{
+					Name:  "admission_updates",
+					Value: description.Dependency.Admission.Updates,
+				},
+			)
+			capabilities = append(capabilities, "dynamic-admission")
+		}
+		return RuntimeStatus{
+			State:        "active",
+			Ready:        true,
+			Degraded:     unhealthyBreakers > 0 || ejectedInstances > 0,
+			Active:       bulkheadInflight,
+			Counters:     counters,
+			Capabilities: capabilities,
+		}, nil
+	}
+}
+
+// SagaRuntimeStatus adapts aggregate orchestration counters without exposing
+// instance IDs, step names, durable failure reasons, or business payloads.
+func SagaRuntimeStatus(engine *saga.Engine) RuntimeStatusProvider {
+	if engine == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := engine.Description()
+		return RuntimeStatus{
+			State:  "available",
+			Ready:  true,
+			Active: int(description.Active),
+			Counters: []RuntimeCounter{
+				{Name: "action_failures", Value: description.ActionFailures},
+				{Name: "compensated", Value: description.Compensated},
+				{
+					Name:  "compensation_failures",
+					Value: description.CompensationFailures,
+				},
+				{Name: "completed", Value: description.Completed},
+				{Name: "contended", Value: description.Contended},
+				{Name: "lease_losses", Value: description.LeaseLosses},
+				{
+					Name:  "repository_failures",
+					Value: description.RepositoryFailures,
+				},
+				{Name: "started", Value: description.Started},
+				{
+					Name:  "terminal_failures",
+					Value: description.TerminalFailures,
+				},
+			},
+			Capabilities: []string{
+				"compensation",
+				"durable-resume",
+				"fencing",
+				"revision-cas",
+			},
+		}, nil
+	}
+}
+
+// TLSSecretRuntimeStatus adapts certificate reload state without exposing
+// secret references, filesystem paths, material versions, or error text.
+func TLSSecretRuntimeStatus(
+	watcher *tlsconfig.SecretWatcher,
+) RuntimeStatusProvider {
+	if watcher == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := watcher.Description()
+		return RuntimeStatus{
+			State:    string(description.State),
+			Ready:    description.Running && description.Reloads > 0,
+			Degraded: description.LastFailed,
+			Counters: []RuntimeCounter{
+				{Name: "failures", Value: description.Failures},
+				{Name: "reconnects", Value: description.Reconnects},
+				{Name: "reloads", Value: description.Reloads},
+			},
+			Capabilities: []string{
+				"atomic-reload",
+				"last-good",
+				"reconnect",
+			},
+		}, nil
+	}
+}
+
+// GRPCBearerRuntimeStatus adapts Secret-backed gRPC bearer state without
+// exposing token material, references, provider revisions, request targets, or
+// error text.
+func GRPCBearerRuntimeStatus(
+	bearer *grpcauth.Bearer,
+) RuntimeStatusProvider {
+	if bearer == nil {
+		return nil
+	}
+	return func(ctx context.Context) (RuntimeStatus, error) {
+		if ctx == nil {
+			return RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return RuntimeStatus{}, cause
+		}
+		description := bearer.Description()
+		return RuntimeStatus{
+			State:    string(description.State),
+			Ready:    description.Ready,
+			Degraded: description.Degraded,
+			Counters: []RuntimeCounter{
+				{Name: "failures", Value: description.Failures},
+				{Name: "reconnects", Value: description.Reconnects},
+				{Name: "reloads", Value: description.Reloads},
+			},
+			Capabilities: []string{
+				"bearer",
+				"hot-reload",
+				"last-good",
+				"secret-reference",
+				"transport-security-required",
+			},
+		}, nil
+	}
+}

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -1,0 +1,265 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+	"go.opentelemetry.io/otel/propagation"
+	ggrpc "google.golang.org/grpc"
+	gmetadata "google.golang.org/grpc/metadata"
+)
+
+// ClientOption configures a generated-client-compatible Client.
+type ClientOption interface {
+	applyClient(*clientOptions) error
+}
+
+type clientOptionFunc func(*clientOptions) error
+
+func (function clientOptionFunc) applyClient(options *clientOptions) error {
+	return function(options)
+}
+
+type clientOptions struct {
+	bundle         *middleware.Bundle
+	streamBundle   *middleware.StreamBundle
+	metadataPolicy metadata.Policy
+	errorCodec     *ErrorCodec
+	propagator     propagation.TextMapPropagator
+}
+
+// WithClientStreamMiddleware configures outbound stream lifecycle hooks.
+func WithClientStreamMiddleware(
+	bundle *middleware.StreamBundle,
+) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if bundle == nil {
+			return fmt.Errorf("stream middleware bundle is nil")
+		}
+		options.streamBundle = bundle
+		return nil
+	})
+}
+
+// WithClientMiddleware configures the immutable outbound middleware Bundle.
+func WithClientMiddleware(bundle *middleware.Bundle) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if bundle == nil {
+			return fmt.Errorf("middleware bundle is nil")
+		}
+		options.bundle = bundle
+		return nil
+	})
+}
+
+// WithClientMetadataPolicy configures gRPC metadata propagation.
+func WithClientMetadataPolicy(policy metadata.Policy) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		options.metadataPolicy = policy
+		return nil
+	})
+}
+
+// WithClientPropagator configures distributed context injection.
+func WithClientPropagator(
+	propagator propagation.TextMapPropagator,
+) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if propagator == nil {
+			return fmt.Errorf("propagator is nil")
+		}
+		options.propagator = propagator
+		return nil
+	})
+}
+
+// WithClientErrorCodec configures framework Error restoration.
+func WithClientErrorCodec(codec *ErrorCodec) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if codec == nil {
+			return fmt.Errorf("error codec is nil")
+		}
+		options.errorCodec = codec
+		return nil
+	})
+}
+
+// Client implements grpc.ClientConnInterface for generated clients.
+type Client struct {
+	connection     ggrpc.ClientConnInterface
+	bundle         *middleware.Bundle
+	streamBundle   *middleware.StreamBundle
+	metadataPolicy metadata.Policy
+	errorCodec     *ErrorCodec
+	propagator     propagation.TextMapPropagator
+}
+
+// NewClient wraps connection with Keelith's outbound contracts.
+func NewClient(
+	connection ggrpc.ClientConnInterface,
+	optionList ...ClientOption,
+) (*Client, error) {
+	if isNilConnection(connection) {
+		return nil, fmt.Errorf("%w: client connection is nil", ErrInvalidOption)
+	}
+	defaultCodec, _ := NewErrorCodec()
+	options := clientOptions{errorCodec: defaultCodec}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: client option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyClient(&options); err != nil {
+			return nil, fmt.Errorf("%w: client option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	return &Client{
+		connection:     connection,
+		bundle:         options.bundle,
+		streamBundle:   options.streamBundle,
+		metadataPolicy: options.metadataPolicy,
+		errorCodec:     options.errorCodec,
+		propagator:     options.propagator,
+	}, nil
+}
+
+// Invoke performs a unary RPC for generated clients.
+func (client *Client) Invoke(
+	ctx context.Context,
+	method string,
+	request any,
+	reply any,
+	options ...ggrpc.CallOption,
+) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	target, err := operationFromMethod(method, operation.KindUnary)
+	if err != nil {
+		return err
+	}
+	ctx, err = withOutboundRequestInfo(ctx, target)
+	if err != nil {
+		return err
+	}
+	invoke := middleware.Handler(func(
+		ctx context.Context,
+		request any,
+	) (any, error) {
+		outbound, outboundErr := outboundContext(
+			ctx,
+			client.metadataPolicy,
+			client.propagator,
+		)
+		if outboundErr != nil {
+			return nil, outboundErr
+		}
+		invokeErr := client.connection.Invoke(
+			outbound,
+			method,
+			request,
+			reply,
+			options...,
+		)
+		return reply, client.errorCodec.Decode(invokeErr)
+	})
+	if client.bundle != nil {
+		invoke = client.bundle.Chain()(invoke)
+	}
+	_, err = invoke(ctx, request)
+	return err
+}
+
+// NewStream begins a streaming RPC for generated clients.
+func (client *Client) NewStream(
+	ctx context.Context,
+	description *ggrpc.StreamDesc,
+	method string,
+	options ...ggrpc.CallOption,
+) (ggrpc.ClientStream, error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	if description == nil {
+		return nil, fmt.Errorf("%w: stream description is nil", ErrInvalidOption)
+	}
+	kind := streamOperationKind(description.ClientStreams, description.ServerStreams)
+	target, err := operationFromMethod(method, kind)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err = withOutboundRequestInfo(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	invoke := middleware.Handler(func(
+		ctx context.Context,
+		_ any,
+	) (any, error) {
+		outbound, outboundErr := outboundContext(
+			ctx,
+			client.metadataPolicy,
+			client.propagator,
+		)
+		if outboundErr != nil {
+			return nil, outboundErr
+		}
+		streamContext, cancelStream := context.WithCancel(outbound)
+		stream, streamErr := client.connection.NewStream(
+			streamContext,
+			description,
+			method,
+			options...,
+		)
+		if streamErr != nil {
+			cancelStream()
+			return nil, client.errorCodec.Decode(streamErr)
+		}
+		wrapped := newClientStream(
+			streamContext,
+			stream,
+			cancelStream,
+			client.errorCodec,
+			client.metadataPolicy,
+			client.streamBundle,
+			description.ClientStreams && !description.ServerStreams,
+		)
+		if openErr := wrapped.open(); openErr != nil {
+			_ = stream.CloseSend()
+			return nil, openErr
+		}
+		return wrapped, nil
+	})
+	if client.bundle != nil {
+		invoke = client.bundle.Chain()(invoke)
+	}
+	result, err := invoke(ctx, StreamInvocation{
+		FullMethod:    method,
+		ClientStreams: description.ClientStreams,
+		ServerStreams: description.ServerStreams,
+	})
+	if err != nil {
+		return nil, err
+	}
+	stream, ok := result.(ggrpc.ClientStream)
+	if !ok {
+		return nil, fmt.Errorf(
+			"grpc transport: middleware returned stream type %T",
+			result,
+		)
+	}
+	return stream, nil
+}
+
+func isNilConnection(connection ggrpc.ClientConnInterface) bool {
+	if connection == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(connection)
+	return reflected.Kind() == reflect.Pointer && reflected.IsNil()
+}
+
+type mapMetadata = gmetadata.MD

--- a/transport/grpc/continuation/client.go
+++ b/transport/grpc/continuation/client.go
@@ -1,0 +1,485 @@
+package continuationgrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	"github.com/keelab/keelith/programmable/continuation"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+const defaultClientMaxResponseBytes = 4 * 1024 * 1024
+
+var (
+	// ErrInvalidClient reports an invalid protocol client or option.
+	ErrInvalidClient = errors.New(
+		"continuation grpc transport: invalid client",
+	)
+)
+
+// ClientOption configures validated continuation v1 calls.
+type ClientOption interface {
+	applyClient(*clientOptions) error
+}
+
+type clientOptionFunc func(*clientOptions) error
+
+func (function clientOptionFunc) applyClient(options *clientOptions) error {
+	return function(options)
+}
+
+type clientOptions struct {
+	maxResponseBytes int
+	callOptions      []grpc.CallOption
+}
+
+// WithClientMaxResponseBytes sets the fully encoded inbound message budget.
+func WithClientMaxResponseBytes(maximum int) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if maximum < 256 || maximum > maxWireMessageBytes {
+			return ErrInvalidClient
+		}
+		options.maxResponseBytes = maximum
+		return nil
+	})
+}
+
+// WithClientCallOptions snapshots gRPC options applied to every RPC.
+func WithClientCallOptions(callOptions ...grpc.CallOption) ClientOption {
+	snapshot := append([]grpc.CallOption(nil), callOptions...)
+	return clientOptionFunc(func(options *clientOptions) error {
+		for _, option := range snapshot {
+			if isNilClientValue(option) {
+				return ErrInvalidClient
+			}
+		}
+		options.callOptions = append([]grpc.CallOption(nil), snapshot...)
+		return nil
+	})
+}
+
+// Client validates the complete ContinuationService protocol surface.
+type Client struct {
+	client           continuationv1.ContinuationServiceClient
+	maxResponseBytes int
+	callOptions      []grpc.CallOption
+}
+
+// NewClient validates and snapshots one generated protocol client.
+func NewClient(
+	client continuationv1.ContinuationServiceClient,
+	optionList ...ClientOption,
+) (*Client, error) {
+	if isNilClientValue(client) {
+		return nil, ErrInvalidClient
+	}
+	options := clientOptions{
+		maxResponseBytes: defaultClientMaxResponseBytes,
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: option %d is nil",
+				ErrInvalidClient,
+				index,
+			)
+		}
+		if err := option.applyClient(&options); err != nil {
+			return nil, fmt.Errorf(
+				"%w: option %d",
+				ErrInvalidClient,
+				index,
+			)
+		}
+	}
+	return &Client{
+		client:           client,
+		maxResponseBytes: options.maxResponseBytes,
+		callOptions:      append([]grpc.CallOption(nil), options.callOptions...),
+	}, nil
+}
+
+// Start durably creates one call and validates its snapshot identity.
+func (client *Client) Start(
+	ctx context.Context,
+	callID continuation.CallID,
+	target continuation.Operation,
+	input []byte,
+) (*continuationv1.StartResponse, error) {
+	if err := client.validateCall(ctx, callID); err != nil ||
+		target.String() == "" {
+		return nil, ErrInvalidClient
+	}
+	if len(input) > maxWirePayloadBytes {
+		return nil, ErrWireMessageTooLarge
+	}
+	response, err := client.client.Start(
+		ctx,
+		&continuationv1.StartRequest{
+			CallId:    callID.String(),
+			Operation: target.String(),
+			Input:     append([]byte(nil), input...),
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateResponse(response); err != nil {
+		return nil, err
+	}
+	if err := validateStartResponse(response, callID, target); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// StartWorkflow durably creates one exact immutable workflow definition.
+func (client *Client) StartWorkflow(
+	ctx context.Context,
+	callID continuation.CallID,
+	target continuation.Operation,
+	version string,
+	input []byte,
+) (*continuationv1.StartResponse, error) {
+	if err := client.validateCall(ctx, callID); err != nil ||
+		target.String() == "" || !validCommandID(version) {
+		return nil, ErrInvalidClient
+	}
+	if len(input) > maxWirePayloadBytes {
+		return nil, ErrWireMessageTooLarge
+	}
+	response, err := client.client.Start(
+		ctx,
+		&continuationv1.StartRequest{
+			CallId:          callID.String(),
+			Operation:       target.String(),
+			Input:           append([]byte(nil), input...),
+			WorkflowVersion: version,
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateResponse(response); err != nil {
+		return nil, err
+	}
+	if err := validateStartResponse(response, callID, target); err != nil ||
+		response.GetSnapshot().GetWorkflow() == nil ||
+		response.GetSnapshot().GetWorkflow().GetVersion() != version {
+		return nil, ErrInvalidWireMessage
+	}
+	return response, nil
+}
+
+// Poll returns one validated live page after an exclusive sequence.
+func (client *Client) Poll(
+	ctx context.Context,
+	callID continuation.CallID,
+	after uint64,
+	limit int,
+) (*continuationv1.PollResponse, error) {
+	if err := client.validatePageCall(ctx, callID, limit); err != nil {
+		return nil, err
+	}
+	response, err := client.client.Poll(
+		ctx,
+		&continuationv1.PollRequest{
+			CallId: callID.String(),
+			After:  after,
+			Limit:  uint32(limit),
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateResponse(response); err != nil {
+		return nil, err
+	}
+	if err := validatePageWire(response.GetPage(), callID, after, limit); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Attach opens one validated server stream after an exclusive sequence.
+func (client *Client) Attach(
+	ctx context.Context,
+	callID continuation.CallID,
+	after uint64,
+	limit int,
+) (*AttachmentStream, error) {
+	if err := client.validatePageCall(ctx, callID, limit); err != nil {
+		return nil, err
+	}
+	stream, err := client.client.Attach(
+		ctx,
+		&continuationv1.AttachRequest{
+			CallId: callID.String(),
+			After:  after,
+			Limit:  uint32(limit),
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if isNilClientValue(stream) {
+		return nil, ErrInvalidClient
+	}
+	return &AttachmentStream{
+		stream:           stream,
+		callID:           callID,
+		after:            after,
+		limit:            limit,
+		maxResponseBytes: client.maxResponseBytes,
+	}, nil
+}
+
+// Signal submits one idempotent signal and validates the returned identity.
+func (client *Client) Signal(
+	ctx context.Context,
+	callID continuation.CallID,
+	commandID string,
+	payload []byte,
+) (*continuationv1.SignalResponse, error) {
+	if err := client.validateCall(ctx, callID); err != nil ||
+		!validCommandID(commandID) {
+		return nil, ErrInvalidClient
+	}
+	if len(payload) > maxWirePayloadBytes {
+		return nil, ErrWireMessageTooLarge
+	}
+	response, err := client.client.Signal(
+		ctx,
+		&continuationv1.SignalRequest{
+			CallId:    callID.String(),
+			CommandId: commandID,
+			Payload:   append([]byte(nil), payload...),
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateSnapshotResponse(
+		response,
+		response.GetSnapshot(),
+		callID,
+	); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Cancel submits one idempotent cancellation command.
+func (client *Client) Cancel(
+	ctx context.Context,
+	callID continuation.CallID,
+	commandID string,
+) (*continuationv1.CancelResponse, error) {
+	if err := client.validateCall(ctx, callID); err != nil ||
+		!validCommandID(commandID) {
+		return nil, ErrInvalidClient
+	}
+	response, err := client.client.Cancel(
+		ctx,
+		&continuationv1.CancelRequest{
+			CallId:    callID.String(),
+			CommandId: commandID,
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateSnapshotResponse(
+		response,
+		response.GetSnapshot(),
+		callID,
+	); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetHistory returns one separately authorized historical page.
+func (client *Client) GetHistory(
+	ctx context.Context,
+	callID continuation.CallID,
+	after uint64,
+	limit int,
+) (*continuationv1.GetHistoryResponse, error) {
+	if err := client.validatePageCall(ctx, callID, limit); err != nil {
+		return nil, err
+	}
+	response, err := client.client.GetHistory(
+		ctx,
+		&continuationv1.GetHistoryRequest{
+			CallId: callID.String(),
+			After:  after,
+			Limit:  uint32(limit),
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateResponse(response); err != nil {
+		return nil, err
+	}
+	if err := validatePageWire(response.GetPage(), callID, after, limit); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetHistoryDetail returns one separately authorized payload-bearing page.
+func (client *Client) GetHistoryDetail(
+	ctx context.Context,
+	callID continuation.CallID,
+	after uint64,
+	limit int,
+	maxPayloadBytes int,
+) (*continuationv1.GetHistoryResponse, error) {
+	if err := client.validatePageCall(ctx, callID, limit); err != nil ||
+		maxPayloadBytes <= 0 || maxPayloadBytes > maxWireHistoryPayloadBytes {
+		return nil, ErrInvalidClient
+	}
+	response, err := client.client.GetHistory(
+		ctx,
+		&continuationv1.GetHistoryRequest{
+			CallId:          callID.String(),
+			After:           after,
+			Limit:           uint32(limit),
+			IncludePayload:  true,
+			MaxPayloadBytes: uint32(maxPayloadBytes),
+		},
+		client.callOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.validateResponse(response); err != nil {
+		return nil, err
+	}
+	if err := validatePageWire(response.GetPage(), callID, after, limit); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// AttachmentStream validates strict cursor continuity for Attach responses.
+type AttachmentStream struct {
+	stream grpc.ServerStreamingClient[continuationv1.AttachResponse]
+
+	mu               sync.Mutex
+	callID           continuation.CallID
+	after            uint64
+	limit            int
+	maxResponseBytes int
+}
+
+// Recv receives one bounded page and advances the exclusive cursor.
+func (stream *AttachmentStream) Recv() (*continuationv1.AttachResponse, error) {
+	if stream == nil || isNilClientValue(stream.stream) {
+		return nil, ErrInvalidClient
+	}
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	response, err := stream.stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	if response == nil || proto.Size(response) > stream.maxResponseBytes {
+		return nil, ErrWireMessageTooLarge
+	}
+	if err := validatePageWire(
+		response.GetPage(),
+		stream.callID,
+		stream.after,
+		stream.limit,
+	); err != nil {
+		return nil, err
+	}
+	stream.after = response.GetPage().GetNextSequence() - 1
+	return response, nil
+}
+
+func (client *Client) validateCall(
+	ctx context.Context,
+	callID continuation.CallID,
+) error {
+	if client == nil || ctx == nil || isNilClientValue(client.client) ||
+		callID.String() == "" {
+		return ErrInvalidClient
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return nil
+}
+
+func (client *Client) validatePageCall(
+	ctx context.Context,
+	callID continuation.CallID,
+	limit int,
+) error {
+	if err := client.validateCall(ctx, callID); err != nil {
+		return err
+	}
+	if limit < 1 || limit > maxWirePageFrames {
+		return ErrInvalidClient
+	}
+	return nil
+}
+
+func (client *Client) validateResponse(response proto.Message) error {
+	if response == nil {
+		return ErrInvalidWireMessage
+	}
+	if proto.Size(response) > client.maxResponseBytes {
+		return ErrWireMessageTooLarge
+	}
+	return nil
+}
+
+func (client *Client) validateSnapshotResponse(
+	response proto.Message,
+	snapshot *continuationv1.Snapshot,
+	callID continuation.CallID,
+) error {
+	if err := client.validateResponse(response); err != nil {
+		return err
+	}
+	if validateSnapshotWire(snapshot) != nil ||
+		snapshot.GetCallId() != callID.String() {
+		return ErrInvalidWireMessage
+	}
+	return nil
+}
+
+func isNilClientValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflection := reflect.ValueOf(value)
+	switch reflection.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return reflection.IsNil()
+	default:
+		return false
+	}
+}

--- a/transport/grpc/continuation/codec.go
+++ b/transport/grpc/continuation/codec.go
@@ -1,0 +1,410 @@
+package continuationgrpc
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	"github.com/keelab/keelith/programmable/continuation"
+)
+
+const (
+	maxWirePayloadBytes        = 1024 * 1024
+	maxWirePageFrames          = 1000
+	maxWireMessageBytes        = 32 * 1024 * 1024
+	maxWireHistoryPayloadBytes = 4 * 1024 * 1024
+)
+
+var (
+	// ErrInvalidWireMessage reports a malformed continuation v1 message.
+	ErrInvalidWireMessage = errors.New(
+		"continuation grpc transport: invalid wire message",
+	)
+	// ErrWireMessageTooLarge reports a message outside the configured budget.
+	ErrWireMessageTooLarge = errors.New(
+		"continuation grpc transport: wire message too large",
+	)
+)
+
+func callIDFromWire(value string) (continuation.CallID, error) {
+	callID, err := continuation.NewCallID(value)
+	if err != nil {
+		return continuation.CallID{}, ErrInvalidWireMessage
+	}
+	return callID, nil
+}
+
+func operationFromWire(value string) (continuation.Operation, error) {
+	target, err := continuation.NewOperation(value)
+	if err != nil {
+		return continuation.Operation{}, ErrInvalidWireMessage
+	}
+	return target, nil
+}
+
+func validCommandID(value string) bool {
+	_, err := continuation.NewCallID(value)
+	return err == nil
+}
+
+func snapshotToWire(
+	snapshot continuation.Snapshot,
+) (*continuationv1.Snapshot, error) {
+	if err := continuation.ValidateSnapshot(snapshot); err != nil {
+		return nil, ErrInvalidWireMessage
+	}
+	status, err := statusToWire(snapshot.Status())
+	if err != nil {
+		return nil, err
+	}
+	encoded := &continuationv1.Snapshot{
+		CallId:     snapshot.CallID().String(),
+		Operation:  snapshot.Operation().String(),
+		Status:     status,
+		Revision:   snapshot.Revision(),
+		Fence:      snapshot.Fence(),
+		Sequence:   snapshot.Sequence(),
+		FrameFloor: snapshot.FrameFloor(),
+		Terminal:   snapshot.Status().Terminal(),
+	}
+	if !snapshot.ReadyAt().IsZero() {
+		encoded.ReadyAt = snapshot.ReadyAt().UTC().Format(time.RFC3339Nano)
+	}
+	if workflow, ok := snapshot.Workflow(); ok {
+		encoded.Workflow, err = workflowToWire(workflow)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return encoded, nil
+}
+
+func frameToWire(
+	frame continuation.Frame,
+) (*continuationv1.Frame, error) {
+	if frame.Sequence() == 0 || len(frame.Payload()) > maxWirePayloadBytes {
+		return nil, ErrInvalidWireMessage
+	}
+	kind, err := frameKindToWire(frame.Kind())
+	if err != nil {
+		return nil, err
+	}
+	return &continuationv1.Frame{
+		Sequence: frame.Sequence(),
+		Kind:     kind,
+		Payload:  frame.Payload(),
+	}, nil
+}
+
+func pageToWire(
+	attachment continuation.Attachment,
+	after uint64,
+	limit int,
+) (*continuationv1.Page, error) {
+	if limit < 1 || limit > maxWirePageFrames ||
+		len(attachment.Frames) > limit ||
+		attachment.FrameFloor != attachment.Snapshot.FrameFloor() ||
+		attachment.Terminal != attachment.Snapshot.Status().Terminal() {
+		return nil, ErrInvalidWireMessage
+	}
+	snapshot, err := snapshotToWire(attachment.Snapshot)
+	if err != nil {
+		return nil, err
+	}
+	frames := make([]*continuationv1.Frame, len(attachment.Frames))
+	expected := after + 1
+	for index, frame := range attachment.Frames {
+		if frame.Sequence() != expected {
+			return nil, ErrInvalidWireMessage
+		}
+		encoded, frameErr := frameToWire(frame)
+		if frameErr != nil {
+			return nil, frameErr
+		}
+		frames[index] = encoded
+		expected++
+	}
+	if attachment.NextSequence != expected ||
+		attachment.NextSequence > attachment.Snapshot.Sequence()+1 {
+		return nil, ErrInvalidWireMessage
+	}
+	return &continuationv1.Page{
+		Snapshot:     snapshot,
+		Frames:       frames,
+		NextSequence: attachment.NextSequence,
+		FrameFloor:   attachment.FrameFloor,
+		Terminal:     attachment.Terminal,
+	}, nil
+}
+
+func startResponseToWire(
+	snapshot continuation.Snapshot,
+) (*continuationv1.StartResponse, error) {
+	encoded, err := snapshotToWire(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	response := &continuationv1.StartResponse{Snapshot: encoded}
+	if !snapshot.Status().Terminal() {
+		return response, nil
+	}
+	frames := snapshot.Frames()
+	if len(frames) == 0 {
+		return response, nil
+	}
+	last := frames[len(frames)-1]
+	if !terminalFrameKind(last.Kind()) {
+		return response, nil
+	}
+	response.TerminalFrame, err = frameToWire(last)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func splitAttachPage(
+	page *continuationv1.Page,
+) []*continuationv1.AttachResponse {
+	if page == nil {
+		return nil
+	}
+	if len(page.GetFrames()) == 0 {
+		if !page.GetTerminal() {
+			return nil
+		}
+		return []*continuationv1.AttachResponse{{Page: page}}
+	}
+	responses := make([]*continuationv1.AttachResponse, len(page.GetFrames()))
+	for index, frame := range page.GetFrames() {
+		responses[index] = &continuationv1.AttachResponse{
+			Page: &continuationv1.Page{
+				Snapshot:     page.GetSnapshot(),
+				Frames:       []*continuationv1.Frame{frame},
+				NextSequence: frame.GetSequence() + 1,
+				FrameFloor:   page.GetFrameFloor(),
+				Terminal:     page.GetTerminal(),
+			},
+		}
+	}
+	return responses
+}
+
+func validateStartResponse(
+	response *continuationv1.StartResponse,
+	callID continuation.CallID,
+	target continuation.Operation,
+) error {
+	if response == nil || validateSnapshotWire(response.GetSnapshot()) != nil ||
+		response.GetSnapshot().GetCallId() != callID.String() ||
+		response.GetSnapshot().GetOperation() != target.String() {
+		return ErrInvalidWireMessage
+	}
+	terminal := response.GetSnapshot().GetTerminal()
+	if response.GetTerminalFrame() != nil {
+		if !terminal || validateFrameWire(response.GetTerminalFrame()) != nil ||
+			response.GetTerminalFrame().GetSequence() !=
+				response.GetSnapshot().GetSequence() {
+			return ErrInvalidWireMessage
+		}
+	}
+	return nil
+}
+
+func validatePageWire(
+	page *continuationv1.Page,
+	callID continuation.CallID,
+	after uint64,
+	limit int,
+) error {
+	if page == nil || limit < 1 || limit > maxWirePageFrames ||
+		validateSnapshotWire(page.GetSnapshot()) != nil ||
+		page.GetSnapshot().GetCallId() != callID.String() ||
+		page.GetFrameFloor() != page.GetSnapshot().GetFrameFloor() ||
+		page.GetTerminal() != page.GetSnapshot().GetTerminal() ||
+		len(page.GetFrames()) > limit {
+		return ErrInvalidWireMessage
+	}
+	expected := after + 1
+	for _, frame := range page.GetFrames() {
+		if validateFrameWire(frame) != nil || frame.GetSequence() != expected {
+			return ErrInvalidWireMessage
+		}
+		expected++
+	}
+	if page.GetNextSequence() != expected ||
+		page.GetNextSequence() > page.GetSnapshot().GetSequence()+1 {
+		return ErrInvalidWireMessage
+	}
+	return nil
+}
+
+func validateSnapshotWire(snapshot *continuationv1.Snapshot) error {
+	if snapshot == nil || snapshot.GetRevision() == 0 ||
+		snapshot.GetFrameFloor() == 0 ||
+		snapshot.GetFrameFloor() > snapshot.GetSequence()+1 {
+		return ErrInvalidWireMessage
+	}
+	if _, err := callIDFromWire(snapshot.GetCallId()); err != nil {
+		return err
+	}
+	if _, err := operationFromWire(snapshot.GetOperation()); err != nil {
+		return err
+	}
+	status, err := statusFromWire(snapshot.GetStatus())
+	if err != nil || status.Terminal() != snapshot.GetTerminal() {
+		return ErrInvalidWireMessage
+	}
+	if readyAt := snapshot.GetReadyAt(); readyAt != "" {
+		parsed, parseErr := time.Parse(time.RFC3339Nano, readyAt)
+		if parseErr != nil || readyAt != parsed.UTC().Format(time.RFC3339Nano) ||
+			status != continuation.StatusSuspended {
+			return ErrInvalidWireMessage
+		}
+	}
+	if snapshot.GetWorkflow() != nil &&
+		validateWorkflowWire(snapshot.GetWorkflow()) != nil {
+		return ErrInvalidWireMessage
+	}
+	return nil
+}
+
+func validateFrameWire(frame *continuationv1.Frame) error {
+	if frame == nil || frame.GetSequence() == 0 ||
+		len(frame.GetPayload()) > maxWirePayloadBytes {
+		return ErrInvalidWireMessage
+	}
+	_, err := frameKindFromWire(frame.GetKind())
+	return err
+}
+
+func statusToWire(
+	status continuation.Status,
+) (continuationv1.CallStatus, error) {
+	switch status {
+	case continuation.StatusAccepted:
+		return continuationv1.CallStatus_CALL_STATUS_ACCEPTED, nil
+	case continuation.StatusRunning:
+		return continuationv1.CallStatus_CALL_STATUS_RUNNING, nil
+	case continuation.StatusWaiting:
+		return continuationv1.CallStatus_CALL_STATUS_WAITING, nil
+	case continuation.StatusSuspended:
+		return continuationv1.CallStatus_CALL_STATUS_SUSPENDED, nil
+	case continuation.StatusCancelRequested:
+		return continuationv1.CallStatus_CALL_STATUS_CANCEL_REQUESTED, nil
+	case continuation.StatusCompleted:
+		return continuationv1.CallStatus_CALL_STATUS_COMPLETED, nil
+	case continuation.StatusFailed:
+		return continuationv1.CallStatus_CALL_STATUS_FAILED, nil
+	case continuation.StatusCanceled:
+		return continuationv1.CallStatus_CALL_STATUS_CANCELED, nil
+	case continuation.StatusExpired:
+		return continuationv1.CallStatus_CALL_STATUS_EXPIRED, nil
+	default:
+		return continuationv1.CallStatus_CALL_STATUS_UNSPECIFIED,
+			ErrInvalidWireMessage
+	}
+}
+
+func statusFromWire(
+	status continuationv1.CallStatus,
+) (continuation.Status, error) {
+	switch status {
+	case continuationv1.CallStatus_CALL_STATUS_ACCEPTED:
+		return continuation.StatusAccepted, nil
+	case continuationv1.CallStatus_CALL_STATUS_RUNNING:
+		return continuation.StatusRunning, nil
+	case continuationv1.CallStatus_CALL_STATUS_WAITING:
+		return continuation.StatusWaiting, nil
+	case continuationv1.CallStatus_CALL_STATUS_SUSPENDED:
+		return continuation.StatusSuspended, nil
+	case continuationv1.CallStatus_CALL_STATUS_CANCEL_REQUESTED:
+		return continuation.StatusCancelRequested, nil
+	case continuationv1.CallStatus_CALL_STATUS_COMPLETED:
+		return continuation.StatusCompleted, nil
+	case continuationv1.CallStatus_CALL_STATUS_FAILED:
+		return continuation.StatusFailed, nil
+	case continuationv1.CallStatus_CALL_STATUS_CANCELED:
+		return continuation.StatusCanceled, nil
+	case continuationv1.CallStatus_CALL_STATUS_EXPIRED:
+		return continuation.StatusExpired, nil
+	default:
+		return "", ErrInvalidWireMessage
+	}
+}
+
+func frameKindToWire(
+	kind continuation.FrameKind,
+) (continuationv1.FrameKind, error) {
+	switch kind {
+	case continuation.FrameAccepted:
+		return continuationv1.FrameKind_FRAME_KIND_ACCEPTED, nil
+	case continuation.FrameEvent:
+		return continuationv1.FrameKind_FRAME_KIND_EVENT, nil
+	case continuation.FrameWaiting:
+		return continuationv1.FrameKind_FRAME_KIND_WAITING, nil
+	case continuation.FrameSignal:
+		return continuationv1.FrameKind_FRAME_KIND_SIGNAL, nil
+	case continuation.FrameSuspended:
+		return continuationv1.FrameKind_FRAME_KIND_SUSPENDED, nil
+	case continuation.FrameCancelRequested:
+		return continuationv1.FrameKind_FRAME_KIND_CANCEL_REQUESTED, nil
+	case continuation.FrameCompleted:
+		return continuationv1.FrameKind_FRAME_KIND_COMPLETED, nil
+	case continuation.FrameFailed:
+		return continuationv1.FrameKind_FRAME_KIND_FAILED, nil
+	case continuation.FrameCanceled:
+		return continuationv1.FrameKind_FRAME_KIND_CANCELED, nil
+	case continuation.FrameExpired:
+		return continuationv1.FrameKind_FRAME_KIND_EXPIRED, nil
+	case continuation.FrameWorkflowChild:
+		return continuationv1.FrameKind_FRAME_KIND_WORKFLOW_CHILD, nil
+	default:
+		return continuationv1.FrameKind_FRAME_KIND_UNSPECIFIED,
+			ErrInvalidWireMessage
+	}
+}
+
+func frameKindFromWire(
+	kind continuationv1.FrameKind,
+) (continuation.FrameKind, error) {
+	switch kind {
+	case continuationv1.FrameKind_FRAME_KIND_ACCEPTED:
+		return continuation.FrameAccepted, nil
+	case continuationv1.FrameKind_FRAME_KIND_EVENT:
+		return continuation.FrameEvent, nil
+	case continuationv1.FrameKind_FRAME_KIND_WAITING:
+		return continuation.FrameWaiting, nil
+	case continuationv1.FrameKind_FRAME_KIND_SIGNAL:
+		return continuation.FrameSignal, nil
+	case continuationv1.FrameKind_FRAME_KIND_SUSPENDED:
+		return continuation.FrameSuspended, nil
+	case continuationv1.FrameKind_FRAME_KIND_CANCEL_REQUESTED:
+		return continuation.FrameCancelRequested, nil
+	case continuationv1.FrameKind_FRAME_KIND_COMPLETED:
+		return continuation.FrameCompleted, nil
+	case continuationv1.FrameKind_FRAME_KIND_FAILED:
+		return continuation.FrameFailed, nil
+	case continuationv1.FrameKind_FRAME_KIND_CANCELED:
+		return continuation.FrameCanceled, nil
+	case continuationv1.FrameKind_FRAME_KIND_EXPIRED:
+		return continuation.FrameExpired, nil
+	case continuationv1.FrameKind_FRAME_KIND_WORKFLOW_CHILD:
+		return continuation.FrameWorkflowChild, nil
+	default:
+		return "", fmt.Errorf("%w: frame kind", ErrInvalidWireMessage)
+	}
+}
+
+func terminalFrameKind(kind continuation.FrameKind) bool {
+	switch kind {
+	case continuation.FrameCompleted,
+		continuation.FrameFailed,
+		continuation.FrameCanceled,
+		continuation.FrameExpired:
+		return true
+	default:
+		return false
+	}
+}

--- a/transport/grpc/continuation/error.go
+++ b/transport/grpc/continuation/error.go
@@ -1,0 +1,326 @@
+package continuationgrpc
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	"github.com/keelab/keelith/programmable/continuation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FailureFromError returns the structured continuation detail attached to a
+// gRPC status without exposing its human-readable message.
+func FailureFromError(err error) (*continuationv1.FailureDetail, bool) {
+	if err == nil {
+		return nil, false
+	}
+	for _, detail := range status.Convert(err).Details() {
+		if failure, ok := detail.(*continuationv1.FailureDetail); ok {
+			return failure, true
+		}
+	}
+	return nil, false
+}
+
+func continuationStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+	var gap *continuation.GapError
+	if errors.As(err, &gap) {
+		return statusWithFailure(
+			codes.OutOfRange,
+			"continuation history is no longer retained",
+			&continuationv1.FailureDetail{
+				Kind:              continuationv1.FailureKind_FAILURE_KIND_GAP,
+				RequestedSequence: gap.After,
+				FloorSequence:     gap.Floor,
+				StableReason:      "RETENTION_GAP",
+			},
+		)
+	}
+	var cursor *continuation.CursorError
+	if errors.As(err, &cursor) {
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation cursor is ahead of durable state",
+			&continuationv1.FailureDetail{
+				Kind:              continuationv1.FailureKind_FAILURE_KIND_CURSOR,
+				RequestedSequence: cursor.After,
+				CurrentSequence:   cursor.Current,
+				StableReason:      "CURSOR_AHEAD",
+			},
+		)
+	}
+	var timer *continuation.TimerNotReadyError
+	if errors.As(err, &timer) {
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation timer is not ready",
+			&continuationv1.FailureDetail{
+				Kind:         continuationv1.FailureKind_FAILURE_KIND_TIMER,
+				Retryable:    true,
+				StableReason: "TIMER_NOT_READY",
+				ReadyAt:      timer.ReadyAt.UTC().Format(time.RFC3339Nano),
+			},
+		)
+	}
+	switch {
+	case errors.Is(err, continuation.ErrTimerNotReady):
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation timer is not ready",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_TIMER,
+				true,
+				"TIMER_NOT_READY",
+			),
+		)
+	case errors.Is(err, continuation.ErrHistoryBudget):
+		return messageBudgetStatus()
+	case errors.Is(err, continuation.ErrAuthenticationRequired):
+		return statusWithFailure(
+			codes.Unauthenticated,
+			"continuation authentication is required",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_AUTHORIZATION,
+				false,
+				"AUTHENTICATION_REQUIRED",
+			),
+		)
+	case errors.Is(err, continuation.ErrAccessDenied),
+		errors.Is(err, continuation.ErrOwnershipConflict):
+		return statusWithFailure(
+			codes.PermissionDenied,
+			"continuation access is denied",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_AUTHORIZATION,
+				false,
+				"ACCESS_DENIED",
+			),
+		)
+	case errors.Is(err, continuation.ErrAuthorizationFailed):
+		return statusWithFailure(
+			codes.Internal,
+			"continuation authorization is unavailable",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_AUTHORIZATION,
+				false,
+				"AUTHORIZATION_FAILED",
+			),
+		)
+	case errors.Is(err, continuation.ErrGap):
+		return statusWithFailure(
+			codes.OutOfRange,
+			"continuation history is no longer retained",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_GAP,
+				false,
+				"RETENTION_GAP",
+			),
+		)
+	case errors.Is(err, continuation.ErrCursorAhead):
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation cursor is ahead of durable state",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_CURSOR,
+				false,
+				"CURSOR_AHEAD",
+			),
+		)
+	case errors.Is(err, continuation.ErrLeaseHeld):
+		return leaseStatus(codes.Aborted, "LEASE_HELD")
+	case errors.Is(err, continuation.ErrLeaseLost):
+		return leaseStatus(codes.Aborted, "LEASE_LOST")
+	case errors.Is(err, continuation.ErrStaleFence):
+		return leaseStatus(codes.Aborted, "STALE_FENCE")
+	case errors.Is(err, continuation.ErrNotReady):
+		return leaseStatus(codes.FailedPrecondition, "CALL_NOT_READY")
+	case errors.Is(err, continuation.ErrLeaseUnsupported):
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation lease capability is unavailable",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_LEASE,
+				false,
+				"LEASE_UNSUPPORTED",
+			),
+		)
+	case errors.Is(err, continuation.ErrMachineNotFound):
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation operation schema is unavailable",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_SCHEMA,
+				false,
+				"MACHINE_NOT_FOUND",
+			),
+		)
+	case errors.Is(err, continuation.ErrWorkflowDefinitionMismatch),
+		errors.Is(err, continuation.ErrWorkflowHandlerNotFound):
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation workflow schema is unavailable",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_SCHEMA,
+				false,
+				"WORKFLOW_SCHEMA_MISMATCH",
+			),
+		)
+	case errors.Is(err, continuation.ErrTerminal):
+		return statusWithFailure(
+			codes.FailedPrecondition,
+			"continuation call is terminal",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_TERMINAL,
+				false,
+				"CALL_TERMINAL",
+			),
+		)
+	case errors.Is(err, continuation.ErrNotFound),
+		errors.Is(err, continuation.ErrOwnershipNotFound):
+		return statusWithFailure(
+			codes.NotFound,
+			"continuation call was not found",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_NOT_FOUND,
+				false,
+				"CALL_NOT_FOUND",
+			),
+		)
+	case errors.Is(err, continuation.ErrAlreadyExists):
+		return statusWithFailure(
+			codes.AlreadyExists,
+			"continuation call already exists",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_CONFLICT,
+				false,
+				"CALL_ALREADY_EXISTS",
+			),
+		)
+	case errors.Is(err, continuation.ErrConflict),
+		errors.Is(err, continuation.ErrCommandConflict),
+		errors.Is(err, continuation.ErrTransition):
+		return statusWithFailure(
+			codes.Aborted,
+			"continuation state conflicts with the request",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_CONFLICT,
+				true,
+				"STATE_CONFLICT",
+			),
+		)
+	case errors.Is(err, ErrInvalidWireMessage),
+		errors.Is(err, continuation.ErrInvalidIdentity),
+		errors.Is(err, continuation.ErrInvalidFrame),
+		errors.Is(err, continuation.ErrInvalidAttach),
+		errors.Is(err, continuation.ErrInvalidInlineBudget),
+		errors.Is(err, continuation.ErrInvalidHistory),
+		errors.Is(err, continuation.ErrInvalidWorkflow),
+		errors.Is(err, continuation.ErrWorkflowCycle):
+		return invalidRequestStatus("INVALID_REQUEST")
+	case errors.Is(err, continuation.ErrInvalidService),
+		errors.Is(err, continuation.ErrInvalidRuntime),
+		errors.Is(err, continuation.ErrInvalidStore):
+		return statusWithFailure(
+			codes.Internal,
+			"continuation service is unavailable",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_UNAVAILABLE,
+				false,
+				"SERVICE_UNAVAILABLE",
+			),
+		)
+	default:
+		return statusWithFailure(
+			codes.Unavailable,
+			"continuation backend is unavailable",
+			failureDetail(
+				continuationv1.FailureKind_FAILURE_KIND_UNAVAILABLE,
+				true,
+				"BACKEND_UNAVAILABLE",
+			),
+		)
+	}
+}
+
+func invalidRequestStatus(reason string) error {
+	return statusWithFailure(
+		codes.InvalidArgument,
+		"continuation request is invalid",
+		failureDetail(
+			continuationv1.FailureKind_FAILURE_KIND_INVALID_REQUEST,
+			false,
+			reason,
+		),
+	)
+}
+
+func messageBudgetStatus() error {
+	return statusWithFailure(
+		codes.ResourceExhausted,
+		"continuation message exceeds configured budget",
+		failureDetail(
+			continuationv1.FailureKind_FAILURE_KIND_INVALID_REQUEST,
+			false,
+			"MESSAGE_BUDGET_EXCEEDED",
+		),
+	)
+}
+
+func invalidBackendStatus() error {
+	return statusWithFailure(
+		codes.Internal,
+		"continuation backend emitted invalid state",
+		failureDetail(
+			continuationv1.FailureKind_FAILURE_KIND_UNAVAILABLE,
+			false,
+			"INVALID_BACKEND_STATE",
+		),
+	)
+}
+
+func leaseStatus(code codes.Code, reason string) error {
+	return statusWithFailure(
+		code,
+		"continuation execution lease changed",
+		failureDetail(
+			continuationv1.FailureKind_FAILURE_KIND_LEASE,
+			true,
+			reason,
+		),
+	)
+}
+
+func failureDetail(
+	kind continuationv1.FailureKind,
+	retryable bool,
+	reason string,
+) *continuationv1.FailureDetail {
+	return &continuationv1.FailureDetail{
+		Kind:         kind,
+		Retryable:    retryable,
+		StableReason: reason,
+	}
+}
+
+func statusWithFailure(
+	code codes.Code,
+	message string,
+	detail *continuationv1.FailureDetail,
+) error {
+	base := status.New(code, message)
+	withDetails, err := base.WithDetails(detail)
+	if err != nil {
+		return base.Err()
+	}
+	return withDetails.Err()
+}

--- a/transport/grpc/continuation/server.go
+++ b/transport/grpc/continuation/server.go
@@ -1,0 +1,470 @@
+// Package continuationgrpc exposes the transport-neutral Continuation Service
+// through a bounded, authenticated gRPC v1 protocol.
+package continuationgrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	"github.com/keelab/keelith/programmable/continuation"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	defaultServerMaxRequestBytes  = 1536 * 1024
+	defaultServerMaxResponseBytes = 4 * 1024 * 1024
+	defaultServerPollInterval     = 100 * time.Millisecond
+	defaultServerInlineDuration   = 50 * time.Millisecond
+	defaultServerInlineSteps      = 64
+)
+
+var (
+	// ErrInvalidServer reports an invalid service, option, or registration.
+	ErrInvalidServer = errors.New(
+		"continuation grpc transport: invalid server",
+	)
+)
+
+// ServerOption configures bounded server behavior.
+type ServerOption interface {
+	applyServer(*serverOptions) error
+}
+
+type serverOptionFunc func(*serverOptions) error
+
+func (function serverOptionFunc) applyServer(options *serverOptions) error {
+	return function(options)
+}
+
+type serverOptions struct {
+	maxRequestBytes  int
+	maxResponseBytes int
+	pollInterval     time.Duration
+	inlineBudget     continuation.InlineBudget
+}
+
+// WithServerMaxRequestBytes sets the fully decoded per-request budget.
+func WithServerMaxRequestBytes(maximum int) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maximum < 256 || maximum > maxWireMessageBytes {
+			return ErrInvalidServer
+		}
+		options.maxRequestBytes = maximum
+		return nil
+	})
+}
+
+// WithServerMaxResponseBytes sets the fully encoded unary/stream message
+// budget. Attach splits pages to keep each message within this boundary.
+func WithServerMaxResponseBytes(maximum int) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maximum < 256 || maximum > maxWireMessageBytes {
+			return ErrInvalidServer
+		}
+		options.maxResponseBytes = maximum
+		return nil
+	})
+}
+
+// WithServerPollInterval sets idle Attach polling without changing cursor
+// semantics.
+func WithServerPollInterval(interval time.Duration) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if interval < time.Millisecond || interval > time.Minute {
+			return ErrInvalidServer
+		}
+		options.pollInterval = interval
+		return nil
+	})
+}
+
+// WithServerInlineBudget bounds synchronous execution after Start persists.
+func WithServerInlineBudget(budget continuation.InlineBudget) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if budget.Duration < time.Millisecond ||
+			budget.Duration > 5*time.Second ||
+			budget.MaxTransitions < 1 ||
+			budget.MaxTransitions > 10_000 {
+			return ErrInvalidServer
+		}
+		options.inlineBudget = budget
+		return nil
+	})
+}
+
+// Server adapts exactly one access-controlled Continuation Service.
+type Server struct {
+	continuationv1.UnimplementedContinuationServiceServer
+
+	service          *continuation.Service
+	maxRequestBytes  int
+	maxResponseBytes int
+	pollInterval     time.Duration
+	inlineBudget     continuation.InlineBudget
+	registered       bool
+}
+
+// NewServer validates and snapshots a fail-closed Continuation Service.
+func NewServer(
+	service *continuation.Service,
+	optionList ...ServerOption,
+) (*Server, error) {
+	if service == nil {
+		return nil, ErrInvalidServer
+	}
+	options := serverOptions{
+		maxRequestBytes:  defaultServerMaxRequestBytes,
+		maxResponseBytes: defaultServerMaxResponseBytes,
+		pollInterval:     defaultServerPollInterval,
+		inlineBudget: continuation.InlineBudget{
+			Duration:       defaultServerInlineDuration,
+			MaxTransitions: defaultServerInlineSteps,
+		},
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: option %d is nil",
+				ErrInvalidServer,
+				index,
+			)
+		}
+		if err := option.applyServer(&options); err != nil {
+			return nil, fmt.Errorf(
+				"%w: option %d",
+				ErrInvalidServer,
+				index,
+			)
+		}
+	}
+	return &Server{
+		service:          service,
+		maxRequestBytes:  options.maxRequestBytes,
+		maxResponseBytes: options.maxResponseBytes,
+		pollInterval:     options.pollInterval,
+		inlineBudget:     options.inlineBudget,
+	}, nil
+}
+
+// Register installs ContinuationService exactly once.
+func (server *Server) Register(registrar grpc.ServiceRegistrar) error {
+	if server == nil || registrar == nil || server.registered {
+		return ErrInvalidServer
+	}
+	continuationv1.RegisterContinuationServiceServer(registrar, server)
+	server.registered = true
+	return nil
+}
+
+// Start persists and optionally completes one authorized call inline.
+func (server *Server) Start(
+	ctx context.Context,
+	request *continuationv1.StartRequest,
+) (*continuationv1.StartResponse, error) {
+	if err := server.validateRequest(ctx, request); err != nil {
+		return nil, err
+	}
+	callID, err := callIDFromWire(request.GetCallId())
+	if err != nil {
+		return nil, invalidRequestStatus("INVALID_CALL_ID")
+	}
+	target, err := operationFromWire(request.GetOperation())
+	if err != nil {
+		return nil, invalidRequestStatus("INVALID_OPERATION")
+	}
+	if len(request.GetInput()) > maxWirePayloadBytes {
+		return nil, messageBudgetStatus()
+	}
+	var snapshot continuation.Snapshot
+	if request.GetWorkflowVersion() == "" {
+		snapshot, err = server.service.StartCallInline(
+			ctx,
+			callID,
+			target,
+			request.GetInput(),
+			server.inlineBudget,
+		)
+	} else {
+		version, versionErr := callIDFromWire(request.GetWorkflowVersion())
+		if versionErr != nil {
+			return nil, invalidRequestStatus("INVALID_WORKFLOW_VERSION")
+		}
+		snapshot, err = server.service.StartWorkflow(
+			ctx,
+			callID,
+			target,
+			version.String(),
+			request.GetInput(),
+		)
+	}
+	if err != nil {
+		return nil, continuationStatus(err)
+	}
+	response, err := startResponseToWire(snapshot)
+	if err != nil {
+		return nil, invalidBackendStatus()
+	}
+	if err := server.validateResponse(response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Poll returns one authorized bounded live page.
+func (server *Server) Poll(
+	ctx context.Context,
+	request *continuationv1.PollRequest,
+) (*continuationv1.PollResponse, error) {
+	if err := server.validateRequest(ctx, request); err != nil {
+		return nil, err
+	}
+	callID, limit, err := parsePageRequest(
+		request.GetCallId(),
+		request.GetLimit(),
+	)
+	if err != nil {
+		return nil, invalidRequestStatus("INVALID_POLL")
+	}
+	attachment, err := server.service.Attach(
+		ctx,
+		callID,
+		request.GetAfter(),
+		limit,
+	)
+	if err != nil {
+		return nil, continuationStatus(err)
+	}
+	page, err := pageToWire(attachment, request.GetAfter(), limit)
+	if err != nil {
+		return nil, invalidBackendStatus()
+	}
+	response := &continuationv1.PollResponse{Page: page}
+	if err := server.validateResponse(response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Attach follows authorized pages until terminal state or disconnect.
+func (server *Server) Attach(
+	request *continuationv1.AttachRequest,
+	stream grpc.ServerStreamingServer[continuationv1.AttachResponse],
+) error {
+	if server == nil || stream == nil {
+		return invalidBackendStatus()
+	}
+	if err := server.validateRequest(stream.Context(), request); err != nil {
+		return err
+	}
+	callID, limit, err := parsePageRequest(
+		request.GetCallId(),
+		request.GetLimit(),
+	)
+	if err != nil {
+		return invalidRequestStatus("INVALID_ATTACH")
+	}
+	after := request.GetAfter()
+	for {
+		attachment, attachErr := server.service.Attach(
+			stream.Context(),
+			callID,
+			after,
+			limit,
+		)
+		if attachErr != nil {
+			return continuationStatus(attachErr)
+		}
+		page, encodeErr := pageToWire(attachment, after, limit)
+		if encodeErr != nil {
+			return invalidBackendStatus()
+		}
+		for _, response := range splitAttachPage(page) {
+			if err := server.validateResponse(response); err != nil {
+				return err
+			}
+			if err := stream.Send(response); err != nil {
+				return err
+			}
+		}
+		if page.GetTerminal() {
+			return nil
+		}
+		if len(page.GetFrames()) > 0 {
+			after = page.GetNextSequence() - 1
+			continue
+		}
+		timer := time.NewTimer(server.pollInterval)
+		select {
+		case <-stream.Context().Done():
+			timer.Stop()
+			return statusFromContext(stream.Context())
+		case <-timer.C:
+		}
+	}
+}
+
+// Signal submits one authorized idempotent command.
+func (server *Server) Signal(
+	ctx context.Context,
+	request *continuationv1.SignalRequest,
+) (*continuationv1.SignalResponse, error) {
+	if err := server.validateRequest(ctx, request); err != nil {
+		return nil, err
+	}
+	callID, err := callIDFromWire(request.GetCallId())
+	if err != nil || !validCommandID(request.GetCommandId()) {
+		return nil, invalidRequestStatus("INVALID_SIGNAL")
+	}
+	if len(request.GetPayload()) > maxWirePayloadBytes {
+		return nil, messageBudgetStatus()
+	}
+	snapshot, err := server.service.SubmitSignal(
+		ctx,
+		callID,
+		request.GetCommandId(),
+		request.GetPayload(),
+	)
+	if err != nil {
+		return nil, continuationStatus(err)
+	}
+	encoded, err := snapshotToWire(snapshot)
+	if err != nil {
+		return nil, invalidBackendStatus()
+	}
+	response := &continuationv1.SignalResponse{Snapshot: encoded}
+	if err := server.validateResponse(response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Cancel submits one authorized idempotent cancellation command.
+func (server *Server) Cancel(
+	ctx context.Context,
+	request *continuationv1.CancelRequest,
+) (*continuationv1.CancelResponse, error) {
+	if err := server.validateRequest(ctx, request); err != nil {
+		return nil, err
+	}
+	callID, err := callIDFromWire(request.GetCallId())
+	if err != nil || !validCommandID(request.GetCommandId()) {
+		return nil, invalidRequestStatus("INVALID_CANCEL")
+	}
+	snapshot, err := server.service.RequestCancel(
+		ctx,
+		callID,
+		request.GetCommandId(),
+	)
+	if err != nil {
+		return nil, continuationStatus(err)
+	}
+	encoded, err := snapshotToWire(snapshot)
+	if err != nil {
+		return nil, invalidBackendStatus()
+	}
+	response := &continuationv1.CancelResponse{Snapshot: encoded}
+	if err := server.validateResponse(response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetHistory returns one separately authorized bounded historical page.
+func (server *Server) GetHistory(
+	ctx context.Context,
+	request *continuationv1.GetHistoryRequest,
+) (*continuationv1.GetHistoryResponse, error) {
+	if err := server.validateRequest(ctx, request); err != nil {
+		return nil, err
+	}
+	callID, limit, err := parsePageRequest(
+		request.GetCallId(),
+		request.GetLimit(),
+	)
+	if err != nil {
+		return nil, invalidRequestStatus("INVALID_HISTORY")
+	}
+	var attachment continuation.Attachment
+	if request.GetIncludePayload() {
+		attachment, err = server.service.HistoryDetail(
+			ctx,
+			callID,
+			request.GetAfter(),
+			limit,
+			int(request.GetMaxPayloadBytes()),
+		)
+	} else {
+		if request.GetMaxPayloadBytes() != 0 {
+			return nil, invalidRequestStatus("INVALID_HISTORY_BUDGET")
+		}
+		attachment, err = server.service.History(
+			ctx,
+			callID,
+			request.GetAfter(),
+			limit,
+		)
+	}
+	if err != nil {
+		return nil, continuationStatus(err)
+	}
+	page, err := pageToWire(attachment, request.GetAfter(), limit)
+	if err != nil {
+		return nil, invalidBackendStatus()
+	}
+	response := &continuationv1.GetHistoryResponse{Page: page}
+	if err := server.validateResponse(response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (server *Server) validateRequest(
+	ctx context.Context,
+	request proto.Message,
+) error {
+	if server == nil || ctx == nil || server.service == nil {
+		return invalidBackendStatus()
+	}
+	if request == nil {
+		return invalidRequestStatus("MISSING_REQUEST")
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return continuationStatus(cause)
+	}
+	if proto.Size(request) > server.maxRequestBytes {
+		return messageBudgetStatus()
+	}
+	return nil
+}
+
+func (server *Server) validateResponse(response proto.Message) error {
+	if response == nil {
+		return invalidBackendStatus()
+	}
+	if proto.Size(response) > server.maxResponseBytes {
+		return messageBudgetStatus()
+	}
+	return nil
+}
+
+func parsePageRequest(
+	callIDValue string,
+	limitValue uint32,
+) (continuation.CallID, int, error) {
+	callID, err := callIDFromWire(callIDValue)
+	if err != nil || limitValue < 1 || limitValue > maxWirePageFrames {
+		return continuation.CallID{}, 0, ErrInvalidWireMessage
+	}
+	return callID, int(limitValue), nil
+}
+
+func statusFromContext(ctx context.Context) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return continuationStatus(cause)
+	}
+	return continuationStatus(context.Canceled)
+}

--- a/transport/grpc/continuation/workflow.go
+++ b/transport/grpc/continuation/workflow.go
@@ -1,0 +1,161 @@
+package continuationgrpc
+
+import (
+	"encoding/hex"
+	"time"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	"github.com/keelab/keelith/programmable/continuation"
+)
+
+const maxWireWorkflowNodes = 10_000
+
+func workflowToWire(
+	workflow continuation.WorkflowView,
+) (*continuationv1.Workflow, error) {
+	nodes := workflow.Nodes()
+	if workflow.Version() == "" || workflow.Fingerprint() == "" ||
+		workflow.StartedAt().IsZero() || len(nodes) == 0 ||
+		len(nodes) > maxWireWorkflowNodes {
+		return nil, ErrInvalidWireMessage
+	}
+	encoded := &continuationv1.Workflow{
+		Version:     workflow.Version(),
+		Fingerprint: workflow.Fingerprint(),
+		StartedAt:   workflow.StartedAt().UTC().Format(time.RFC3339Nano),
+		Nodes:       make([]*continuationv1.WorkflowNode, len(nodes)),
+	}
+	for index, node := range nodes {
+		kind, err := workflowNodeKindToWire(node.Kind())
+		if err != nil {
+			return nil, err
+		}
+		status, err := workflowNodeStatusToWire(node.Status())
+		if err != nil {
+			return nil, err
+		}
+		encoded.Nodes[index] = &continuationv1.WorkflowNode{
+			Id:           node.ID(),
+			Kind:         kind,
+			Status:       status,
+			Attempt:      node.Attempt(),
+			ChildCallId:  node.ChildCallID().String(),
+			FailureClass: node.FailureClass(),
+		}
+		if !node.ReadyAt().IsZero() {
+			encoded.Nodes[index].ReadyAt = node.ReadyAt().UTC().Format(time.RFC3339Nano)
+		}
+	}
+	return encoded, nil
+}
+
+func validateWorkflowWire(workflow *continuationv1.Workflow) error {
+	if workflow == nil || workflow.GetVersion() == "" ||
+		len(workflow.GetFingerprint()) != 64 || workflow.GetStartedAt() == "" ||
+		len(workflow.GetNodes()) == 0 || len(workflow.GetNodes()) > maxWireWorkflowNodes {
+		return ErrInvalidWireMessage
+	}
+	if _, err := hex.DecodeString(workflow.GetFingerprint()); err != nil {
+		return ErrInvalidWireMessage
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, workflow.GetStartedAt())
+	if err != nil || workflow.GetStartedAt() != startedAt.UTC().Format(time.RFC3339Nano) {
+		return ErrInvalidWireMessage
+	}
+	seen := make(map[string]struct{}, len(workflow.GetNodes()))
+	for _, node := range workflow.GetNodes() {
+		if node == nil || node.GetId() == "" {
+			return ErrInvalidWireMessage
+		}
+		if _, duplicate := seen[node.GetId()]; duplicate {
+			return ErrInvalidWireMessage
+		}
+		seen[node.GetId()] = struct{}{}
+		if _, err := workflowNodeKindFromWire(node.GetKind()); err != nil {
+			return err
+		}
+		if _, err := workflowNodeStatusFromWire(node.GetStatus()); err != nil {
+			return err
+		}
+		if node.GetChildCallId() != "" {
+			if _, err := callIDFromWire(node.GetChildCallId()); err != nil {
+				return err
+			}
+		}
+		if node.GetReadyAt() != "" {
+			readyAt, parseErr := time.Parse(time.RFC3339Nano, node.GetReadyAt())
+			if parseErr != nil || node.GetReadyAt() != readyAt.UTC().Format(time.RFC3339Nano) {
+				return ErrInvalidWireMessage
+			}
+		}
+	}
+	return nil
+}
+
+func workflowNodeKindToWire(kind continuation.WorkflowNodeKind) (continuationv1.WorkflowNodeKind, error) {
+	switch kind {
+	case continuation.WorkflowNodeMachine:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_MACHINE, nil
+	case continuation.WorkflowNodeTimer:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_TIMER, nil
+	case continuation.WorkflowNodeChild:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_CHILD, nil
+	case continuation.WorkflowNodeJoin:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_JOIN, nil
+	default:
+		return 0, ErrInvalidWireMessage
+	}
+}
+
+func workflowNodeKindFromWire(kind continuationv1.WorkflowNodeKind) (continuation.WorkflowNodeKind, error) {
+	switch kind {
+	case continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_MACHINE:
+		return continuation.WorkflowNodeMachine, nil
+	case continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_TIMER:
+		return continuation.WorkflowNodeTimer, nil
+	case continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_CHILD:
+		return continuation.WorkflowNodeChild, nil
+	case continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_JOIN:
+		return continuation.WorkflowNodeJoin, nil
+	default:
+		return "", ErrInvalidWireMessage
+	}
+}
+
+func workflowNodeStatusToWire(status continuation.WorkflowNodeStatus) (continuationv1.WorkflowNodeStatus, error) {
+	switch status {
+	case continuation.WorkflowNodePending:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_PENDING, nil
+	case continuation.WorkflowNodeRunning:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_RUNNING, nil
+	case continuation.WorkflowNodeWaiting:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_WAITING, nil
+	case continuation.WorkflowNodeSucceeded:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_SUCCEEDED, nil
+	case continuation.WorkflowNodeFailed:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_FAILED, nil
+	case continuation.WorkflowNodeSkipped:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_SKIPPED, nil
+	default:
+		return 0, ErrInvalidWireMessage
+	}
+}
+
+func workflowNodeStatusFromWire(status continuationv1.WorkflowNodeStatus) (continuation.WorkflowNodeStatus, error) {
+	switch status {
+	case continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_PENDING:
+		return continuation.WorkflowNodePending, nil
+	case continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_RUNNING:
+		return continuation.WorkflowNodeRunning, nil
+	case continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_WAITING:
+		return continuation.WorkflowNodeWaiting, nil
+	case continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_SUCCEEDED:
+		return continuation.WorkflowNodeSucceeded, nil
+	case continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_FAILED:
+		return continuation.WorkflowNodeFailed, nil
+	case continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_SKIPPED:
+		return continuation.WorkflowNodeSkipped, nil
+	default:
+		return "", ErrInvalidWireMessage
+	}
+}

--- a/transport/grpc/dependency.go
+++ b/transport/grpc/dependency.go
@@ -1,0 +1,501 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	kclient "github.com/keelab/keelith/client"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/registry"
+	"github.com/keelab/keelith/selector"
+	"go.opentelemetry.io/otel/propagation"
+	ggrpc "google.golang.org/grpc"
+)
+
+const defaultDependencyRollbackTimeout = 5 * time.Second
+
+// SelectorFactory creates one service-scoped Selector while preserving
+// Outbound instance-health options.
+type SelectorFactory func(
+	scheme string,
+	options ...selector.Option,
+) (selector.Selector, error)
+
+// ManagedDependencyConfig defines one lifecycle-owned gRPC dependency.
+//
+// Discovery, Dial, and Outbound are application-instance dependencies. The
+// managed dependency owns only its Router, dynamic connection pool, and
+// transport wrapper.
+type ManagedDependencyConfig struct {
+	Name                  string
+	Service               string
+	Discovery             registry.Discovery
+	Outbound              *kclient.Outbound
+	Dial                  DialFunc
+	SelectorFactory       SelectorFactory
+	SelectorOptions       []selector.Option
+	ComponentDependencies []string
+	ReconnectMin          time.Duration
+	ReconnectMax          time.Duration
+	MaxStale              time.Duration
+	MaxConnections        int
+	IdleTimeout           time.Duration
+	RollbackTimeout       time.Duration
+	MetadataPolicy        metadata.Policy
+	Propagator            propagation.TextMapPropagator
+	ErrorCodec            *ErrorCodec
+}
+
+// ManagedDependencyFactoryConfig defines application-instance defaults shared
+// by generated gRPC dependency bindings.
+type ManagedDependencyFactoryConfig struct {
+	Discovery             registry.Discovery
+	Outbound              *kclient.Outbound
+	Dial                  DialFunc
+	SelectorFactory       SelectorFactory
+	SelectorOptions       []selector.Option
+	ComponentDependencies []string
+	ReconnectMin          time.Duration
+	ReconnectMax          time.Duration
+	MaxStale              time.Duration
+	MaxConnections        int
+	IdleTimeout           time.Duration
+	RollbackTimeout       time.Duration
+	MetadataPolicy        metadata.Policy
+	Propagator            propagation.TextMapPropagator
+	ErrorCodec            *ErrorCodec
+}
+
+// ManagedDependencyDescription is an immutable diagnostic snapshot.
+//
+// This detailed description may contain service identity and provider error
+// summaries. Use the Ops adapter for an HTTP-safe, value-free projection.
+type ManagedDependencyDescription struct {
+	Name            string
+	Service         string
+	PreferenceTiers int
+	Router          kclient.Description
+	Connection      DiscoveryDescription
+}
+
+// ManagedDependency owns the complete dynamic gRPC client path for one
+// logical service.
+//
+// It implements app.Component structurally. Start initializes discovery
+// before the connection pool; Stop drains connections before closing the
+// discovery watcher.
+type ManagedDependency struct {
+	name         string
+	service      string
+	dependencies []string
+	router       *kclient.Router
+	connection   *DiscoveryConnection
+	client       *Client
+	rollback     time.Duration
+	preference   int
+}
+
+// ManagedDependencyFactory creates independent service-scoped components that
+// share application-owned discovery, dial, policy, and telemetry defaults.
+//
+// The factory owns no goroutines or connections.
+type ManagedDependencyFactory struct {
+	config ManagedDependencyFactoryConfig
+}
+
+// NewManagedDependencyFactory validates shared generated-binding inputs.
+func NewManagedDependencyFactory(
+	config ManagedDependencyFactoryConfig,
+) (*ManagedDependencyFactory, error) {
+	if isNilDependencyValue(config.Discovery) {
+		return nil, fmt.Errorf("%w: discovery is nil", ErrInvalidOption)
+	}
+	if config.Outbound == nil {
+		return nil, fmt.Errorf("%w: outbound is nil", ErrInvalidOption)
+	}
+	if config.Dial == nil {
+		return nil, fmt.Errorf("%w: dial function is nil", ErrInvalidOption)
+	}
+	dependencies, err := validateFactoryDependencies(
+		config.ComponentDependencies,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if config.RollbackTimeout < 0 {
+		return nil, fmt.Errorf(
+			"%w: rollback timeout must not be negative",
+			ErrInvalidOption,
+		)
+	}
+	selectorOptions, err := copySelectorOptions(config.SelectorOptions)
+	if err != nil {
+		return nil, err
+	}
+	config.ComponentDependencies = dependencies
+	config.SelectorOptions = selectorOptions
+	return &ManagedDependencyFactory{config: config}, nil
+}
+
+// New creates one managed dependency with a distinct Router, Selector,
+// connection pool, and lifecycle.
+func (factory *ManagedDependencyFactory) New(
+	name string,
+	service string,
+) (*ManagedDependency, error) {
+	if factory == nil {
+		return nil, fmt.Errorf(
+			"%w: managed dependency factory is nil",
+			ErrInvalidOption,
+		)
+	}
+	config := factory.config
+	return NewManagedDependency(ManagedDependencyConfig{
+		Name:                  name,
+		Service:               service,
+		Discovery:             config.Discovery,
+		Outbound:              config.Outbound,
+		Dial:                  config.Dial,
+		SelectorFactory:       config.SelectorFactory,
+		SelectorOptions:       config.SelectorOptions,
+		ComponentDependencies: config.ComponentDependencies,
+		ReconnectMin:          config.ReconnectMin,
+		ReconnectMax:          config.ReconnectMax,
+		MaxStale:              config.MaxStale,
+		MaxConnections:        config.MaxConnections,
+		IdleTimeout:           config.IdleTimeout,
+		RollbackTimeout:       config.RollbackTimeout,
+		MetadataPolicy:        config.MetadataPolicy,
+		Propagator:            config.Propagator,
+		ErrorCodec:            config.ErrorCodec,
+	})
+}
+
+// NewManagedDependency assembles a service-scoped dynamic gRPC client.
+func NewManagedDependency(
+	config ManagedDependencyConfig,
+) (*ManagedDependency, error) {
+	name := strings.TrimSpace(config.Name)
+	service := strings.TrimSpace(config.Service)
+	if !validDiscoveryName(name) || !validDiscoveryName(service) {
+		return nil, fmt.Errorf(
+			"%w: dependency name or service is malformed",
+			ErrInvalidOption,
+		)
+	}
+	if isNilDependencyValue(config.Discovery) {
+		return nil, fmt.Errorf("%w: discovery is nil", ErrInvalidOption)
+	}
+	if config.Outbound == nil {
+		return nil, fmt.Errorf("%w: outbound is nil", ErrInvalidOption)
+	}
+	if config.Dial == nil {
+		return nil, fmt.Errorf("%w: dial function is nil", ErrInvalidOption)
+	}
+	dependencies, err := validateComponentDependencies(
+		name,
+		config.ComponentDependencies,
+	)
+	if err != nil {
+		return nil, err
+	}
+	factory := config.SelectorFactory
+	if factory == nil {
+		factory = defaultSelectorFactory
+	}
+	selectorOptions, err := copySelectorOptions(config.SelectorOptions)
+	if err != nil {
+		return nil, err
+	}
+	selectorOptions = append(
+		config.Outbound.SelectorOptions(),
+		selectorOptions...,
+	)
+	selected, err := factory("grpc", selectorOptions...)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create selector: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	if isNilDependencyValue(selected) {
+		return nil, fmt.Errorf(
+			"%w: selector factory returned nil",
+			ErrInvalidOption,
+		)
+	}
+	preferenceTiers := 0
+	if describer, ok := selected.(selector.PreferenceDescriber); ok {
+		preferenceTiers = describer.PreferenceTierCount()
+	}
+	router, err := kclient.NewRouter(kclient.RouterConfig{
+		Name:         name + ".router",
+		Service:      service,
+		Discovery:    config.Discovery,
+		Selector:     selected,
+		ReconnectMin: config.ReconnectMin,
+		ReconnectMax: config.ReconnectMax,
+		MaxStale:     config.MaxStale,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create router: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	connection, err := NewDiscoveryConnection(DiscoveryConnectionConfig{
+		Name:           name + ".connection",
+		Picker:         router,
+		NodeChanges:    router,
+		Dial:           config.Dial,
+		MaxConnections: config.MaxConnections,
+		IdleTimeout:    config.IdleTimeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create discovery connection: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	options := []ClientOption{
+		WithClientMiddleware(config.Outbound.Middleware()),
+		WithClientStreamMiddleware(config.Outbound.StreamMiddleware()),
+		WithClientMetadataPolicy(config.MetadataPolicy),
+	}
+	if config.Propagator != nil {
+		options = append(options, WithClientPropagator(config.Propagator))
+	}
+	if config.ErrorCodec != nil {
+		options = append(options, WithClientErrorCodec(config.ErrorCodec))
+	}
+	transport, err := NewClient(connection, options...)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create client transport: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	rollback := config.RollbackTimeout
+	if rollback == 0 {
+		rollback = defaultDependencyRollbackTimeout
+	}
+	if rollback <= 0 {
+		return nil, fmt.Errorf(
+			"%w: rollback timeout must be positive",
+			ErrInvalidOption,
+		)
+	}
+	return &ManagedDependency{
+		name:         name,
+		service:      service,
+		dependencies: dependencies,
+		router:       router,
+		connection:   connection,
+		client:       transport,
+		rollback:     rollback,
+		preference:   preferenceTiers,
+	}, nil
+}
+
+// Name returns the stable App component name.
+func (dependency *ManagedDependency) Name() string {
+	if dependency == nil {
+		return ""
+	}
+	return dependency.name
+}
+
+// Service returns the exact Protobuf service identity.
+func (dependency *ManagedDependency) Service() string {
+	if dependency == nil {
+		return ""
+	}
+	return dependency.service
+}
+
+// Dependencies returns explicit App component prerequisites such as a
+// provider-owned registry connection.
+func (dependency *ManagedDependency) Dependencies() []string {
+	if dependency == nil {
+		return nil
+	}
+	return append([]string(nil), dependency.dependencies...)
+}
+
+// ClientConn returns the generated-client-compatible governed transport.
+//
+// It is safe to construct typed clients before Start. Invocations are rejected
+// until the App starts this component.
+func (dependency *ManagedDependency) ClientConn() ggrpc.ClientConnInterface {
+	if dependency == nil {
+		return nil
+	}
+	return dependency.client
+}
+
+// Start loads the first discovery snapshot and then enables pooled calls.
+func (dependency *ManagedDependency) Start(ctx context.Context) error {
+	if dependency == nil {
+		return fmt.Errorf("%w: managed dependency is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	if err := dependency.router.Start(ctx); err != nil {
+		return fmt.Errorf("grpc transport: start dependency router: %w", err)
+	}
+	if err := dependency.connection.Start(ctx); err != nil {
+		rollbackCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			dependency.rollback,
+		)
+		defer cancel()
+		rollbackErr := errors.Join(
+			dependency.connection.Stop(rollbackCtx),
+			dependency.router.Stop(rollbackCtx),
+		)
+		return errors.Join(
+			fmt.Errorf(
+				"grpc transport: start dependency connection: %w",
+				err,
+			),
+			rollbackErr,
+		)
+	}
+	return nil
+}
+
+// Stop drains calls and streams before closing the discovery watcher.
+func (dependency *ManagedDependency) Stop(ctx context.Context) error {
+	if dependency == nil {
+		return nil
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	connectionErr := dependency.connection.Stop(ctx)
+	routerErr := dependency.router.Stop(ctx)
+	return errors.Join(connectionErr, routerErr)
+}
+
+// Describe returns detailed local diagnostics for the managed path.
+func (dependency *ManagedDependency) Describe() ManagedDependencyDescription {
+	if dependency == nil {
+		return ManagedDependencyDescription{}
+	}
+	return ManagedDependencyDescription{
+		Name:            dependency.name,
+		Service:         dependency.service,
+		PreferenceTiers: dependency.preference,
+		Router:          dependency.router.Describe(),
+		Connection:      dependency.connection.Describe(),
+	}
+}
+
+func copySelectorOptions(options []selector.Option) ([]selector.Option, error) {
+	result := append([]selector.Option(nil), options...)
+	for index, option := range result {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: selector option %d is nil",
+				ErrInvalidOption,
+				index,
+			)
+		}
+	}
+	return result, nil
+}
+
+func defaultSelectorFactory(
+	scheme string,
+	options ...selector.Option,
+) (selector.Selector, error) {
+	return selector.NewP2C(scheme, options...)
+}
+
+func validateComponentDependencies(
+	name string,
+	dependencies []string,
+) ([]string, error) {
+	result := make([]string, len(dependencies))
+	seen := make(map[string]struct{}, len(dependencies))
+	for index, dependency := range dependencies {
+		if strings.TrimSpace(dependency) != dependency ||
+			!validDiscoveryName(dependency) ||
+			dependency == name {
+			return nil, fmt.Errorf(
+				"%w: component dependency %d is malformed",
+				ErrInvalidOption,
+				index,
+			)
+		}
+		if _, duplicate := seen[dependency]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: component dependency %q is duplicated",
+				ErrInvalidOption,
+				dependency,
+			)
+		}
+		seen[dependency] = struct{}{}
+		result[index] = dependency
+	}
+	return result, nil
+}
+
+func validateFactoryDependencies(
+	dependencies []string,
+) ([]string, error) {
+	result := make([]string, len(dependencies))
+	seen := make(map[string]struct{}, len(dependencies))
+	for index, dependency := range dependencies {
+		if strings.TrimSpace(dependency) != dependency ||
+			!validDiscoveryName(dependency) {
+			return nil, fmt.Errorf(
+				"%w: component dependency %d is malformed",
+				ErrInvalidOption,
+				index,
+			)
+		}
+		if _, duplicate := seen[dependency]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: component dependency %q is duplicated",
+				ErrInvalidOption,
+				dependency,
+			)
+		}
+		seen[dependency] = struct{}{}
+		result[index] = dependency
+	}
+	return result, nil
+}
+
+func isNilDependencyValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+var _ ggrpc.ClientConnInterface = (*Client)(nil)

--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -1,0 +1,135 @@
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+
+	"github.com/keelab/keelith/selector"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+var (
+	// ErrInsecureEndpoint reports a grpc:// endpoint rejected by dial policy.
+	ErrInsecureEndpoint = errors.New(
+		"grpc transport: insecure endpoint is not allowed",
+	)
+)
+
+// NodeDialerConfig configures the default grpc-go connection factory.
+//
+// TLSConfig is cloned for every grpcs:// connection. DialOptions are copied;
+// DisableRetry, validated Keepalive, and transport credentials are appended
+// afterward so application options cannot weaken the profile's connection
+// policy. DisableRetry blocks service-configured retries, but grpc-go may still
+// transparently retry a call that was not processed by the remote server.
+// grpc-go v1.82.1 does not implement concurrent hedging, so this option does
+// not establish independently tested hedging semantics.
+type NodeDialerConfig struct {
+	TLSConfig     *tls.Config
+	AllowInsecure bool
+	// DisableRetry blocks service-configured replay after remote processing begins.
+	DisableRetry bool
+	DialOptions  []ggrpc.DialOption
+	Keepalive    *ClientKeepaliveConfig
+}
+
+// NewNodeDialer creates a DialFunc for discovered grpc:// and grpcs:// nodes.
+//
+// grpc:// is rejected unless AllowInsecure is explicitly enabled. grpcs://
+// uses system roots by default or a clone of TLSConfig when supplied.
+func NewNodeDialer(config NodeDialerConfig) (DialFunc, error) {
+	if config.TLSConfig != nil &&
+		config.TLSConfig.MinVersion != 0 &&
+		config.TLSConfig.MinVersion < tls.VersionTLS12 {
+		return nil, fmt.Errorf(
+			"%w: TLS minimum version must be TLS 1.2 or newer",
+			ErrInvalidOption,
+		)
+	}
+	options := append([]ggrpc.DialOption(nil), config.DialOptions...)
+	if config.DisableRetry {
+		options = append(options, ggrpc.WithDisableRetry())
+	}
+	if config.Keepalive != nil {
+		if err := validateClientKeepalive(*config.Keepalive); err != nil {
+			return nil, fmt.Errorf(
+				"%w: client keepalive: %w",
+				ErrInvalidOption,
+				err,
+			)
+		}
+		keepaliveConfig := *config.Keepalive
+		options = append(
+			options,
+			ggrpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time:                keepaliveConfig.PingInterval,
+				Timeout:             keepaliveConfig.PingTimeout,
+				PermitWithoutStream: keepaliveConfig.PermitWithoutStream,
+			}),
+		)
+	}
+	var tlsTemplate *tls.Config
+	if config.TLSConfig != nil {
+		tlsTemplate = config.TLSConfig.Clone()
+	}
+	return func(
+		ctx context.Context,
+		node selector.Node,
+	) (*ggrpc.ClientConn, error) {
+		if ctx == nil {
+			return nil, ErrNilContext
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return nil, cause
+		}
+		endpoint, err := parseGRPCEndpoint(node)
+		if err != nil {
+			return nil, err
+		}
+		dialOptions := append([]ggrpc.DialOption(nil), options...)
+		switch endpoint.Scheme {
+		case "grpc":
+			if !config.AllowInsecure {
+				return nil, fmt.Errorf(
+					"%w: node %q",
+					ErrInsecureEndpoint,
+					node.ID(),
+				)
+			}
+			dialOptions = append(
+				dialOptions,
+				ggrpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+		case "grpcs":
+			tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+			if tlsTemplate != nil {
+				tlsConfig = tlsTemplate.Clone()
+				if tlsConfig.MinVersion == 0 {
+					tlsConfig.MinVersion = tls.VersionTLS12
+				}
+			}
+			dialOptions = append(
+				dialOptions,
+				ggrpc.WithTransportCredentials(
+					credentials.NewTLS(tlsConfig),
+				),
+			)
+		default:
+			return nil, fmt.Errorf("%w: %q", ErrInvalidEndpoint, node.Endpoint())
+		}
+		connection, err := ggrpc.NewClient(endpoint.Host, dialOptions...)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"grpc transport: dial node %q: %w",
+				node.ID(),
+				err,
+			)
+		}
+		return connection, nil
+	}, nil
+}

--- a/transport/grpc/discovery.go
+++ b/transport/grpc/discovery.go
@@ -1,0 +1,1149 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	kclient "github.com/keelab/keelith/client"
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/registry"
+	"github.com/keelab/keelith/selector"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultDiscoveryMaxConnections = 64
+	defaultDiscoveryIdleTimeout    = 5 * time.Minute
+)
+
+var (
+	// ErrDiscoveryNotRunning reports an invocation outside pool lifecycle.
+	ErrDiscoveryNotRunning = errors.New("grpc transport: discovery connection not running")
+	// ErrPoolExhausted reports a full pool with no inactive connection to evict.
+	ErrPoolExhausted = errors.New("grpc transport: discovery connection pool exhausted")
+	// ErrInvalidEndpoint reports a selected non-gRPC authority endpoint.
+	ErrInvalidEndpoint = errors.New("grpc transport: invalid selected endpoint")
+	// ErrNodeRetired reports a node removed after selection but before leasing.
+	ErrNodeRetired = errors.New("grpc transport: selected node was retired")
+)
+
+// DiscoveryState is the observable dynamic connection lifecycle.
+type DiscoveryState string
+
+const (
+	// DiscoveryStateNew means Start has not been called.
+	DiscoveryStateNew DiscoveryState = "new"
+	// DiscoveryStateRunning means new call and stream leases are accepted.
+	DiscoveryStateRunning DiscoveryState = "running"
+	// DiscoveryStateStopping means new leases are rejected while active work drains.
+	DiscoveryStateStopping DiscoveryState = "stopping"
+	// DiscoveryStateStopped means every ClientConn has been closed.
+	DiscoveryStateStopped DiscoveryState = "stopped"
+)
+
+// DialFunc creates one grpc-go ClientConn for a selected immutable Node.
+type DialFunc func(context.Context, selector.Node) (*ggrpc.ClientConn, error)
+
+// DiscoveryConnectionConfig configures an instance-scoped dynamic pool.
+type DiscoveryConnectionConfig struct {
+	Name           string
+	Dependency     string
+	Picker         kclient.Picker
+	NodeChanges    kclient.NodeChangeSource
+	Dial           DialFunc
+	MaxConnections int
+	IdleTimeout    time.Duration
+}
+
+// DiscoveryDescription is a bounded dynamic connection diagnostic snapshot.
+type DiscoveryDescription struct {
+	Name             string
+	State            DiscoveryState
+	Connections      int
+	Dialing          int
+	Active           int
+	MaxConnections   int
+	DialAttempts     uint64
+	DialFailures     uint64
+	Evictions        uint64
+	Retired          int
+	Reconciliations  uint64
+	TopologyRevision string
+	LastError        string
+}
+
+type connectionEntry struct {
+	key        string
+	node       selector.Node
+	connection *ggrpc.ClientConn
+	active     int
+	lastUsed   time.Time
+	retired    bool
+}
+
+type pendingDial struct {
+	done   chan struct{}
+	cancel context.CancelCauseFunc
+}
+
+// DiscoveryConnection implements grpc.ClientConnInterface and app.Component.
+//
+// It lazily dials selected nodes, bounds cached connections, and holds stream
+// leases until their terminal event.
+type DiscoveryConnection struct {
+	name           string
+	dependency     string
+	picker         kclient.Picker
+	nodeChanges    kclient.NodeChangeSource
+	dial           DialFunc
+	maxConnections int
+	idleTimeout    time.Duration
+
+	mu               sync.Mutex
+	state            DiscoveryState
+	starting         bool
+	entries          map[string]*connectionEntry
+	dialing          map[string]*pendingDial
+	desired          map[string]struct{}
+	retired          map[string]struct{}
+	topologyManaged  bool
+	topologyVersion  uint64
+	topologyRevision string
+	active           int
+	finalizing       bool
+	stopErr          error
+	lastError        string
+
+	dialAttempts    uint64
+	dialFailures    uint64
+	evictions       uint64
+	reconciliations uint64
+
+	changeWatcher kclient.NodeChangeWatcher
+	changeCancel  context.CancelFunc
+	changeDone    chan struct{}
+	done          chan struct{}
+	doneOnce      sync.Once
+}
+
+// NewDiscoveryConnection validates a dynamic pool without starting it.
+func NewDiscoveryConnection(
+	config DiscoveryConnectionConfig,
+) (*DiscoveryConnection, error) {
+	name := strings.TrimSpace(config.Name)
+	if !validDiscoveryName(name) {
+		return nil, fmt.Errorf("%w: name is malformed", ErrInvalidOption)
+	}
+	dependency := strings.TrimSpace(config.Dependency)
+	if dependency != "" && !validDiscoveryName(dependency) {
+		return nil, fmt.Errorf("%w: dependency is malformed", ErrInvalidOption)
+	}
+	if isNilPicker(config.Picker) {
+		return nil, fmt.Errorf("%w: picker is nil", ErrInvalidOption)
+	}
+	if config.Dial == nil {
+		return nil, fmt.Errorf("%w: dial function is nil", ErrInvalidOption)
+	}
+	nodeChanges := config.NodeChanges
+	if isNilNodeChangeSource(nodeChanges) {
+		nodeChanges = nil
+		if source, ok := config.Picker.(kclient.NodeChangeSource); ok &&
+			!isNilNodeChangeSource(source) {
+			nodeChanges = source
+		}
+	}
+	maxConnections := config.MaxConnections
+	if maxConnections == 0 {
+		maxConnections = defaultDiscoveryMaxConnections
+	}
+	idleTimeout := config.IdleTimeout
+	if idleTimeout == 0 {
+		idleTimeout = defaultDiscoveryIdleTimeout
+	}
+	if maxConnections <= 0 || idleTimeout <= 0 {
+		return nil, fmt.Errorf(
+			"%w: connection limit and idle timeout must be positive",
+			ErrInvalidOption,
+		)
+	}
+	return &DiscoveryConnection{
+		name:           name,
+		dependency:     dependency,
+		picker:         config.Picker,
+		nodeChanges:    nodeChanges,
+		dial:           config.Dial,
+		maxConnections: maxConnections,
+		idleTimeout:    idleTimeout,
+		state:          DiscoveryStateNew,
+		entries:        make(map[string]*connectionEntry),
+		dialing:        make(map[string]*pendingDial),
+		desired:        make(map[string]struct{}),
+		retired:        make(map[string]struct{}),
+		done:           make(chan struct{}),
+	}, nil
+}
+
+// Name returns the stable App component name.
+func (connection *DiscoveryConnection) Name() string {
+	if connection == nil {
+		return ""
+	}
+	return connection.name
+}
+
+// Dependencies returns the optional Router component dependency.
+func (connection *DiscoveryConnection) Dependencies() []string {
+	if connection == nil || connection.dependency == "" {
+		return nil
+	}
+	return []string{connection.dependency}
+}
+
+// Start enables dynamic call leases.
+func (connection *DiscoveryConnection) Start(ctx context.Context) error {
+	if connection == nil {
+		return fmt.Errorf("%w: discovery connection is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	connection.mu.Lock()
+	if connection.state != DiscoveryStateNew || connection.starting {
+		connection.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	if connection.nodeChanges == nil {
+		connection.state = DiscoveryStateRunning
+		connection.mu.Unlock()
+		return nil
+	}
+	connection.starting = true
+	runtimeCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	connection.changeCancel = cancel
+	connection.mu.Unlock()
+
+	watcher, err := connection.nodeChanges.WatchNodeChanges(runtimeCtx)
+	if err != nil {
+		cancel()
+		connection.failChangeStart(err)
+		return fmt.Errorf("grpc transport: watch node changes: %w", err)
+	}
+	if isNilNodeChangeWatcher(watcher) {
+		cancel()
+		err = errors.New("node change source returned a nil watcher")
+		connection.failChangeStart(err)
+		return fmt.Errorf("grpc transport: %w", err)
+	}
+	initial, err := watcher.Next(ctx)
+	if err != nil {
+		cancel()
+		_ = watcher.Close()
+		connection.failChangeStart(err)
+		return fmt.Errorf("grpc transport: initial node change: %w", err)
+	}
+
+	connection.mu.Lock()
+	if connection.state != DiscoveryStateNew {
+		connection.starting = false
+		connection.changeCancel = nil
+		connection.mu.Unlock()
+		cancel()
+		_ = watcher.Close()
+		return ErrDiscoveryNotRunning
+	}
+	connection.starting = false
+	connection.state = DiscoveryStateRunning
+	connection.topologyManaged = true
+	connection.changeWatcher = watcher
+	connection.changeDone = make(chan struct{})
+	connection.applyNodeChangeLocked(initial)
+	changeDone := connection.changeDone
+	connection.mu.Unlock()
+
+	go connection.watchNodeChanges(runtimeCtx, watcher, changeDone)
+	return nil
+}
+
+// Stop rejects new leases, drains active calls/streams, and closes connections.
+func (connection *DiscoveryConnection) Stop(ctx context.Context) error {
+	if connection == nil {
+		return nil
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+
+	connection.mu.Lock()
+	switch connection.state {
+	case DiscoveryStateNew:
+		connection.state = DiscoveryStateStopping
+	case DiscoveryStateRunning:
+		connection.state = DiscoveryStateStopping
+	case DiscoveryStateStopping:
+	case DiscoveryStateStopped:
+		err := connection.stopErr
+		connection.mu.Unlock()
+		return err
+	}
+	changeCancel := connection.changeCancel
+	changeWatcher := connection.changeWatcher
+	changeDone := connection.changeDone
+	connection.cancelPendingDialsLocked(ErrDiscoveryNotRunning)
+	toClose, finalize := connection.beginFinalizeLocked()
+	done := connection.done
+	connection.mu.Unlock()
+	if changeCancel != nil {
+		changeCancel()
+	}
+	if !isNilNodeChangeWatcher(changeWatcher) {
+		_ = changeWatcher.Close()
+	}
+	if finalize {
+		connection.finalize(toClose)
+	}
+	if err := waitDiscoveryChannels(ctx, done, changeDone); err != nil {
+		return err
+	}
+	connection.mu.Lock()
+	err := connection.stopErr
+	connection.mu.Unlock()
+	return err
+}
+
+// Invoke selects one node and performs a unary call on its pooled ClientConn.
+func (connection *DiscoveryConnection) Invoke(
+	ctx context.Context,
+	method string,
+	request any,
+	reply any,
+	options ...ggrpc.CallOption,
+) (resultErr error) {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if err := connection.accepting(); err != nil {
+		return err
+	}
+	target, err := operationFromMethod(method, operation.KindUnary)
+	if err != nil {
+		return err
+	}
+	started := time.Now()
+	topologyVersion := connection.currentTopologyVersion()
+	node, done, err := connection.picker.Pick(ctx, target)
+	if err != nil {
+		return dependencyFailure(err)
+	}
+	defer completeSelection(ctx, done, started, &resultErr)
+
+	routedContext, err := selectedGRPCContext(ctx, target, node)
+	if err != nil {
+		return failure.MarkTransport(err)
+	}
+	entry, release, err := connection.lease(
+		routedContext,
+		node,
+		topologyVersion,
+	)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return entry.connection.Invoke(
+		routedContext,
+		method,
+		request,
+		reply,
+		options...,
+	)
+}
+
+// NewStream selects one node and holds its lease until stream termination.
+func (connection *DiscoveryConnection) NewStream(
+	ctx context.Context,
+	description *ggrpc.StreamDesc,
+	method string,
+	options ...ggrpc.CallOption,
+) (result ggrpc.ClientStream, resultErr error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	if description == nil {
+		return nil, fmt.Errorf("%w: stream description is nil", ErrInvalidOption)
+	}
+	if err := connection.accepting(); err != nil {
+		return nil, err
+	}
+	target, err := operationFromMethod(
+		method,
+		streamOperationKind(description.ClientStreams, description.ServerStreams),
+	)
+	if err != nil {
+		return nil, err
+	}
+	started := time.Now()
+	topologyVersion := connection.currentTopologyVersion()
+	node, done, err := connection.picker.Pick(ctx, target)
+	if err != nil {
+		return nil, dependencyFailure(err)
+	}
+	handedOff := false
+	var release func()
+	defer func() {
+		recovered := recover()
+		if !handedOff {
+			if release != nil {
+				release()
+			}
+			feedbackErr := resultErr
+			if recovered != nil {
+				feedbackErr = errors.New("grpc transport: stream creation panic")
+			}
+			done(selectionResult(ctx, started, feedbackErr))
+		}
+		if recovered != nil {
+			panic(recovered)
+		}
+	}()
+
+	routedContext, err := selectedGRPCContext(ctx, target, node)
+	if err != nil {
+		return nil, failure.MarkTransport(err)
+	}
+	entry, releaseLease, err := connection.lease(
+		routedContext,
+		node,
+		topologyVersion,
+	)
+	if err != nil {
+		return nil, err
+	}
+	release = releaseLease
+	stream, err := entry.connection.NewStream(
+		routedContext,
+		description,
+		method,
+		options...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	result = newDiscoveryClientStream(
+		routedContext,
+		stream,
+		done,
+		release,
+		started,
+		description.ClientStreams && !description.ServerStreams,
+	)
+	handedOff = true
+	return result, nil
+}
+
+// Describe returns bounded connection, dial, and lifecycle diagnostics.
+func (connection *DiscoveryConnection) Describe() DiscoveryDescription {
+	if connection == nil {
+		return DiscoveryDescription{
+			State:     DiscoveryStateStopped,
+			LastError: "discovery connection is nil",
+		}
+	}
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	retired := 0
+	for _, entry := range connection.entries {
+		if entry.retired {
+			retired++
+		}
+	}
+	return DiscoveryDescription{
+		Name:             connection.name,
+		State:            connection.state,
+		Connections:      len(connection.entries),
+		Dialing:          len(connection.dialing),
+		Active:           connection.active,
+		MaxConnections:   connection.maxConnections,
+		DialAttempts:     connection.dialAttempts,
+		DialFailures:     connection.dialFailures,
+		Evictions:        connection.evictions,
+		Retired:          retired,
+		Reconciliations:  connection.reconciliations,
+		TopologyRevision: connection.topologyRevision,
+		LastError:        connection.lastError,
+	}
+}
+
+func (connection *DiscoveryConnection) accepting() error {
+	if connection == nil {
+		return ErrDiscoveryNotRunning
+	}
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if connection.state != DiscoveryStateRunning {
+		return ErrDiscoveryNotRunning
+	}
+	return nil
+}
+
+func (connection *DiscoveryConnection) lease(
+	ctx context.Context,
+	node selector.Node,
+	selectionVersion uint64,
+) (*connectionEntry, func(), error) {
+	if _, err := parseGRPCEndpoint(node); err != nil {
+		return nil, nil, err
+	}
+	key := discoveryNodeKey(node.ID(), node.Endpoint(), node.Metadata())
+	for {
+		connection.mu.Lock()
+		if connection.state != DiscoveryStateRunning {
+			connection.mu.Unlock()
+			return nil, nil, ErrDiscoveryNotRunning
+		}
+		if connection.nodeRetiredLocked(key, selectionVersion) {
+			connection.mu.Unlock()
+			return nil, nil, retiredNodeError(node)
+		}
+		if entry := connection.entries[key]; entry != nil {
+			entry.active++
+			connection.active++
+			connection.mu.Unlock()
+			return entry, connection.releaseFunc(entry), nil
+		}
+		if pending := connection.dialing[key]; pending != nil {
+			done := pending.done
+			connection.mu.Unlock()
+			select {
+			case <-done:
+				continue
+			case <-ctx.Done():
+				return nil, nil, context.Cause(ctx)
+			}
+		}
+
+		evicted := connection.evictLocked(key, time.Now())
+		if len(connection.entries)+len(connection.dialing) >=
+			connection.maxConnections {
+			connection.mu.Unlock()
+			connection.closeEvicted(evicted)
+			return nil, nil, ErrPoolExhausted
+		}
+		dialContext, cancelDial := context.WithCancelCause(ctx)
+		pending := &pendingDial{
+			done:   make(chan struct{}),
+			cancel: cancelDial,
+		}
+		connection.dialing[key] = pending
+		connection.dialAttempts++
+		connection.mu.Unlock()
+		connection.closeEvicted(evicted)
+
+		clientConnection, dialErr := connection.dial(dialContext, node)
+		dialCause := context.Cause(dialContext)
+		cancelDial(context.Canceled)
+		if dialErr == nil && isNilClientConnection(clientConnection) {
+			dialErr = errors.New("dial function returned a nil ClientConn")
+		}
+
+		connection.mu.Lock()
+		delete(connection.dialing, key)
+		close(pending.done)
+		if errors.Is(dialCause, ErrNodeRetired) {
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			if !isNilClientConnection(clientConnection) {
+				_ = clientConnection.Close()
+			}
+			if finalize {
+				connection.finalize(toClose)
+			}
+			return nil, nil, retiredNodeError(node)
+		}
+		if errors.Is(dialCause, ErrDiscoveryNotRunning) {
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			if !isNilClientConnection(clientConnection) {
+				_ = clientConnection.Close()
+			}
+			if finalize {
+				connection.finalize(toClose)
+			}
+			return nil, nil, ErrDiscoveryNotRunning
+		}
+		if dialCause != nil {
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			if !isNilClientConnection(clientConnection) {
+				_ = clientConnection.Close()
+			}
+			if finalize {
+				connection.finalize(toClose)
+			}
+			return nil, nil, dialCause
+		}
+		if dialErr != nil {
+			connection.dialFailures++
+			connection.lastError = dialErr.Error()
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			if !isNilClientConnection(clientConnection) {
+				_ = clientConnection.Close()
+			}
+			if finalize {
+				connection.finalize(toClose)
+			}
+			return nil, nil, failure.MarkTransport(fmt.Errorf(
+				"grpc transport: dial node %q: %w",
+				node.ID(),
+				dialErr,
+			))
+		}
+		if connection.state != DiscoveryStateRunning {
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			_ = clientConnection.Close()
+			if finalize {
+				connection.finalize(toClose)
+			}
+			return nil, nil, ErrDiscoveryNotRunning
+		}
+		if connection.nodeRetiredLocked(key, selectionVersion) {
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			_ = clientConnection.Close()
+			if finalize {
+				connection.finalize(toClose)
+			}
+			return nil, nil, retiredNodeError(node)
+		}
+		entry := &connectionEntry{
+			key:        key,
+			node:       node,
+			connection: clientConnection,
+			active:     1,
+			lastUsed:   time.Now(),
+		}
+		connection.entries[key] = entry
+		connection.active++
+		connection.lastError = ""
+		connection.mu.Unlock()
+		return entry, connection.releaseFunc(entry), nil
+	}
+}
+
+func (connection *DiscoveryConnection) releaseFunc(
+	entry *connectionEntry,
+) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			connection.mu.Lock()
+			if entry.active > 0 {
+				entry.active--
+				connection.active--
+			}
+			entry.lastUsed = time.Now()
+			var retired []*ggrpc.ClientConn
+			if entry.active == 0 && entry.retired {
+				if connection.entries[entry.key] == entry {
+					delete(connection.entries, entry.key)
+					retired = append(retired, entry.connection)
+					connection.evictions++
+				}
+			}
+			toClose, finalize := connection.beginFinalizeLocked()
+			connection.mu.Unlock()
+			connection.closeEvicted(retired)
+			if finalize {
+				connection.finalize(toClose)
+			}
+		})
+	}
+}
+
+func (connection *DiscoveryConnection) failChangeStart(err error) {
+	connection.mu.Lock()
+	connection.starting = false
+	connection.changeCancel = nil
+	if err != nil {
+		connection.lastError = err.Error()
+	}
+	connection.mu.Unlock()
+}
+
+func (connection *DiscoveryConnection) watchNodeChanges(
+	ctx context.Context,
+	watcher kclient.NodeChangeWatcher,
+	done chan struct{},
+) {
+	defer close(done)
+	for {
+		change, err := watcher.Next(ctx)
+		if err != nil {
+			if context.Cause(ctx) == nil &&
+				!errors.Is(err, kclient.ErrNodeChangeWatcherClosed) {
+				connection.mu.Lock()
+				connection.lastError = err.Error()
+				connection.mu.Unlock()
+			}
+			return
+		}
+		connection.applyNodeChange(change)
+	}
+}
+
+func (connection *DiscoveryConnection) applyNodeChange(
+	change kclient.NodeChange,
+) {
+	connection.mu.Lock()
+	if connection.state != DiscoveryStateRunning {
+		connection.mu.Unlock()
+		return
+	}
+	toClose := connection.applyNodeChangeLocked(change)
+	connection.mu.Unlock()
+	connection.closeEvicted(toClose)
+}
+
+func (connection *DiscoveryConnection) applyNodeChangeLocked(
+	change kclient.NodeChange,
+) []*ggrpc.ClientConn {
+	desired := grpcTopologyKeys(change.Current())
+	retired := make(map[string]struct{})
+	for key := range connection.desired {
+		if _, exists := desired[key]; !exists {
+			retired[key] = struct{}{}
+		}
+	}
+	for _, instance := range change.Removed() {
+		for key := range grpcInstanceKeys(instance) {
+			retired[key] = struct{}{}
+		}
+	}
+	for _, update := range change.Updated() {
+		for key := range grpcInstanceKeys(update.Previous()) {
+			retired[key] = struct{}{}
+		}
+	}
+	for key := range desired {
+		delete(retired, key)
+	}
+
+	toClose := make([]*ggrpc.ClientConn, 0)
+	for key, entry := range connection.entries {
+		if _, exists := desired[key]; exists {
+			entry.retired = false
+			continue
+		}
+		entry.retired = true
+		retired[key] = struct{}{}
+		if entry.active == 0 {
+			delete(connection.entries, key)
+			toClose = append(toClose, entry.connection)
+			connection.evictions++
+		}
+	}
+	for key, pending := range connection.dialing {
+		if _, exists := desired[key]; exists {
+			continue
+		}
+		retired[key] = struct{}{}
+		if pending.cancel != nil {
+			pending.cancel(ErrNodeRetired)
+		}
+	}
+	connection.desired = desired
+	connection.retired = retired
+	connection.topologyManaged = true
+	connection.topologyVersion++
+	connection.topologyRevision = change.Revision()
+	connection.reconciliations++
+	return toClose
+}
+
+func (connection *DiscoveryConnection) cancelPendingDialsLocked(cause error) {
+	for _, pending := range connection.dialing {
+		if pending.cancel != nil {
+			pending.cancel(cause)
+		}
+	}
+}
+
+func grpcTopologyKeys(
+	instances []registry.Instance,
+) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, instance := range instances {
+		for key := range grpcInstanceKeys(instance) {
+			result[key] = struct{}{}
+		}
+	}
+	return result
+}
+
+func grpcInstanceKeys(instance registry.Instance) map[string]struct{} {
+	result := make(map[string]struct{})
+	metadata := instance.Metadata()
+	for _, endpoint := range instance.Endpoints() {
+		if _, err := parseGRPCEndpointValue(endpoint); err != nil {
+			continue
+		}
+		result[discoveryNodeKey(instance.ID(), endpoint, metadata)] = struct{}{}
+	}
+	return result
+}
+
+func discoveryNodeKey(
+	id string,
+	endpoint string,
+	metadata map[string]string,
+) string {
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var fingerprint strings.Builder
+	for _, key := range keys {
+		value := metadata[key]
+		fingerprint.WriteString(strconv.Itoa(len(key)))
+		fingerprint.WriteByte(':')
+		fingerprint.WriteString(key)
+		fingerprint.WriteString(strconv.Itoa(len(value)))
+		fingerprint.WriteByte(':')
+		fingerprint.WriteString(value)
+	}
+	return id + "\x00" + endpoint + "\x00" + fingerprint.String()
+}
+
+func waitDiscoveryChannels(
+	ctx context.Context,
+	poolDone <-chan struct{},
+	changeDone <-chan struct{},
+) error {
+	for poolDone != nil || changeDone != nil {
+		select {
+		case <-poolDone:
+			poolDone = nil
+		case <-changeDone:
+			changeDone = nil
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
+	}
+	return nil
+}
+
+func (connection *DiscoveryConnection) currentTopologyVersion() uint64 {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	return connection.topologyVersion
+}
+
+func (connection *DiscoveryConnection) nodeRetiredLocked(
+	key string,
+	selectionVersion uint64,
+) bool {
+	if !connection.topologyManaged {
+		return false
+	}
+	if _, retired := connection.retired[key]; retired {
+		return true
+	}
+	if connection.topologyVersion > selectionVersion {
+		_, current := connection.desired[key]
+		return !current
+	}
+	return false
+}
+
+func retiredNodeError(node selector.Node) error {
+	return failure.MarkTransport(fmt.Errorf(
+		"%w: %s at %s",
+		ErrNodeRetired,
+		node.ID(),
+		node.Endpoint(),
+	))
+}
+
+func (connection *DiscoveryConnection) evictLocked(
+	requestedKey string,
+	now time.Time,
+) []*ggrpc.ClientConn {
+	evicted := make([]*ggrpc.ClientConn, 0)
+	for key, entry := range connection.entries {
+		if key == requestedKey || entry.active != 0 {
+			continue
+		}
+		if now.Sub(entry.lastUsed) >= connection.idleTimeout {
+			delete(connection.entries, key)
+			evicted = append(evicted, entry.connection)
+			connection.evictions++
+		}
+	}
+	for len(connection.entries)+len(connection.dialing) >=
+		connection.maxConnections {
+		var oldest *connectionEntry
+		for _, entry := range connection.entries {
+			if entry.active != 0 ||
+				oldest != nil && !entry.lastUsed.Before(oldest.lastUsed) {
+				continue
+			}
+			oldest = entry
+		}
+		if oldest == nil {
+			break
+		}
+		delete(connection.entries, oldest.key)
+		evicted = append(evicted, oldest.connection)
+		connection.evictions++
+	}
+	return evicted
+}
+
+func (connection *DiscoveryConnection) closeEvicted(
+	connections []*ggrpc.ClientConn,
+) {
+	var closeErr error
+	for _, clientConnection := range connections {
+		if err := clientConnection.Close(); err != nil {
+			closeErr = errors.Join(closeErr, err)
+		}
+	}
+	if closeErr != nil {
+		connection.mu.Lock()
+		connection.stopErr = errors.Join(connection.stopErr, closeErr)
+		connection.lastError = closeErr.Error()
+		connection.mu.Unlock()
+	}
+}
+
+func (connection *DiscoveryConnection) beginFinalizeLocked() (
+	[]*ggrpc.ClientConn,
+	bool,
+) {
+	if connection.state != DiscoveryStateStopping ||
+		connection.finalizing ||
+		connection.active != 0 ||
+		len(connection.dialing) != 0 {
+		return nil, false
+	}
+	connection.finalizing = true
+	result := make([]*ggrpc.ClientConn, 0, len(connection.entries))
+	for _, entry := range connection.entries {
+		result = append(result, entry.connection)
+	}
+	connection.entries = make(map[string]*connectionEntry)
+	return result, true
+}
+
+func (connection *DiscoveryConnection) finalize(
+	connections []*ggrpc.ClientConn,
+) {
+	var closeErr error
+	for _, clientConnection := range connections {
+		if err := clientConnection.Close(); err != nil {
+			closeErr = errors.Join(closeErr, err)
+		}
+	}
+	connection.mu.Lock()
+	connection.stopErr = errors.Join(connection.stopErr, closeErr)
+	if closeErr != nil {
+		connection.lastError = closeErr.Error()
+	}
+	connection.state = DiscoveryStateStopped
+	connection.doneOnce.Do(func() { close(connection.done) })
+	connection.mu.Unlock()
+}
+
+func selectedGRPCContext(
+	ctx context.Context,
+	target operation.Operation,
+	node selector.Node,
+) (context.Context, error) {
+	endpoint, err := parseGRPCEndpoint(node)
+	if err != nil {
+		return nil, err
+	}
+	peer, err := operation.NewPeer(endpoint.Scheme, endpoint.Host)
+	if err != nil {
+		return nil, fmt.Errorf("%w: peer: %w", ErrInvalidEndpoint, err)
+	}
+	info, err := operation.NewRequestInfo(target, operation.WithPeer(peer))
+	if err != nil {
+		return nil, err
+	}
+	return operation.WithRequestInfo(ctx, info), nil
+}
+
+func parseGRPCEndpoint(node selector.Node) (*url.URL, error) {
+	return parseGRPCEndpointValue(node.Endpoint())
+}
+
+func parseGRPCEndpointValue(value string) (*url.URL, error) {
+	endpoint, err := url.Parse(value)
+	if err != nil ||
+		endpoint.Scheme != "grpc" && endpoint.Scheme != "grpcs" ||
+		endpoint.Host == "" ||
+		endpoint.User != nil ||
+		endpoint.Opaque != "" ||
+		endpoint.RawQuery != "" ||
+		endpoint.Fragment != "" ||
+		endpoint.RawPath != "" ||
+		endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, fmt.Errorf(
+			"%w: %q",
+			ErrInvalidEndpoint,
+			value,
+		)
+	}
+	return endpoint, nil
+}
+
+func completeSelection(
+	ctx context.Context,
+	done selector.Done,
+	started time.Time,
+	resultErr *error,
+) {
+	recovered := recover()
+	feedbackErr := *resultErr
+	if recovered != nil {
+		feedbackErr = errors.New("grpc transport: unary invocation panic")
+	}
+	done(selectionResult(ctx, started, feedbackErr))
+	if recovered != nil {
+		panic(recovered)
+	}
+}
+
+func selectionResult(
+	ctx context.Context,
+	started time.Time,
+	err error,
+) selector.Result {
+	feedbackErr := feedbackFailure(err)
+	return selector.Result{
+		Latency:  time.Since(started),
+		Error:    feedbackErr,
+		Canceled: errors.Is(feedbackErr, context.Canceled),
+		Retried:  operation.AttemptFromContext(ctx) > 1,
+	}
+}
+
+func feedbackFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	switch status.Code(err) {
+	case codes.Canceled:
+		return context.Canceled
+	case codes.DeadlineExceeded:
+		return context.DeadlineExceeded
+	case codes.Unavailable:
+		return failure.MarkTransport(err)
+	default:
+		return err
+	}
+}
+
+func dependencyFailure(err error) error {
+	if err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return failure.MarkTransport(err)
+}
+
+func validDiscoveryName(value string) bool {
+	if value == "" || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNilPicker(picker kclient.Picker) bool {
+	if picker == nil {
+		return true
+	}
+	value := reflect.ValueOf(picker)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func isNilNodeChangeSource(source kclient.NodeChangeSource) bool {
+	if source == nil {
+		return true
+	}
+	value := reflect.ValueOf(source)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func isNilNodeChangeWatcher(watcher kclient.NodeChangeWatcher) bool {
+	if watcher == nil {
+		return true
+	}
+	value := reflect.ValueOf(watcher)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func isNilClientConnection(connection *ggrpc.ClientConn) bool {
+	return connection == nil
+}
+
+var _ ggrpc.ClientConnInterface = (*DiscoveryConnection)(nil)

--- a/transport/grpc/discovery_stream.go
+++ b/transport/grpc/discovery_stream.go
@@ -1,0 +1,102 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/selector"
+	ggrpc "google.golang.org/grpc"
+)
+
+type discoveryClientStream struct {
+	ggrpc.ClientStream
+
+	done            selector.Done
+	release         func()
+	started         time.Time
+	context         context.Context
+	finishOnReceive bool
+	completed       chan struct{}
+	once            sync.Once
+}
+
+func newDiscoveryClientStream(
+	ctx context.Context,
+	stream ggrpc.ClientStream,
+	done selector.Done,
+	release func(),
+	started time.Time,
+	finishOnReceive bool,
+) *discoveryClientStream {
+	wrapped := &discoveryClientStream{
+		ClientStream:    stream,
+		done:            done,
+		release:         release,
+		started:         started,
+		context:         ctx,
+		finishOnReceive: finishOnReceive,
+		completed:       make(chan struct{}),
+	}
+	go wrapped.watchContext()
+	return wrapped
+}
+
+func (stream *discoveryClientStream) Header() (mapMetadata, error) {
+	header, err := stream.ClientStream.Header()
+	if err != nil {
+		stream.finish(err)
+	}
+	return header, err
+}
+
+func (stream *discoveryClientStream) CloseSend() error {
+	err := stream.ClientStream.CloseSend()
+	if err != nil {
+		stream.finish(err)
+	}
+	return err
+}
+
+func (stream *discoveryClientStream) SendMsg(message any) error {
+	err := stream.ClientStream.SendMsg(message)
+	if err != nil && !errors.Is(err, io.EOF) {
+		stream.finish(err)
+	}
+	return err
+}
+
+func (stream *discoveryClientStream) RecvMsg(message any) error {
+	err := stream.ClientStream.RecvMsg(message)
+	switch {
+	case errors.Is(err, io.EOF):
+		stream.finish(nil)
+	case err != nil:
+		stream.finish(err)
+	case stream.finishOnReceive:
+		stream.finish(nil)
+	}
+	return err
+}
+
+func (stream *discoveryClientStream) finish(err error) {
+	stream.once.Do(func() {
+		stream.release()
+		stream.done(selectionResult(
+			stream.context,
+			stream.started,
+			err,
+		))
+		close(stream.completed)
+	})
+}
+
+func (stream *discoveryClientStream) watchContext() {
+	select {
+	case <-stream.context.Done():
+		stream.finish(context.Cause(stream.context))
+	case <-stream.completed:
+	}
+}

--- a/transport/grpc/error.go
+++ b/transport/grpc/error.go
@@ -1,0 +1,180 @@
+// Package grpc provides Keelith's grpc-go transport.
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	errorDomain   = "keelith.anniext.cn"
+	errorCodeKey  = "keelith_code"
+	defaultReason = "GRPC_ERROR"
+)
+
+var (
+	// ErrInvalidOption means a transport option is unsafe or incomplete.
+	ErrInvalidOption = errors.New("grpc transport: invalid option")
+	// ErrAlreadyStarted means Server.Start was called more than once.
+	ErrAlreadyStarted = errors.New("grpc transport: server already started")
+	// ErrNilContext means a public operation received a nil context.
+	ErrNilContext = errors.New("grpc transport: nil context")
+)
+
+// ErrorCodec maps immutable Keelith Errors to gRPC status details.
+type ErrorCodec struct {
+	allowed []string
+}
+
+// NewErrorCodec constructs an ErrorCodec with a wire metadata allowlist.
+func NewErrorCodec(allowedMetadata ...string) (*ErrorCodec, error) {
+	allowed := make([]string, 0, len(allowedMetadata))
+	seen := make(map[string]struct{}, len(allowedMetadata))
+	for _, key := range allowedMetadata {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" || normalized == errorCodeKey {
+			return nil, fmt.Errorf("%w: error metadata key %q", ErrInvalidOption, key)
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate error metadata key %q",
+				ErrInvalidOption,
+				normalized,
+			)
+		}
+		seen[normalized] = struct{}{}
+		allowed = append(allowed, normalized)
+	}
+	sort.Strings(allowed)
+	return &ErrorCodec{allowed: allowed}, nil
+}
+
+// Encode converts err to a gRPC-compatible status error.
+func (codec *ErrorCodec) Encode(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+
+	var frameworkErr *kerrors.Error
+	if !errors.As(err, &frameworkErr) {
+		if _, ok := status.FromError(err); ok {
+			return err
+		}
+		return status.Error(codes.Internal, "internal server error")
+	}
+	detailMetadata := map[string]string{
+		errorCodeKey: strconv.FormatInt(int64(frameworkErr.Code()), 10),
+	}
+	allowed := make(map[string]struct{}, len(codec.allowedKeys()))
+	for _, key := range codec.allowedKeys() {
+		allowed[key] = struct{}{}
+	}
+	for key, value := range frameworkErr.Metadata() {
+		normalized := strings.ToLower(key)
+		if _, ok := allowed[normalized]; ok {
+			detailMetadata[normalized] = value
+		}
+	}
+	detail := &errdetails.ErrorInfo{
+		Reason:   normalizeReason(frameworkErr.Reason()),
+		Domain:   errorDomain,
+		Metadata: detailMetadata,
+	}
+	target := status.New(codeToGRPC(frameworkErr.Code()), frameworkErr.Message())
+	withDetails, detailErr := target.WithDetails(detail)
+	if detailErr != nil {
+		return target.Err()
+	}
+	return withDetails.Err()
+}
+
+// Decode restores a Keelith Error when status details were produced by
+// ErrorCodec.
+func (codec *ErrorCodec) Decode(err error) error {
+	if err == nil {
+		return nil
+	}
+	target, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	for _, detail := range target.Details() {
+		info, detailOK := detail.(*errdetails.ErrorInfo)
+		if !detailOK || info.GetDomain() != errorDomain {
+			continue
+		}
+		code, parseErr := strconv.ParseInt(info.GetMetadata()[errorCodeKey], 10, 32)
+		if parseErr != nil {
+			continue
+		}
+		metadata := make(map[string]string)
+		for _, key := range codec.allowedKeys() {
+			if value, exists := info.GetMetadata()[key]; exists {
+				metadata[key] = value
+			}
+		}
+		return kerrors.New(
+			int32(code),
+			info.GetReason(),
+			target.Message(),
+			kerrors.WithMetadata(metadata),
+		)
+	}
+	return err
+}
+
+func (codec *ErrorCodec) allowedKeys() []string {
+	if codec == nil {
+		return nil
+	}
+	return codec.allowed
+}
+
+func normalizeReason(reason string) string {
+	if reason == "" {
+		return defaultReason
+	}
+	return reason
+}
+
+func codeToGRPC(code int32) codes.Code {
+	switch code {
+	case 400:
+		return codes.InvalidArgument
+	case 401:
+		return codes.Unauthenticated
+	case 403:
+		return codes.PermissionDenied
+	case 404:
+		return codes.NotFound
+	case 409:
+		return codes.Aborted
+	case 412:
+		return codes.FailedPrecondition
+	case 413, 429:
+		return codes.ResourceExhausted
+	case 499:
+		return codes.Canceled
+	case 501:
+		return codes.Unimplemented
+	case 503:
+		return codes.Unavailable
+	case 504:
+		return codes.DeadlineExceeded
+	default:
+		return codes.Internal
+	}
+}

--- a/transport/grpc/health.go
+++ b/transport/grpc/health.go
@@ -1,0 +1,79 @@
+package grpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/keelab/keelith/health"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+const healthWatchInterval = 20 * time.Millisecond
+
+type healthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	registry *health.Registry
+}
+
+func (server *healthServer) Check(
+	ctx context.Context,
+	request *grpc_health_v1.HealthCheckRequest,
+) (*grpc_health_v1.HealthCheckResponse, error) {
+	if request.GetService() != "" {
+		return nil, status.Error(codes.NotFound, "unknown health service")
+	}
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: server.status(ctx),
+	}, nil
+}
+
+func (server *healthServer) List(
+	ctx context.Context,
+	_ *grpc_health_v1.HealthListRequest,
+) (*grpc_health_v1.HealthListResponse, error) {
+	return &grpc_health_v1.HealthListResponse{
+		Statuses: map[string]*grpc_health_v1.HealthCheckResponse{
+			"": {Status: server.status(ctx)},
+		},
+	}, nil
+}
+
+func (server *healthServer) Watch(
+	request *grpc_health_v1.HealthCheckRequest,
+	stream ggrpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse],
+) error {
+	unknownService := request.GetService() != ""
+	last := grpc_health_v1.HealthCheckResponse_ServingStatus(-1)
+	ticker := time.NewTicker(healthWatchInterval)
+	defer ticker.Stop()
+	for {
+		current := grpc_health_v1.HealthCheckResponse_SERVICE_UNKNOWN
+		if !unknownService {
+			current = server.status(stream.Context())
+		}
+		if current != last {
+			if err := stream.Send(&grpc_health_v1.HealthCheckResponse{
+				Status: current,
+			}); err != nil {
+				return err
+			}
+			last = current
+		}
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (server *healthServer) status(ctx context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
+	report := server.registry.Check(ctx, health.KindReadiness)
+	if report.Status == health.StatusPass {
+		return grpc_health_v1.HealthCheckResponse_SERVING
+	}
+	return grpc_health_v1.HealthCheckResponse_NOT_SERVING
+}

--- a/transport/grpc/interceptor.go
+++ b/transport/grpc/interceptor.go
@@ -1,0 +1,336 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+	"go.opentelemetry.io/otel/propagation"
+	ggrpc "google.golang.org/grpc"
+)
+
+// StreamInvocation is the transport-neutral middleware request for a stream.
+type StreamInvocation struct {
+	FullMethod    string
+	ClientStreams bool
+	ServerStreams bool
+}
+
+func unaryServerInterceptor(
+	bundle *middleware.Bundle,
+	policy metadata.Policy,
+	codec *ErrorCodec,
+	propagator propagation.TextMapPropagator,
+) ggrpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		request any,
+		info *ggrpc.UnaryServerInfo,
+		handler ggrpc.UnaryHandler,
+	) (any, error) {
+		target, err := operationFromMethod(info.FullMethod, operation.KindUnary)
+		if err != nil {
+			return nil, codec.Encode(err)
+		}
+		ctx, err = inboundContext(ctx, policy, propagator)
+		if err != nil {
+			return nil, codec.Encode(kerrors.Wrap(
+				err,
+				429,
+				"METADATA_TOO_LARGE",
+				"request metadata is invalid",
+			))
+		}
+		ctx, err = withInboundRequestInfo(ctx, target)
+		if err != nil {
+			return nil, codec.Encode(err)
+		}
+		invoke := middleware.Handler(func(
+			ctx context.Context,
+			request any,
+		) (any, error) {
+			return handler(ctx, request)
+		})
+		if bundle != nil {
+			invoke = bundle.Chain()(invoke)
+		}
+		response, err := invoke(ctx, request)
+		return response, codec.Encode(err)
+	}
+}
+
+func streamServerInterceptor(
+	bundle *middleware.Bundle,
+	streamBundle *middleware.StreamBundle,
+	policy metadata.Policy,
+	codec *ErrorCodec,
+	propagator propagation.TextMapPropagator,
+) ggrpc.StreamServerInterceptor {
+	return func(
+		service any,
+		stream ggrpc.ServerStream,
+		info *ggrpc.StreamServerInfo,
+		handler ggrpc.StreamHandler,
+	) error {
+		kind := streamOperationKind(info.IsClientStream, info.IsServerStream)
+		target, err := operationFromMethod(info.FullMethod, kind)
+		if err != nil {
+			return codec.Encode(err)
+		}
+		ctx, err := inboundContext(stream.Context(), policy, propagator)
+		if err != nil {
+			return codec.Encode(kerrors.Wrap(
+				err,
+				429,
+				"METADATA_TOO_LARGE",
+				"request metadata is invalid",
+			))
+		}
+		ctx, err = withInboundRequestInfo(ctx, target)
+		if err != nil {
+			return codec.Encode(err)
+		}
+		wrapped := newServerStream(ctx, stream, streamBundle)
+		invoke := middleware.Handler(func(
+			handlerContext context.Context,
+			_ any,
+		) (_ any, resultErr error) {
+			wrapped.context = handlerContext
+			wrapped.events.context = handlerContext
+			defer func() {
+				recovered := recover()
+				if recovered != nil {
+					_ = wrapped.events.finish(errors.New(
+						"grpc transport: stream handler panic",
+					))
+					panic(recovered)
+				}
+				resultErr = errors.Join(
+					resultErr,
+					wrapped.events.finish(resultErr),
+				)
+			}()
+			if err := wrapped.events.create(); err != nil {
+				return nil, err
+			}
+			return nil, handler(service, wrapped)
+		})
+		if bundle != nil {
+			invoke = bundle.Chain()(invoke)
+		}
+		_, err = invoke(ctx, StreamInvocation{
+			FullMethod:    info.FullMethod,
+			ClientStreams: info.IsClientStream,
+			ServerStreams: info.IsServerStream,
+		})
+		return codec.Encode(err)
+	}
+}
+
+type serverStream struct {
+	ggrpc.ServerStream
+	context context.Context
+	events  *streamEvents
+}
+
+func newServerStream(
+	ctx context.Context,
+	stream ggrpc.ServerStream,
+	bundle *middleware.StreamBundle,
+) *serverStream {
+	wrapped := &serverStream{
+		ServerStream: stream,
+		context:      ctx,
+	}
+	wrapped.events = newStreamEvents(
+		ctx,
+		middleware.StreamSideServer,
+		bundle,
+		func(_ context.Context, anyMessage any) error {
+			return stream.SendMsg(anyMessage)
+		},
+		func(_ context.Context, anyMessage any) error {
+			return stream.RecvMsg(anyMessage)
+		},
+	)
+	return wrapped
+}
+
+func (stream *serverStream) Context() context.Context {
+	return stream.context
+}
+
+func (stream *serverStream) SendMsg(message any) error {
+	return stream.events.send(message)
+}
+
+func (stream *serverStream) RecvMsg(message any) error {
+	return stream.events.receive(message)
+}
+
+func operationFromMethod(
+	fullMethod string,
+	kind operation.Kind,
+) (operation.Operation, error) {
+	trimmed := strings.TrimPrefix(fullMethod, "/")
+	separator := strings.LastIndex(trimmed, "/")
+	if separator <= 0 || separator == len(trimmed)-1 {
+		return operation.Operation{}, fmt.Errorf(
+			"grpc transport: invalid full method %q",
+			fullMethod,
+		)
+	}
+	return operation.New(
+		"grpc",
+		trimmed[:separator],
+		trimmed[separator+1:],
+		kind,
+	)
+}
+
+func streamOperationKind(clientStreams, serverStreams bool) operation.Kind {
+	switch {
+	case clientStreams && serverStreams:
+		return operation.KindBidiStream
+	case clientStreams:
+		return operation.KindClientStream
+	default:
+		return operation.KindServerStream
+	}
+}
+
+type clientStream struct {
+	ggrpc.ClientStream
+	codec           *ErrorCodec
+	policy          metadata.Policy
+	context         context.Context
+	cancel          context.CancelFunc
+	events          *streamEvents
+	finishOnReceive bool
+	completed       chan struct{}
+	finishOnce      sync.Once
+	finishErr       error
+}
+
+func newClientStream(
+	ctx context.Context,
+	stream ggrpc.ClientStream,
+	cancel context.CancelFunc,
+	codec *ErrorCodec,
+	policy metadata.Policy,
+	bundle *middleware.StreamBundle,
+	finishOnReceive bool,
+) *clientStream {
+	wrapped := &clientStream{
+		ClientStream:    stream,
+		codec:           codec,
+		policy:          policy,
+		context:         ctx,
+		cancel:          cancel,
+		finishOnReceive: finishOnReceive,
+		completed:       make(chan struct{}),
+	}
+	wrapped.events = newStreamEvents(
+		ctx,
+		middleware.StreamSideClient,
+		bundle,
+		func(_ context.Context, anyMessage any) error {
+			err := stream.SendMsg(anyMessage)
+			if errors.Is(err, io.EOF) {
+				return err
+			}
+			return codec.Decode(err)
+		},
+		func(_ context.Context, anyMessage any) error {
+			err := stream.RecvMsg(anyMessage)
+			if errors.Is(err, io.EOF) {
+				return err
+			}
+			return codec.Decode(err)
+		},
+	)
+	return wrapped
+}
+
+func (stream *clientStream) open() error {
+	if err := stream.events.create(); err != nil {
+		return errors.Join(err, stream.finish(err))
+	}
+	go stream.watchContext()
+	return nil
+}
+
+func (stream *clientStream) Header() (mapMetadata, error) {
+	header, err := stream.ClientStream.Header()
+	if err != nil {
+		decoded := stream.codec.Decode(err)
+		return nil, errors.Join(decoded, stream.finish(decoded))
+	}
+	filtered, err := filterMetadata(header, stream.policy)
+	return filtered, err
+}
+
+func (stream *clientStream) Trailer() mapMetadata {
+	filtered, err := filterMetadata(stream.ClientStream.Trailer(), stream.policy)
+	if err != nil {
+		return nil
+	}
+	return filtered
+}
+
+func (stream *clientStream) CloseSend() error {
+	err := stream.codec.Decode(stream.ClientStream.CloseSend())
+	if err != nil {
+		return errors.Join(err, stream.finish(err))
+	}
+	return nil
+}
+
+func (stream *clientStream) SendMsg(message any) error {
+	err := stream.events.send(message)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return errors.Join(err, stream.finish(err))
+	}
+	return err
+}
+
+func (stream *clientStream) RecvMsg(message any) error {
+	err := stream.events.receive(message)
+	switch {
+	case errors.Is(err, io.EOF):
+		if finishErr := stream.finish(nil); finishErr != nil {
+			return finishErr
+		}
+		return err
+	case err != nil:
+		return errors.Join(err, stream.finish(err))
+	case stream.finishOnReceive:
+		return stream.finish(nil)
+	default:
+		return nil
+	}
+}
+
+func (stream *clientStream) finish(err error) error {
+	stream.finishOnce.Do(func() {
+		stream.finishErr = stream.events.finish(err)
+		stream.cancel()
+		close(stream.completed)
+	})
+	return stream.finishErr
+}
+
+func (stream *clientStream) watchContext() {
+	select {
+	case <-stream.context.Done():
+		_ = stream.finish(context.Cause(stream.context))
+	case <-stream.completed:
+	}
+}

--- a/transport/grpc/keepalive.go
+++ b/transport/grpc/keepalive.go
@@ -1,0 +1,166 @@
+package grpc
+
+import (
+	"fmt"
+	"time"
+
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	minKeepalivePingInterval = 10 * time.Second
+	minKeepaliveTimeout      = time.Second
+	minKeepaliveConnection   = time.Minute
+	maxKeepaliveDuration     = 24 * time.Hour
+)
+
+// ServerKeepaliveConfig controls connection lifetime, server pings, and
+// enforcement of client ping frequency.
+//
+// Zero connection lifetime fields preserve grpc-go's unlimited behavior.
+type ServerKeepaliveConfig struct {
+	MaxConnectionIdle     time.Duration
+	MaxConnectionAge      time.Duration
+	MaxConnectionAgeGrace time.Duration
+	PingInterval          time.Duration
+	PingTimeout           time.Duration
+	MinClientPingInterval time.Duration
+	PermitWithoutStream   bool
+}
+
+// ClientKeepaliveConfig controls pings on a dynamically dialed grpc-go
+// connection.
+type ClientKeepaliveConfig struct {
+	PingInterval        time.Duration
+	PingTimeout         time.Duration
+	PermitWithoutStream bool
+}
+
+// DefaultServerKeepaliveConfig returns Keelith's production profile defaults.
+func DefaultServerKeepaliveConfig() ServerKeepaliveConfig {
+	return ServerKeepaliveConfig{
+		MaxConnectionIdle:     15 * time.Minute,
+		PingInterval:          2 * time.Hour,
+		PingTimeout:           20 * time.Second,
+		MinClientPingInterval: 30 * time.Second,
+		PermitWithoutStream:   false,
+	}
+}
+
+// DefaultClientKeepaliveConfig returns Keelith's dynamic client defaults.
+func DefaultClientKeepaliveConfig() ClientKeepaliveConfig {
+	return ClientKeepaliveConfig{
+		PingInterval:        time.Minute,
+		PingTimeout:         20 * time.Second,
+		PermitWithoutStream: false,
+	}
+}
+
+// WithKeepalive applies validated server connection and ping policy.
+func WithKeepalive(config ServerKeepaliveConfig) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if err := validateServerKeepalive(config); err != nil {
+			return err
+		}
+		cloned := config
+		options.keepalive = &cloned
+		return nil
+	})
+}
+
+func serverKeepaliveOptions(config ServerKeepaliveConfig) []ggrpc.ServerOption {
+	return []ggrpc.ServerOption{
+		ggrpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle:     config.MaxConnectionIdle,
+			MaxConnectionAge:      config.MaxConnectionAge,
+			MaxConnectionAgeGrace: config.MaxConnectionAgeGrace,
+			Time:                  config.PingInterval,
+			Timeout:               config.PingTimeout,
+		}),
+		ggrpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             config.MinClientPingInterval,
+			PermitWithoutStream: config.PermitWithoutStream,
+		}),
+	}
+}
+
+func validateServerKeepalive(config ServerKeepaliveConfig) error {
+	durations := []struct {
+		name  string
+		value time.Duration
+	}{
+		{name: "max connection idle", value: config.MaxConnectionIdle},
+		{name: "max connection age", value: config.MaxConnectionAge},
+		{
+			name:  "max connection age grace",
+			value: config.MaxConnectionAgeGrace,
+		},
+		{name: "ping interval", value: config.PingInterval},
+		{name: "ping timeout", value: config.PingTimeout},
+		{
+			name:  "minimum client ping",
+			value: config.MinClientPingInterval,
+		},
+	}
+	for _, duration := range durations {
+		if duration.value < 0 || duration.value > maxKeepaliveDuration {
+			return fmt.Errorf(
+				"%s is outside the supported range",
+				duration.name,
+			)
+		}
+	}
+	if config.MaxConnectionIdle > 0 &&
+		config.MaxConnectionIdle < minKeepaliveConnection {
+		return fmt.Errorf("max connection idle must be at least %s", minKeepaliveConnection)
+	}
+	if config.MaxConnectionAge > 0 &&
+		config.MaxConnectionAge < minKeepaliveConnection {
+		return fmt.Errorf("max connection age must be at least %s", minKeepaliveConnection)
+	}
+	if config.MaxConnectionAgeGrace > 0 && config.MaxConnectionAge == 0 {
+		return fmt.Errorf("max connection age grace requires max connection age")
+	}
+	if config.PingInterval > 0 &&
+		config.PingInterval < minKeepalivePingInterval {
+		return fmt.Errorf("ping interval must be at least %s", minKeepalivePingInterval)
+	}
+	if config.PingTimeout > 0 && config.PingTimeout < minKeepaliveTimeout {
+		return fmt.Errorf("ping timeout must be at least %s", minKeepaliveTimeout)
+	}
+	if config.PingInterval > 0 &&
+		config.PingTimeout > config.PingInterval {
+		return fmt.Errorf("ping timeout must not exceed ping interval")
+	}
+	if config.MinClientPingInterval > 0 &&
+		config.MinClientPingInterval < minKeepalivePingInterval {
+		return fmt.Errorf(
+			"minimum client ping interval must be at least %s",
+			minKeepalivePingInterval,
+		)
+	}
+	if config == (ServerKeepaliveConfig{}) {
+		return fmt.Errorf("keepalive config is empty")
+	}
+	return nil
+}
+
+func validateClientKeepalive(config ClientKeepaliveConfig) error {
+	if config.PingInterval < minKeepalivePingInterval ||
+		config.PingInterval > maxKeepaliveDuration {
+		return fmt.Errorf(
+			"client ping interval must be within [%s, %s]",
+			minKeepalivePingInterval,
+			maxKeepaliveDuration,
+		)
+	}
+	if config.PingTimeout < minKeepaliveTimeout ||
+		config.PingTimeout > config.PingInterval {
+		return fmt.Errorf(
+			"client ping timeout must be within [%s, ping interval]",
+			minKeepaliveTimeout,
+		)
+	}
+	return nil
+}

--- a/transport/grpc/metadata.go
+++ b/transport/grpc/metadata.go
@@ -1,0 +1,103 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keelab/keelith/metadata"
+	"go.opentelemetry.io/otel/propagation"
+	gmetadata "google.golang.org/grpc/metadata"
+)
+
+func inboundContext(
+	ctx context.Context,
+	policy metadata.Policy,
+	propagator propagation.TextMapPropagator,
+) (context.Context, error) {
+	carrier := grpcMetadataCarrier{}
+	if incoming, ok := gmetadata.FromIncomingContext(ctx); ok {
+		carrier = grpcMetadataCarrier(incoming.Copy())
+	}
+	if propagator != nil {
+		ctx = propagator.Extract(
+			ctx,
+			grpcPropagationCarrier(gmetadata.MD(carrier)),
+		)
+	}
+	extracted, err := policy.Extract(carrier)
+	if err != nil {
+		return nil, fmt.Errorf("grpc transport: extract metadata: %w", err)
+	}
+	return metadata.WithInbound(ctx, extracted), nil
+}
+
+func outboundContext(
+	ctx context.Context,
+	policy metadata.Policy,
+	propagator propagation.TextMapPropagator,
+) (context.Context, error) {
+	carrier := grpcMetadataCarrier{}
+	if outgoing, ok := gmetadata.FromOutgoingContext(ctx); ok {
+		carrier = grpcMetadataCarrier(outgoing.Copy())
+	}
+	if outbound, ok := metadata.Outbound(ctx); ok {
+		if err := policy.Inject(outbound, carrier); err != nil {
+			return nil, fmt.Errorf("grpc transport: inject metadata: %w", err)
+		}
+	}
+	if propagator != nil {
+		propagator.Inject(
+			ctx,
+			grpcPropagationCarrier(gmetadata.MD(carrier)),
+		)
+	}
+	return gmetadata.NewOutgoingContext(ctx, gmetadata.MD(carrier)), nil
+}
+
+func filterMetadata(
+	source gmetadata.MD,
+	policy metadata.Policy,
+) (gmetadata.MD, error) {
+	extracted, err := policy.Extract(grpcMetadataCarrier(source.Copy()))
+	if err != nil {
+		return nil, err
+	}
+	result := make(gmetadata.MD)
+	if err := policy.Inject(extracted, grpcMetadataCarrier(result)); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type grpcMetadataCarrier gmetadata.MD
+
+func (carrier grpcMetadataCarrier) Values(key string) []string {
+	return append([]string(nil), gmetadata.MD(carrier).Get(key)...)
+}
+
+func (carrier grpcMetadataCarrier) Set(key string, values []string) {
+	gmetadata.MD(carrier).Set(key, append([]string(nil), values...)...)
+}
+
+type grpcPropagationCarrier gmetadata.MD
+
+func (carrier grpcPropagationCarrier) Get(key string) string {
+	values := gmetadata.MD(carrier).Get(strings.ToLower(key))
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (carrier grpcPropagationCarrier) Set(key string, value string) {
+	gmetadata.MD(carrier).Set(strings.ToLower(key), value)
+}
+
+func (carrier grpcPropagationCarrier) Keys() []string {
+	keys := make([]string, 0, len(carrier))
+	for key := range carrier {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/transport/grpc/projection/authorization.go
+++ b/transport/grpc/projection/authorization.go
@@ -1,0 +1,87 @@
+package projectiongrpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/programmable/projection"
+	"github.com/keelab/keelith/security"
+	"github.com/keelab/keelith/security/authz"
+)
+
+const maximumProjectionACLRules = 1024
+
+// ProjectionACLRule grants roles/scopes access to one exact ProjectionID.
+type ProjectionACLRule struct {
+	Projection    projection.ProjectionID
+	AnyRole       []string
+	RequiredScope []string
+}
+
+// ProjectionACL is an immutable exact-ID authorization policy.
+type ProjectionACL struct {
+	rules map[projection.ProjectionID]*authz.RBAC
+}
+
+// NewProjectionACL validates and snapshots exact projection rules.
+func NewProjectionACL(rules ...ProjectionACLRule) (*ProjectionACL, error) {
+	if len(rules) == 0 || len(rules) > maximumProjectionACLRules {
+		return nil, ErrInvalidServer
+	}
+	result := &ProjectionACL{
+		rules: make(map[projection.ProjectionID]*authz.RBAC, len(rules)),
+	}
+	for index, rule := range rules {
+		if err := rule.Projection.Validate(); err != nil {
+			return nil, fmt.Errorf(
+				"%w: ACL rule %d projection",
+				ErrInvalidServer,
+				index,
+			)
+		}
+		if _, duplicate := result.rules[rule.Projection]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate ACL projection %q",
+				ErrInvalidServer,
+				rule.Projection,
+			)
+		}
+		policy, err := authz.NewRBAC(authz.Rule{
+			Service:       "*",
+			Method:        "*",
+			AnyRole:       rule.AnyRole,
+			RequiredScope: rule.RequiredScope,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%w: ACL rule %d",
+				ErrInvalidServer,
+				index,
+			)
+		}
+		result.rules[rule.Projection] = policy
+	}
+	return result, nil
+}
+
+// Authorize implements authz.Authorizer and denies unknown projection IDs.
+func (acl *ProjectionACL) Authorize(
+	ctx context.Context,
+	principal security.Principal,
+	target operation.Operation,
+	request any,
+) (authz.Decision, error) {
+	if acl == nil {
+		return authz.Decision{}, ErrInvalidServer
+	}
+	access, ok := request.(AuthorizationRequest)
+	if !ok {
+		return authz.Decision{}, ErrInvalidServer
+	}
+	policy := acl.rules[access.Projection]
+	if policy == nil {
+		return authz.Decision{Allowed: false}, nil
+	}
+	return policy.Authorize(ctx, principal, target, request)
+}

--- a/transport/grpc/projection/client.go
+++ b/transport/grpc/projection/client.go
@@ -1,0 +1,251 @@
+package projectiongrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sync"
+
+	projectionv1 "github.com/keelab/keelith/api/projection/v1"
+	"github.com/keelab/keelith/programmable/projection"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const defaultClientMaxFrameBytes = maxWireFrameBytes
+
+var (
+	// ErrInvalidClient reports a nil protocol client or unsafe byte budget.
+	ErrInvalidClient = errors.New(
+		"projection grpc transport: invalid client",
+	)
+	// ErrSessionClosed reports Next after a local session Close.
+	ErrSessionClosed = errors.New(
+		"projection grpc transport: session closed",
+	)
+)
+
+// ClientOption configures the remote projection Source.
+type ClientOption interface {
+	applyClient(*clientOptions) error
+}
+
+type clientOptionFunc func(*clientOptions) error
+
+func (function clientOptionFunc) applyClient(options *clientOptions) error {
+	return function(options)
+}
+
+type clientOptions struct {
+	maxFrameBytes int
+	callOptions   []grpc.CallOption
+}
+
+// WithClientMaxFrameBytes sets the decoded per-frame byte budget.
+func WithClientMaxFrameBytes(maximum int) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if maximum < 256 || maximum > maxWireFrameBytes {
+			return ErrInvalidClient
+		}
+		options.maxFrameBytes = maximum
+		return nil
+	})
+}
+
+// WithCallOptions snapshots gRPC options used for each new subscription.
+func WithCallOptions(callOptions ...grpc.CallOption) ClientOption {
+	snapshot := append([]grpc.CallOption(nil), callOptions...)
+	return clientOptionFunc(func(options *clientOptions) error {
+		for _, option := range snapshot {
+			if isNilValue(option) {
+				return ErrInvalidClient
+			}
+		}
+		options.callOptions = snapshot
+		return nil
+	})
+}
+
+// Source implements projection.Source over ProjectionService.
+type Source struct {
+	client        projectionv1.ProjectionServiceClient
+	maxFrameBytes int
+	callOptions   []grpc.CallOption
+}
+
+var _ projection.Source = (*Source)(nil)
+
+// NewSource validates and constructs one remote projection Source.
+func NewSource(
+	client projectionv1.ProjectionServiceClient,
+	optionList ...ClientOption,
+) (*Source, error) {
+	if isNilProjectionClient(client) {
+		return nil, ErrInvalidClient
+	}
+	options := clientOptions{maxFrameBytes: defaultClientMaxFrameBytes}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: option %d is nil",
+				ErrInvalidClient,
+				index,
+			)
+		}
+		if err := option.applyClient(&options); err != nil {
+			return nil, err
+		}
+	}
+	return &Source{
+		client:        client,
+		maxFrameBytes: options.maxFrameBytes,
+		callOptions:   append([]grpc.CallOption(nil), options.callOptions...),
+	}, nil
+}
+
+// Open starts one cancelable server stream from a durable checkpoint.
+func (source *Source) Open(
+	ctx context.Context,
+	request projection.SubscribeRequest,
+) (projection.Session, error) {
+	if source == nil || ctx == nil {
+		return nil, ErrInvalidClient
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+	sessionContext, cancel := context.WithCancelCause(ctx)
+	stream, err := source.client.Subscribe(
+		sessionContext,
+		requestToWire(request),
+		source.callOptions...,
+	)
+	if err != nil {
+		cancel(err)
+		return nil, err
+	}
+	if isNilValue(stream) {
+		cancel(ErrInvalidClient)
+		return nil, ErrInvalidClient
+	}
+	return &clientSession{
+		stream:        stream,
+		cancel:        cancel,
+		maxFrameBytes: source.maxFrameBytes,
+	}, nil
+}
+
+type receiveResult struct {
+	frame *projectionv1.SubscribeResponse
+	err   error
+}
+
+type clientSession struct {
+	stream grpc.ServerStreamingClient[projectionv1.SubscribeResponse]
+	cancel context.CancelCauseFunc
+
+	maxFrameBytes int
+	receiveMu     sync.Mutex
+	stateMu       sync.Mutex
+	closed        bool
+}
+
+// Next receives and validates one bounded wire frame.
+func (session *clientSession) Next(
+	ctx context.Context,
+) (projection.Frame, error) {
+	if session == nil || ctx == nil {
+		return nil, ErrInvalidClient
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	session.receiveMu.Lock()
+	defer session.receiveMu.Unlock()
+	if session.isClosed() {
+		return nil, ErrSessionClosed
+	}
+
+	result := make(chan receiveResult, 1)
+	go func() {
+		frame, err := session.stream.Recv()
+		result <- receiveResult{frame: frame, err: err}
+	}()
+	select {
+	case received := <-result:
+		if received.err != nil {
+			if session.isClosed() &&
+				(status.Code(received.err) == codes.Canceled ||
+					errors.Is(received.err, context.Canceled)) {
+				return nil, ErrSessionClosed
+			}
+			if errors.Is(received.err, io.EOF) {
+				return nil, io.EOF
+			}
+			return nil, received.err
+		}
+		if received.frame == nil {
+			return nil, ErrInvalidWireFrame
+		}
+		if proto.Size(received.frame) > session.maxFrameBytes {
+			return nil, ErrFrameTooLarge
+		}
+		frame, err := frameFromWire(received.frame)
+		if err != nil {
+			return nil, err
+		}
+		return frame, nil
+	case <-ctx.Done():
+		session.cancel(context.Cause(ctx))
+		return nil, context.Cause(ctx)
+	}
+}
+
+// Close cancels the stream and unblocks a concurrent Next.
+func (session *clientSession) Close() error {
+	if session == nil {
+		return nil
+	}
+	session.stateMu.Lock()
+	if session.closed {
+		session.stateMu.Unlock()
+		return nil
+	}
+	session.closed = true
+	session.stateMu.Unlock()
+	session.cancel(ErrSessionClosed)
+	return nil
+}
+
+func (session *clientSession) isClosed() bool {
+	session.stateMu.Lock()
+	defer session.stateMu.Unlock()
+	return session.closed
+}
+
+func isNilProjectionClient(
+	client projectionv1.ProjectionServiceClient,
+) bool {
+	if client == nil {
+		return true
+	}
+	value := reflect.ValueOf(client)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/transport/grpc/projection/codec.go
+++ b/transport/grpc/projection/codec.go
@@ -1,0 +1,380 @@
+package projectiongrpc
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	projectionv1 "github.com/keelab/keelith/api/projection/v1"
+	"github.com/keelab/keelith/programmable/projection"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	maxWireMutations  = 10_000
+	maxWireFrameBytes = 32 * 1024 * 1024
+)
+
+var (
+	// ErrInvalidWireFrame reports a malformed projection protocol message.
+	ErrInvalidWireFrame = errors.New(
+		"projection grpc transport: invalid wire frame",
+	)
+	// ErrFrameTooLarge reports a frame beyond the configured byte budget.
+	ErrFrameTooLarge = errors.New(
+		"projection grpc transport: frame too large",
+	)
+)
+
+func requestToWire(
+	request projection.SubscribeRequest,
+) *projectionv1.SubscribeRequest {
+	return &projectionv1.SubscribeRequest{
+		Schema:        schemaToWire(request.Schema),
+		After:         string(request.After),
+		ForceSnapshot: request.ForceSnapshot,
+	}
+}
+
+func requestFromWire(
+	request *projectionv1.SubscribeRequest,
+) (projection.SubscribeRequest, error) {
+	if request == nil {
+		return projection.SubscribeRequest{}, ErrInvalidWireFrame
+	}
+	schema, err := schemaFromWire(request.GetSchema())
+	if err != nil {
+		return projection.SubscribeRequest{}, err
+	}
+	result := projection.SubscribeRequest{
+		Schema:        schema,
+		After:         projection.Cursor(request.GetAfter()),
+		ForceSnapshot: request.GetForceSnapshot(),
+	}
+	if err := result.Validate(); err != nil {
+		return projection.SubscribeRequest{}, fmt.Errorf(
+			"%w: subscription",
+			ErrInvalidWireFrame,
+		)
+	}
+	return result, nil
+}
+
+func schemaToWire(schema projection.Schema) *projectionv1.Schema {
+	return &projectionv1.Schema{
+		Id:                     string(schema.ID),
+		Fingerprint:            schema.Fingerprint,
+		KeyFingerprint:         schema.KeyFingerprint,
+		CompatibleFingerprints: schema.CompatibleFingerprints.Values(),
+	}
+}
+
+func schemaFromWire(
+	schema *projectionv1.Schema,
+) (projection.Schema, error) {
+	if schema == nil {
+		return projection.Schema{}, ErrInvalidWireFrame
+	}
+	compatible, err := projection.NewFingerprintSet(
+		schema.GetCompatibleFingerprints()...,
+	)
+	if err != nil {
+		return projection.Schema{}, fmt.Errorf(
+			"%w: schema compatibility",
+			ErrInvalidWireFrame,
+		)
+	}
+	result := projection.Schema{
+		ID:                     projection.ProjectionID(schema.GetId()),
+		Fingerprint:            schema.GetFingerprint(),
+		KeyFingerprint:         schema.GetKeyFingerprint(),
+		CompatibleFingerprints: compatible,
+	}
+	if err := result.Validate(); err != nil {
+		return projection.Schema{}, fmt.Errorf(
+			"%w: schema",
+			ErrInvalidWireFrame,
+		)
+	}
+	return result, nil
+}
+
+func frameToWire(
+	frame projection.Frame,
+) (*projectionv1.SubscribeResponse, error) {
+	switch current := frame.(type) {
+	case projection.SnapshotBeginFrame:
+		if err := current.Schema.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		return &projectionv1.SubscribeResponse{
+			Body: &projectionv1.SubscribeResponse_SnapshotBegin{
+				SnapshotBegin: &projectionv1.SnapshotBegin{
+					Schema: schemaToWire(current.Schema),
+				},
+			},
+		}, nil
+	case projection.SnapshotChunkFrame:
+		mutations, err := mutationsToWire(current.Mutations)
+		if err != nil || len(mutations) == 0 {
+			return nil, ErrInvalidWireFrame
+		}
+		return &projectionv1.SubscribeResponse{
+			Body: &projectionv1.SubscribeResponse_SnapshotChunk{
+				SnapshotChunk: &projectionv1.SnapshotChunk{
+					Mutations: mutations,
+				},
+			},
+		}, nil
+	case projection.SnapshotEndFrame:
+		if err := current.Cursor.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		sourceTime, err := timeToWire(current.SourceTime)
+		if err != nil {
+			return nil, err
+		}
+		return &projectionv1.SubscribeResponse{
+			Body: &projectionv1.SubscribeResponse_SnapshotEnd{
+				SnapshotEnd: &projectionv1.SnapshotEnd{
+					Cursor:     string(current.Cursor),
+					SourceTime: sourceTime,
+				},
+			},
+		}, nil
+	case projection.DeltaFrame:
+		if err := current.Batch.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		mutations, err := mutationsToWire(current.Batch.Mutations)
+		if err != nil {
+			return nil, err
+		}
+		sourceTime, err := timeToWire(current.Batch.SourceTime)
+		if err != nil {
+			return nil, err
+		}
+		return &projectionv1.SubscribeResponse{
+			Body: &projectionv1.SubscribeResponse_Delta{
+				Delta: &projectionv1.Delta{
+					Schema:     schemaToWire(current.Batch.Schema),
+					Previous:   string(current.Batch.Previous),
+					Cursor:     string(current.Batch.Cursor),
+					SourceTime: sourceTime,
+					Mutations:  mutations,
+				},
+			},
+		}, nil
+	case projection.HeartbeatFrame:
+		if err := current.Cursor.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		sourceTime, err := timeToWire(current.SourceTime)
+		if err != nil {
+			return nil, err
+		}
+		return &projectionv1.SubscribeResponse{
+			Body: &projectionv1.SubscribeResponse_Heartbeat{
+				Heartbeat: &projectionv1.Heartbeat{
+					Cursor:     string(current.Cursor),
+					SourceTime: sourceTime,
+				},
+			},
+		}, nil
+	case projection.GapFrame:
+		if err := current.Requested.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		if err := current.Floor.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		return &projectionv1.SubscribeResponse{
+			Body: &projectionv1.SubscribeResponse_Gap{
+				Gap: &projectionv1.Gap{
+					Requested: string(current.Requested),
+					Floor:     string(current.Floor),
+				},
+			},
+		}, nil
+	default:
+		return nil, ErrInvalidWireFrame
+	}
+}
+
+func frameFromWire(
+	frame *projectionv1.SubscribeResponse,
+) (projection.Frame, error) {
+	if frame == nil {
+		return nil, ErrInvalidWireFrame
+	}
+	switch body := frame.GetBody().(type) {
+	case *projectionv1.SubscribeResponse_SnapshotBegin:
+		schema, err := schemaFromWire(body.SnapshotBegin.GetSchema())
+		if err != nil {
+			return nil, err
+		}
+		return projection.SnapshotBeginFrame{Schema: schema}, nil
+	case *projectionv1.SubscribeResponse_SnapshotChunk:
+		mutations, err := mutationsFromWire(
+			body.SnapshotChunk.GetMutations(),
+		)
+		if err != nil || len(mutations) == 0 {
+			return nil, ErrInvalidWireFrame
+		}
+		return projection.SnapshotChunkFrame{Mutations: mutations}, nil
+	case *projectionv1.SubscribeResponse_SnapshotEnd:
+		cursor := projection.Cursor(body.SnapshotEnd.GetCursor())
+		if err := cursor.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		sourceTime, err := timeFromWire(body.SnapshotEnd.GetSourceTime())
+		if err != nil {
+			return nil, err
+		}
+		return projection.SnapshotEndFrame{
+			Cursor:     cursor,
+			SourceTime: sourceTime,
+		}, nil
+	case *projectionv1.SubscribeResponse_Delta:
+		schema, err := schemaFromWire(body.Delta.GetSchema())
+		if err != nil {
+			return nil, err
+		}
+		sourceTime, err := timeFromWire(body.Delta.GetSourceTime())
+		if err != nil {
+			return nil, err
+		}
+		mutations, err := mutationsFromWire(body.Delta.GetMutations())
+		if err != nil {
+			return nil, err
+		}
+		batch := projection.DeltaBatch{
+			Schema:     schema,
+			Previous:   projection.Cursor(body.Delta.GetPrevious()),
+			Cursor:     projection.Cursor(body.Delta.GetCursor()),
+			SourceTime: sourceTime,
+			Mutations:  mutations,
+		}
+		if err := batch.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		return projection.DeltaFrame{Batch: batch}, nil
+	case *projectionv1.SubscribeResponse_Heartbeat:
+		cursor := projection.Cursor(body.Heartbeat.GetCursor())
+		if err := cursor.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		sourceTime, err := timeFromWire(body.Heartbeat.GetSourceTime())
+		if err != nil {
+			return nil, err
+		}
+		return projection.HeartbeatFrame{
+			Cursor:     cursor,
+			SourceTime: sourceTime,
+		}, nil
+	case *projectionv1.SubscribeResponse_Gap:
+		requested := projection.Cursor(body.Gap.GetRequested())
+		floor := projection.Cursor(body.Gap.GetFloor())
+		if err := requested.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		if err := floor.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		return projection.GapFrame{
+			Requested: requested,
+			Floor:     floor,
+		}, nil
+	default:
+		return nil, ErrInvalidWireFrame
+	}
+}
+
+func mutationsToWire(
+	mutations []projection.Mutation,
+) ([]*projectionv1.Mutation, error) {
+	if len(mutations) == 0 || len(mutations) > maxWireMutations {
+		return nil, ErrInvalidWireFrame
+	}
+	result := make([]*projectionv1.Mutation, len(mutations))
+	for index, mutation := range mutations {
+		if err := mutation.Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+		var kind projectionv1.Mutation_Kind
+		switch mutation.Kind() {
+		case projection.MutationUpsert:
+			kind = projectionv1.Mutation_KIND_UPSERT
+		case projection.MutationDelete:
+			kind = projectionv1.Mutation_KIND_DELETE
+		default:
+			return nil, ErrInvalidWireFrame
+		}
+		result[index] = &projectionv1.Mutation{
+			Kind:  kind,
+			Key:   mutation.Key(),
+			Value: mutation.Value(),
+		}
+	}
+	return result, nil
+}
+
+func mutationsFromWire(
+	mutations []*projectionv1.Mutation,
+) ([]projection.Mutation, error) {
+	if len(mutations) == 0 || len(mutations) > maxWireMutations {
+		return nil, ErrInvalidWireFrame
+	}
+	result := make([]projection.Mutation, len(mutations))
+	for index, mutation := range mutations {
+		if mutation == nil {
+			return nil, ErrInvalidWireFrame
+		}
+		switch mutation.GetKind() {
+		case projectionv1.Mutation_KIND_UPSERT:
+			result[index] = projection.Upsert(
+				mutation.GetKey(),
+				mutation.GetValue(),
+			)
+		case projectionv1.Mutation_KIND_DELETE:
+			if len(mutation.GetValue()) != 0 {
+				return nil, ErrInvalidWireFrame
+			}
+			result[index] = projection.Delete(mutation.GetKey())
+		default:
+			return nil, ErrInvalidWireFrame
+		}
+		if err := result[index].Validate(); err != nil {
+			return nil, ErrInvalidWireFrame
+		}
+	}
+	return result, nil
+}
+
+func timeToWire(value time.Time) (*timestamppb.Timestamp, error) {
+	if value.IsZero() {
+		return nil, ErrInvalidWireFrame
+	}
+	result := timestamppb.New(value.UTC())
+	if err := result.CheckValid(); err != nil {
+		return nil, ErrInvalidWireFrame
+	}
+	return result, nil
+}
+
+func timeFromWire(
+	value *timestamppb.Timestamp,
+) (time.Time, error) {
+	if value == nil || value.CheckValid() != nil {
+		return time.Time{}, ErrInvalidWireFrame
+	}
+	result := value.AsTime().UTC()
+	if result.IsZero() {
+		return time.Time{}, ErrInvalidWireFrame
+	}
+	return result, nil
+}
+
+func sameSchema(left, right projection.Schema) bool {
+	return right.Accepts(left) == nil
+}

--- a/transport/grpc/projection/server.go
+++ b/transport/grpc/projection/server.go
@@ -1,0 +1,487 @@
+// Package projectiongrpc adapts projection Sources to a bounded gRPC stream.
+package projectiongrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+
+	projectionv1 "github.com/keelab/keelith/api/projection/v1"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/programmable/projection"
+	"github.com/keelab/keelith/security"
+	"github.com/keelab/keelith/security/authz"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+const defaultServerMaxFrameBytes = maxWireFrameBytes
+
+var (
+	// ErrInvalidServer reports an invalid registration or byte budget.
+	ErrInvalidServer = errors.New(
+		"projection grpc transport: invalid server",
+	)
+	// ErrDuplicateProjection reports more than one owner for an identity.
+	ErrDuplicateProjection = errors.New(
+		"projection grpc transport: duplicate projection",
+	)
+)
+
+// Registration assigns one exact schema to its single owner Source.
+type Registration struct {
+	Schema projection.Schema
+	Source projection.Source
+}
+
+// ServerOption configures the projection gRPC server adapter.
+type ServerOption interface {
+	applyServer(*serverOptions) error
+}
+
+type serverOptionFunc func(*serverOptions) error
+
+func (function serverOptionFunc) applyServer(options *serverOptions) error {
+	return function(options)
+}
+
+type serverOptions struct {
+	maxFrameBytes int
+	publicAccess  bool
+	authorizer    authz.Authorizer
+	accessSet     bool
+	quota         *projection.QuotaManager
+	scheduler     *projection.FairScheduler
+}
+
+// WithServerMaxFrameBytes sets the encoded per-frame send budget.
+func WithServerMaxFrameBytes(maximum int) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maximum < 256 || maximum > maxWireFrameBytes {
+			return ErrInvalidServer
+		}
+		options.maxFrameBytes = maximum
+		return nil
+	})
+}
+
+// WithServerPublicAccess explicitly allows unauthenticated subscriptions.
+//
+// Omitting both public access and an Authorizer makes the server fail closed.
+func WithServerPublicAccess() ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if options.accessSet {
+			return ErrInvalidServer
+		}
+		options.publicAccess = true
+		options.accessSet = true
+		return nil
+	})
+}
+
+// WithServerAuthorizer requires an authenticated Principal and delegates each
+// projection identity decision to the existing Keelith authorization model.
+func WithServerAuthorizer(authorizer authz.Authorizer) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if options.accessSet || isNilValue(authorizer) {
+			return ErrInvalidServer
+		}
+		options.authorizer = authorizer
+		options.accessSet = true
+		return nil
+	})
+}
+
+// WithServerAdmission enables tenant quota and fair frame scheduling. Tenant
+// claims are parsed only after the configured Authorizer allows the request.
+func WithServerAdmission(
+	quota *projection.QuotaManager,
+	scheduler *projection.FairScheduler,
+) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if quota == nil || scheduler == nil || options.quota != nil ||
+			options.scheduler != nil {
+			return ErrInvalidServer
+		}
+		options.quota = quota
+		options.scheduler = scheduler
+		return nil
+	})
+}
+
+// AuthorizationRequest is the bounded request value passed to Authorizer.
+type AuthorizationRequest struct {
+	Projection projection.ProjectionID
+}
+
+type serverProjection struct {
+	schema projection.Schema
+	source projection.Source
+}
+
+// Server exposes registered owner Sources through ProjectionService.
+type Server struct {
+	projectionv1.UnimplementedProjectionServiceServer
+
+	projections   map[projection.ProjectionID]serverProjection
+	maxFrameBytes int
+	publicAccess  bool
+	authorizer    authz.Authorizer
+	quota         *projection.QuotaManager
+	scheduler     *projection.FairScheduler
+	registered    bool
+}
+
+// NewServer validates and snapshots exact projection registrations.
+func NewServer(
+	registrations []Registration,
+	optionList ...ServerOption,
+) (*Server, error) {
+	if len(registrations) == 0 || len(registrations) > 1024 {
+		return nil, ErrInvalidServer
+	}
+	options := serverOptions{maxFrameBytes: defaultServerMaxFrameBytes}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: option %d is nil",
+				ErrInvalidServer,
+				index,
+			)
+		}
+		if err := option.applyServer(&options); err != nil {
+			return nil, err
+		}
+	}
+	result := &Server{
+		projections:   make(map[projection.ProjectionID]serverProjection),
+		maxFrameBytes: options.maxFrameBytes,
+		publicAccess:  options.publicAccess,
+		authorizer:    options.authorizer,
+		quota:         options.quota,
+		scheduler:     options.scheduler,
+	}
+	for _, registration := range registrations {
+		if err := registration.Schema.Validate(); err != nil ||
+			isNilSource(registration.Source) {
+			return nil, ErrInvalidServer
+		}
+		if _, duplicate := result.projections[registration.Schema.ID]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: %q",
+				ErrDuplicateProjection,
+				registration.Schema.ID,
+			)
+		}
+		result.projections[registration.Schema.ID] = serverProjection{
+			schema: registration.Schema,
+			source: registration.Source,
+		}
+	}
+	return result, nil
+}
+
+// Register installs the protocol service exactly once.
+func (server *Server) Register(registrar grpc.ServiceRegistrar) error {
+	if server == nil || registrar == nil || server.registered {
+		return ErrInvalidServer
+	}
+	projectionv1.RegisterProjectionServiceServer(registrar, server)
+	server.registered = true
+	return nil
+}
+
+// Subscribe relays one ordered Source session until disconnect or completion.
+func (server *Server) Subscribe(
+	request *projectionv1.SubscribeRequest,
+	stream grpc.ServerStreamingServer[projectionv1.SubscribeResponse],
+) error {
+	if server == nil || stream == nil {
+		return status.Error(codes.Internal, "projection server unavailable")
+	}
+	subscription, err := requestFromWire(request)
+	if err != nil {
+		return status.Error(
+			codes.InvalidArgument,
+			"invalid projection subscription",
+		)
+	}
+	principal, authenticated, err := server.authorize(
+		stream.Context(),
+		subscription.Schema.ID,
+	)
+	if err != nil {
+		return err
+	}
+	var tenant projection.Tenant
+	if server.quota != nil {
+		tenant, err = admittedTenant(principal, authenticated)
+		if err != nil {
+			return status.Error(codes.PermissionDenied, "projection tenant denied")
+		}
+	}
+	registered, exists := server.projections[subscription.Schema.ID]
+	if !exists {
+		return status.Error(codes.NotFound, "projection not registered")
+	}
+	if !sameSchema(registered.schema, subscription.Schema) {
+		return status.Error(
+			codes.FailedPrecondition,
+			"projection schema mismatch",
+		)
+	}
+	var quotaLease *projection.SessionQuotaLease
+	if server.quota != nil {
+		quotaLease, err = server.quota.AcquireSession(tenant, time.Now().UTC())
+		if err != nil {
+			return admissionStatus(err)
+		}
+		defer func() { _ = quotaLease.Close() }()
+	}
+	session, err := registered.source.Open(stream.Context(), subscription)
+	if err != nil {
+		return sourceStatus(err)
+	}
+	if isNilSession(session) {
+		return status.Error(codes.Internal, "projection source unavailable")
+	}
+	defer func() {
+		_ = session.Close()
+	}()
+	for {
+		frame, nextErr := session.Next(stream.Context())
+		if nextErr != nil {
+			if errors.Is(nextErr, io.EOF) {
+				return nil
+			}
+			return sourceStatus(nextErr)
+		}
+		encoded, encodeErr := frameToWire(frame)
+		if encodeErr != nil {
+			return status.Error(
+				codes.Internal,
+				"projection source emitted an invalid frame",
+			)
+		}
+		if proto.Size(encoded) > server.maxFrameBytes {
+			return status.Error(
+				codes.ResourceExhausted,
+				"projection frame exceeds server budget",
+			)
+		}
+		frameBytes := proto.Size(encoded)
+		var permit *projection.SchedulePermit
+		if server.scheduler != nil {
+			permit, err = server.scheduler.Acquire(
+				stream.Context(),
+				tenant,
+				frameBytes,
+			)
+			if err != nil {
+				return admissionStatus(err)
+			}
+		}
+		if quotaLease != nil {
+			if err := quotaLease.AllowFrame(
+				frameRows(frame),
+				frameBytes,
+				time.Now().UTC(),
+			); err != nil {
+				_ = permit.Close()
+				return admissionStatus(err)
+			}
+		}
+		sendErr := stream.Send(encoded)
+		_ = permit.Close()
+		if sendErr != nil {
+			return sendErr
+		}
+	}
+}
+
+func (server *Server) authorize(
+	ctx context.Context,
+	projectionID projection.ProjectionID,
+) (security.Principal, bool, error) {
+	if server.publicAccess {
+		return security.Principal{}, false, nil
+	}
+	if server.authorizer == nil {
+		return security.Principal{}, false,
+			status.Error(codes.PermissionDenied, "projection access denied")
+	}
+	principal, exists := security.PrincipalFromContext(ctx)
+	if !exists || principal.Validate(time.Now()) != nil {
+		return security.Principal{}, false, status.Error(
+			codes.Unauthenticated,
+			"projection authentication required",
+		)
+	}
+	target, exists := operation.FromContext(ctx)
+	if !exists {
+		var err error
+		target, err = operation.New(
+			"grpc",
+			projectionv1.ProjectionService_ServiceDesc.ServiceName,
+			"Subscribe",
+			operation.KindServerStream,
+		)
+		if err != nil {
+			return security.Principal{}, false, status.Error(
+				codes.Internal,
+				"projection authorization unavailable",
+			)
+		}
+	}
+	decision, err := callAuthorizer(
+		ctx,
+		server.authorizer,
+		principal,
+		target,
+		AuthorizationRequest{Projection: projectionID},
+	)
+	if err != nil {
+		return security.Principal{}, false, status.Error(
+			codes.Internal,
+			"projection authorization unavailable",
+		)
+	}
+	if !decision.Allowed {
+		return security.Principal{}, false,
+			status.Error(codes.PermissionDenied, "projection access denied")
+	}
+	return principal, true, nil
+}
+
+func admittedTenant(
+	principal security.Principal,
+	authenticated bool,
+) (projection.Tenant, error) {
+	if !authenticated {
+		return projection.NewTenant("public", projection.TenantStandard)
+	}
+	claims := principal.Claims()
+	identity := claims["keelith.tenant"]
+	if identity == "" {
+		identity = principal.Issuer() + "\x00" + principal.Subject()
+	}
+	class := projection.TenantClass(claims["keelith.tenant_class"])
+	if class == "" {
+		class = projection.TenantStandard
+	}
+	return projection.NewTenant(identity, class)
+}
+
+func frameRows(frame projection.Frame) int {
+	switch value := frame.(type) {
+	case projection.SnapshotChunkFrame:
+		return len(value.Mutations)
+	case projection.DeltaFrame:
+		return len(value.Batch.Mutations)
+	default:
+		return 0
+	}
+}
+
+func admissionStatus(err error) error {
+	if err == nil {
+		return status.Error(codes.Internal, "projection admission failed")
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+	retryAfter := time.Duration(0)
+	var quota *projection.QuotaExceededError
+	if errors.As(err, &quota) {
+		retryAfter = quota.RetryAfter
+	}
+	var full *projection.SchedulerFullError
+	if errors.As(err, &full) {
+		retryAfter = full.RetryAfter
+	}
+	if retryAfter <= 0 {
+		return status.Error(codes.Unavailable, "projection admission unavailable")
+	}
+	base := status.New(codes.ResourceExhausted, "projection tenant budget exceeded")
+	withDetails, detailErr := base.WithDetails(&errdetails.RetryInfo{
+		RetryDelay: durationpb.New(retryAfter),
+	})
+	if detailErr != nil {
+		return base.Err()
+	}
+	return withDetails.Err()
+}
+
+func callAuthorizer(
+	ctx context.Context,
+	authorizer authz.Authorizer,
+	principal security.Principal,
+	target operation.Operation,
+	request AuthorizationRequest,
+) (decision authz.Decision, err error) {
+	defer func() {
+		if recover() != nil {
+			decision = authz.Decision{}
+			err = ErrInvalidServer
+		}
+	}()
+	return authorizer.Authorize(ctx, principal, target, request)
+}
+
+func sourceStatus(err error) error {
+	if err == nil {
+		return status.Error(codes.Internal, "projection source failed")
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+	if errors.Is(err, projection.ErrSchemaMismatch) {
+		return status.Error(
+			codes.FailedPrecondition,
+			"projection schema mismatch",
+		)
+	}
+	if errors.Is(err, projection.ErrInvalidSubscription) ||
+		errors.Is(err, projection.ErrInvalidCursor) {
+		return status.Error(
+			codes.InvalidArgument,
+			"invalid projection subscription",
+		)
+	}
+	return status.Error(codes.Unavailable, "projection source unavailable")
+}
+
+func isNilSource(source projection.Source) bool {
+	return isNilValue(source)
+}
+
+func isNilSession(session projection.Session) bool {
+	return isNilValue(session)
+}
+
+func isNilValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflection := reflect.ValueOf(value)
+	switch reflection.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return reflection.IsNil()
+	default:
+		return false
+	}
+}

--- a/transport/grpc/request_info.go
+++ b/transport/grpc/request_info.go
@@ -1,0 +1,41 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/keelab/keelith/operation"
+	gpeer "google.golang.org/grpc/peer"
+)
+
+func withInboundRequestInfo(
+	ctx context.Context,
+	target operation.Operation,
+) (context.Context, error) {
+	options := make([]operation.RequestInfoOption, 0, 1)
+	if remote, ok := gpeer.FromContext(ctx); ok && remote.Addr != nil {
+		peer, err := operation.NewPeer(
+			remote.Addr.Network(),
+			remote.Addr.String(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, operation.WithPeer(peer))
+	}
+	info, err := operation.NewRequestInfo(target, options...)
+	if err != nil {
+		return nil, err
+	}
+	return operation.WithRequestInfo(ctx, info), nil
+}
+
+func withOutboundRequestInfo(
+	ctx context.Context,
+	target operation.Operation,
+) (context.Context, error) {
+	info, err := operation.NewRequestInfo(target)
+	if err != nil {
+		return nil, err
+	}
+	return operation.WithRequestInfo(ctx, info), nil
+}

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -1,0 +1,615 @@
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/keelab/keelith/health"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"go.opentelemetry.io/otel/propagation"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+const (
+	defaultAddress    = "127.0.0.1:0"
+	defaultServerName = "keelith.transport.grpc"
+	defaultMessageMax = 4 * 1024 * 1024
+)
+
+type serverState uint8
+
+const (
+	serverStateNew serverState = iota
+	serverStateStarting
+	serverStateRunning
+	serverStateStopping
+	serverStateStopped
+)
+
+// ServerOption configures a Server.
+type ServerOption interface {
+	applyServer(*serverOptions) error
+}
+
+type serverOptionFunc func(*serverOptions) error
+
+func (function serverOptionFunc) applyServer(options *serverOptions) error {
+	return function(options)
+}
+
+type serverOptions struct {
+	address          string
+	addressSet       bool
+	listener         net.Listener
+	name             string
+	bundle           *middleware.Bundle
+	streamBundle     *middleware.StreamBundle
+	metadataPolicy   metadata.Policy
+	errorCodec       *ErrorCodec
+	health           *health.Registry
+	maxReceiveBytes  int
+	maxSendBytes     int
+	propagator       propagation.TextMapPropagator
+	tlsConfig        *tls.Config
+	keepalive        *ServerKeepaliveConfig
+	localDiagnostics []localDiagnostic
+}
+
+// LocalDiagnosticServer is the bounded registration surface required by
+// reflection and grpc-go administration services.
+type LocalDiagnosticServer interface {
+	ggrpc.ServiceRegistrar
+	GetServiceInfo() map[string]ggrpc.ServiceInfo
+}
+
+// LocalDiagnosticRegistrar registers an opt-in local-only gRPC diagnostic.
+//
+// The returned cleanup runs after serving stops. Implementations must register
+// synchronously and must not retain the ServiceRegistrar.
+type LocalDiagnosticRegistrar func(
+	LocalDiagnosticServer,
+) (cleanup func(), err error)
+
+type localDiagnostic struct {
+	name     string
+	register LocalDiagnosticRegistrar
+}
+
+// WithAddress sets the TCP listen address.
+func WithAddress(address string) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil || host == "" || port == "" {
+			return fmt.Errorf("invalid listen address %q", address)
+		}
+		options.address = address
+		options.addressSet = true
+		return nil
+	})
+}
+
+// WithListener uses listener instead of opening a TCP address.
+func WithListener(listener net.Listener) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if isNilListener(listener) {
+			return fmt.Errorf("listener is nil")
+		}
+		options.listener = listener
+		return nil
+	})
+}
+
+// WithName sets the stable diagnostic and health contributor name.
+func WithName(name string) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		normalized := strings.TrimSpace(name)
+		if normalized == "" {
+			return fmt.Errorf("server name is empty")
+		}
+		options.name = normalized
+		return nil
+	})
+}
+
+// WithMiddleware configures the immutable inbound middleware Bundle.
+func WithMiddleware(bundle *middleware.Bundle) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if bundle == nil {
+			return fmt.Errorf("middleware bundle is nil")
+		}
+		options.bundle = bundle
+		return nil
+	})
+}
+
+// WithStreamMiddleware configures per-stream create/send/receive/finish hooks.
+func WithStreamMiddleware(bundle *middleware.StreamBundle) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if bundle == nil {
+			return fmt.Errorf("stream middleware bundle is nil")
+		}
+		options.streamBundle = bundle
+		return nil
+	})
+}
+
+// WithMetadataPolicy configures incoming gRPC metadata propagation.
+func WithMetadataPolicy(policy metadata.Policy) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		options.metadataPolicy = policy
+		return nil
+	})
+}
+
+// WithPropagator configures distributed context extraction.
+func WithPropagator(propagator propagation.TextMapPropagator) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if propagator == nil {
+			return fmt.Errorf("propagator is nil")
+		}
+		options.propagator = propagator
+		return nil
+	})
+}
+
+// WithErrorCodec configures framework Error serialization.
+func WithErrorCodec(codec *ErrorCodec) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if codec == nil {
+			return fmt.Errorf("error codec is nil")
+		}
+		options.errorCodec = codec
+		return nil
+	})
+}
+
+// WithHealth exposes standard gRPC Health from registry readiness.
+func WithHealth(registry *health.Registry) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if registry == nil {
+			return fmt.Errorf("health registry is nil")
+		}
+		options.health = registry
+		return nil
+	})
+}
+
+// WithLocalDiagnostic registers an explicit loopback/Unix-only gRPC service.
+//
+// Optional reflection and admin adapters live outside the core transport.
+func WithLocalDiagnostic(
+	name string,
+	register LocalDiagnosticRegistrar,
+) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		normalized := strings.TrimSpace(name)
+		if normalized != name || !validDiscoveryName(normalized) {
+			return fmt.Errorf("local diagnostic name is malformed")
+		}
+		if register == nil {
+			return fmt.Errorf("local diagnostic registrar is nil")
+		}
+		options.localDiagnostics = append(
+			options.localDiagnostics,
+			localDiagnostic{name: normalized, register: register},
+		)
+		return nil
+	})
+}
+
+// WithMaxReceiveMessageBytes sets the decoded request message budget.
+func WithMaxReceiveMessageBytes(maxBytes int) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max receive message bytes must be positive")
+		}
+		options.maxReceiveBytes = maxBytes
+		return nil
+	})
+}
+
+// WithMaxSendMessageBytes sets the encoded response message budget.
+func WithMaxSendMessageBytes(maxBytes int) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max send message bytes must be positive")
+		}
+		options.maxSendBytes = maxBytes
+		return nil
+	})
+}
+
+// WithTLS enables the shared TLS/mTLS server profile.
+func WithTLS(config *tls.Config) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if config == nil {
+			return fmt.Errorf("TLS config is nil")
+		}
+		if config.MinVersion < tls.VersionTLS12 {
+			return fmt.Errorf("TLS minimum version must be 1.2 or newer")
+		}
+		options.tlsConfig = config.Clone()
+		return nil
+	})
+}
+
+// Server is a grpc-go lifecycle component.
+type Server struct {
+	name       string
+	address    string
+	configured net.Listener
+	grpcServer *ggrpc.Server
+
+	mu                sync.Mutex
+	state             serverState
+	listener          net.Listener
+	serveErr          error
+	stopErr           error
+	shutdownInitiated bool
+
+	startDone chan struct{}
+	done      chan struct{}
+	stopDone  chan struct{}
+	doneOnce  sync.Once
+	stopOnce  sync.Once
+
+	diagnosticCleanups    []func()
+	diagnosticCleanupOnce sync.Once
+}
+
+// NewServer validates options and constructs a Server.
+func NewServer(optionList ...ServerOption) (*Server, error) {
+	defaultCodec, _ := NewErrorCodec()
+	options := serverOptions{
+		address:         defaultAddress,
+		name:            defaultServerName,
+		errorCodec:      defaultCodec,
+		maxReceiveBytes: defaultMessageMax,
+		maxSendBytes:    defaultMessageMax,
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: server option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyServer(&options); err != nil {
+			return nil, fmt.Errorf("%w: server option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	if options.listener != nil && options.addressSet {
+		return nil, fmt.Errorf(
+			"%w: address and listener are mutually exclusive",
+			ErrInvalidOption,
+		)
+	}
+	if len(options.localDiagnostics) > 0 &&
+		!localDiagnosticListener(options.address, options.listener) {
+		return nil, fmt.Errorf(
+			"%w: local diagnostics require a loopback or Unix listener",
+			ErrInvalidOption,
+		)
+	}
+
+	transport := &Server{
+		name:       options.name,
+		address:    options.address,
+		configured: options.listener,
+		state:      serverStateNew,
+		startDone:  make(chan struct{}),
+		done:       make(chan struct{}),
+		stopDone:   make(chan struct{}),
+	}
+	grpcOptions := []ggrpc.ServerOption{
+		ggrpc.ChainUnaryInterceptor(unaryServerInterceptor(
+			options.bundle,
+			options.metadataPolicy,
+			options.errorCodec,
+			options.propagator,
+		)),
+		ggrpc.ChainStreamInterceptor(streamServerInterceptor(
+			options.bundle,
+			options.streamBundle,
+			options.metadataPolicy,
+			options.errorCodec,
+			options.propagator,
+		)),
+		ggrpc.MaxRecvMsgSize(options.maxReceiveBytes),
+		ggrpc.MaxSendMsgSize(options.maxSendBytes),
+	}
+	if options.tlsConfig != nil {
+		grpcOptions = append(
+			grpcOptions,
+			ggrpc.Creds(credentials.NewTLS(options.tlsConfig)),
+		)
+	}
+	if options.keepalive != nil {
+		grpcOptions = append(
+			grpcOptions,
+			serverKeepaliveOptions(*options.keepalive)...,
+		)
+	}
+	transport.grpcServer = ggrpc.NewServer(grpcOptions...)
+	if options.health != nil {
+		if err := options.health.Register(
+			health.KindReadiness,
+			options.name,
+			transport.readiness,
+		); err != nil {
+			return nil, fmt.Errorf("%w: register health: %w", ErrInvalidOption, err)
+		}
+		grpc_health_v1.RegisterHealthServer(
+			transport.grpcServer,
+			&healthServer{registry: options.health},
+		)
+	}
+	diagnosticNames := make(map[string]struct{}, len(options.localDiagnostics))
+	for _, diagnostic := range options.localDiagnostics {
+		if _, exists := diagnosticNames[diagnostic.name]; exists {
+			transport.cleanupDiagnostics()
+			return nil, fmt.Errorf(
+				"%w: local diagnostic %q is duplicated",
+				ErrInvalidOption,
+				diagnostic.name,
+			)
+		}
+		cleanup, err := registerLocalDiagnostic(
+			transport.grpcServer,
+			diagnostic,
+		)
+		if err != nil {
+			transport.cleanupDiagnostics()
+			return nil, fmt.Errorf(
+				"%w: register local diagnostic %q: %w",
+				ErrInvalidOption,
+				diagnostic.name,
+				err,
+			)
+		}
+		diagnosticNames[diagnostic.name] = struct{}{}
+		if cleanup != nil {
+			transport.diagnosticCleanups = append(
+				transport.diagnosticCleanups,
+				cleanup,
+			)
+		}
+	}
+	return transport, nil
+}
+
+// Registrar returns the grpc-go service registrar.
+func (server *Server) Registrar() ggrpc.ServiceRegistrar {
+	return server.grpcServer
+}
+
+// Name returns the stable App diagnostic name.
+func (server *Server) Name() string {
+	return server.name
+}
+
+// Start opens or adopts a listener and begins serving in the background.
+func (server *Server) Start(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	server.mu.Lock()
+	if server.state != serverStateNew {
+		server.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	server.state = serverStateStarting
+	server.mu.Unlock()
+	defer close(server.startDone)
+
+	listener := server.configured
+	var err error
+	if listener == nil {
+		var listenConfig net.ListenConfig
+		listener, err = listenConfig.Listen(ctx, "tcp", server.address)
+		if err != nil {
+			server.completeServe(fmt.Errorf("grpc transport: listen %q: %w", server.address, err))
+			return fmt.Errorf("grpc transport: listen %q: %w", server.address, err)
+		}
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		closeErr := listener.Close()
+		result := errors.Join(cause, closeErr)
+		server.completeServe(result)
+		return result
+	}
+
+	server.mu.Lock()
+	server.listener = listener
+	server.state = serverStateRunning
+	server.mu.Unlock()
+	go server.serve(listener)
+	return nil
+}
+
+// Stop gracefully drains active RPCs and force-stops at ctx deadline.
+func (server *Server) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	for {
+		server.mu.Lock()
+		switch server.state {
+		case serverStateNew:
+			server.state = serverStateStopped
+			server.doneOnce.Do(func() { close(server.done) })
+			server.stopOnce.Do(func() { close(server.stopDone) })
+			server.mu.Unlock()
+			server.cleanupDiagnostics()
+			return nil
+		case serverStateStarting:
+			startDone := server.startDone
+			server.mu.Unlock()
+			select {
+			case <-startDone:
+				continue
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		case serverStateRunning:
+			server.state = serverStateStopping
+			if !server.shutdownInitiated {
+				server.shutdownInitiated = true
+				go server.shutdown(ctx)
+			}
+			stopDone := server.stopDone
+			server.mu.Unlock()
+			return server.waitStop(ctx, stopDone)
+		case serverStateStopping:
+			stopDone := server.stopDone
+			server.mu.Unlock()
+			return server.waitStop(ctx, stopDone)
+		case serverStateStopped:
+			err := server.stopErr
+			server.mu.Unlock()
+			return err
+		default:
+			server.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// Wait blocks until serving terminates.
+func (server *Server) Wait() error {
+	<-server.done
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	return server.serveErr
+}
+
+// Address returns the active listener address.
+func (server *Server) Address() (string, bool) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.listener == nil {
+		return "", false
+	}
+	return server.listener.Addr().String(), true
+}
+
+func (server *Server) serve(listener net.Listener) {
+	err := server.grpcServer.Serve(listener)
+	if errors.Is(err, ggrpc.ErrServerStopped) {
+		err = nil
+	}
+	server.completeServe(err)
+}
+
+func (server *Server) completeServe(err error) {
+	server.mu.Lock()
+	if server.serveErr == nil {
+		server.serveErr = err
+	}
+	if server.state != serverStateStopping {
+		server.state = serverStateStopped
+	}
+	server.mu.Unlock()
+	server.cleanupDiagnostics()
+	server.doneOnce.Do(func() { close(server.done) })
+}
+
+func (server *Server) shutdown(ctx context.Context) {
+	gracefulDone := make(chan struct{})
+	go func() {
+		server.grpcServer.GracefulStop()
+		close(gracefulDone)
+	}()
+	select {
+	case <-gracefulDone:
+	case <-ctx.Done():
+		server.grpcServer.Stop()
+		<-gracefulDone
+	}
+	<-server.done
+	server.mu.Lock()
+	server.stopErr = server.serveErr
+	if cause := context.Cause(ctx); cause != nil {
+		server.stopErr = errors.Join(cause, server.stopErr)
+	}
+	server.state = serverStateStopped
+	server.mu.Unlock()
+	server.stopOnce.Do(func() { close(server.stopDone) })
+}
+
+func (server *Server) waitStop(ctx context.Context, stopDone <-chan struct{}) error {
+	select {
+	case <-stopDone:
+		server.mu.Lock()
+		defer server.mu.Unlock()
+		return server.stopErr
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (server *Server) readiness(context.Context) health.Result {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.state == serverStateRunning {
+		return health.Pass("gRPC listener is accepting requests")
+	}
+	return health.Fail("gRPC listener is not accepting requests")
+}
+
+func isNilListener(listener net.Listener) bool {
+	if listener == nil {
+		return true
+	}
+	value := reflect.ValueOf(listener)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}
+
+func (server *Server) cleanupDiagnostics() {
+	server.diagnosticCleanupOnce.Do(func() {
+		for index := len(server.diagnosticCleanups) - 1; index >= 0; index-- {
+			server.diagnosticCleanups[index]()
+		}
+	})
+}
+
+func registerLocalDiagnostic(
+	registrar LocalDiagnosticServer,
+	diagnostic localDiagnostic,
+) (cleanup func(), err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			cleanup = nil
+			err = fmt.Errorf("registrar panic: %v", recovered)
+		}
+	}()
+	return diagnostic.register(registrar)
+}
+
+func localDiagnosticListener(
+	address string,
+	listener net.Listener,
+) bool {
+	if listener != nil {
+		network := strings.ToLower(listener.Addr().Network())
+		if network == "unix" || network == "unixpacket" {
+			return true
+		}
+		address = listener.Addr().String()
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/transport/grpc/stream_lifecycle.go
+++ b/transport/grpc/stream_lifecycle.go
@@ -1,0 +1,95 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/keelab/keelith/middleware"
+)
+
+type streamEvents struct {
+	context context.Context
+	side    middleware.StreamSide
+	handler middleware.StreamHandler
+
+	sendSequence    atomic.Uint64
+	receiveSequence atomic.Uint64
+	finishOnce      sync.Once
+	finishErr       error
+}
+
+func newStreamEvents(
+	ctx context.Context,
+	side middleware.StreamSide,
+	bundle *middleware.StreamBundle,
+	send func(context.Context, any) error,
+	receive func(context.Context, any) error,
+) *streamEvents {
+	terminal := middleware.StreamHandler(func(
+		ctx context.Context,
+		event middleware.StreamEvent,
+	) error {
+		switch event.Phase {
+		case middleware.StreamPhaseCreate, middleware.StreamPhaseFinish:
+			return nil
+		case middleware.StreamPhaseSend:
+			return send(ctx, event.Message)
+		case middleware.StreamPhaseReceive:
+			return receive(ctx, event.Message)
+		default:
+			return fmt.Errorf(
+				"grpc transport: unsupported stream phase %q",
+				event.Phase,
+			)
+		}
+	})
+	if bundle != nil {
+		terminal = bundle.Chain()(terminal)
+	}
+	return &streamEvents{
+		context: ctx,
+		side:    side,
+		handler: terminal,
+	}
+}
+
+func (events *streamEvents) create() error {
+	return events.handler(events.context, middleware.StreamEvent{
+		Side:  events.side,
+		Phase: middleware.StreamPhaseCreate,
+	})
+}
+
+func (events *streamEvents) send(message any) error {
+	return events.handler(events.context, middleware.StreamEvent{
+		Side:     events.side,
+		Phase:    middleware.StreamPhaseSend,
+		Sequence: events.sendSequence.Add(1),
+		Message:  message,
+	})
+}
+
+func (events *streamEvents) receive(message any) error {
+	return events.handler(events.context, middleware.StreamEvent{
+		Side:     events.side,
+		Phase:    middleware.StreamPhaseReceive,
+		Sequence: events.receiveSequence.Add(1),
+		Message:  message,
+	})
+}
+
+func (events *streamEvents) finish(err error) error {
+	events.finishOnce.Do(func() {
+		events.finishErr = events.handler(
+			events.context,
+			middleware.StreamEvent{
+				Side:  events.side,
+				Phase: middleware.StreamPhaseFinish,
+				Error: err,
+			},
+		)
+	})
+	return events.finishErr
+}

--- a/transport/grpcauth/bearer.go
+++ b/transport/grpcauth/bearer.go
@@ -1,0 +1,545 @@
+// Package grpcauth provides Secret-backed outbound gRPC credentials without
+// coupling application config to plaintext authentication material.
+package grpcauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/keelab/keelith/secret"
+)
+
+// Bearer lifecycle states.
+const (
+	defaultMaxTokenBytes = 8 * 1024
+	maximumTokenBytes    = 64 * 1024
+	reconnectInitial     = 250 * time.Millisecond
+	reconnectMaximum     = 5 * time.Second
+)
+
+var (
+	// ErrInvalidOption reports an invalid manager, reference, or token budget.
+	ErrInvalidOption = errors.New("grpc auth: invalid option")
+	// ErrCredentialUnavailable reports a request before valid last-good
+	// credentials have been loaded.
+	ErrCredentialUnavailable = errors.New("grpc auth: credential unavailable")
+	// ErrStopped reports an operation after lifecycle shutdown.
+	ErrStopped = errors.New("grpc auth: stopped")
+)
+
+// SecretManager resolves and watches complete credential replacements.
+type SecretManager interface {
+	Resolve(context.Context, secret.Reference) (secret.Value, error)
+	Watch(context.Context, secret.Reference) (secret.Watcher, error)
+}
+
+// Config defines one strict bearer token credential.
+type Config struct {
+	Reference     secret.Reference
+	MaxTokenBytes int
+}
+
+// State is a bounded lifecycle state.
+type State string
+
+const (
+	// StateNew is the state before the credential starts.
+	StateNew State = "new"
+	// StateStarting is the state while the initial secret is resolving.
+	StateStarting State = "starting"
+	// StateRunning is the active credential state.
+	StateRunning State = "running"
+	// StateStopped is the terminal stopped state.
+	StateStopped State = "stopped"
+	// StateFailed is the state after a terminal credential failure.
+	StateFailed State = "failed"
+)
+
+// Description is a token-free operational snapshot.
+type Description struct {
+	State      State
+	Ready      bool
+	Degraded   bool
+	Reloads    uint64
+	Reconnects uint64
+	Failures   uint64
+}
+
+type credential struct {
+	authorization string
+}
+
+// Bearer implements gRPC PerRPCCredentials, App Lifecycle, and
+// secret.UpdateSource. Every request receives the current last-good token;
+// consumers such as long-lived ADS streams can subscribe to successful
+// replacements and reconnect proactively.
+type Bearer struct {
+	manager       SecretManager
+	reference     secret.Reference
+	maxTokenBytes int
+	current       atomic.Pointer[credential]
+
+	mu             sync.Mutex
+	state          State
+	lastError      error
+	version        string
+	generation     uint64
+	nextSubscriber uint64
+	subscribers    map[uint64]chan uint64
+	cancel         context.CancelFunc
+	watcher        secret.Watcher
+	done           chan struct{}
+
+	reloads    atomic.Uint64
+	reconnects atomic.Uint64
+	failures   atomic.Uint64
+}
+
+// Subscription observes successful token generations without token material,
+// provider revision, reference, or errors.
+type Subscription struct {
+	bearer    *Bearer
+	id        uint64
+	baseline  uint64
+	updates   <-chan uint64
+	closeOnce sync.Once
+}
+
+// New validates and constructs a dormant bearer credential lifecycle.
+func New(manager SecretManager, config Config) (*Bearer, error) {
+	if isNil(manager) {
+		return nil, fmt.Errorf("%w: secret manager is nil", ErrInvalidOption)
+	}
+	normalized, err := NormalizeConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &Bearer{
+		manager:       manager,
+		reference:     normalized.Reference,
+		maxTokenBytes: normalized.MaxTokenBytes,
+		state:         StateNew,
+		subscribers:   make(map[uint64]chan uint64),
+	}, nil
+}
+
+// NormalizeConfig applies stable budgets and validates the material-free
+// credential contract without resolving the referenced token.
+func NormalizeConfig(config Config) (Config, error) {
+	if _, err := secret.NewReference(
+		config.Reference.Provider(),
+		config.Reference.Key(),
+	); err != nil {
+		return Config{}, err
+	}
+	if config.MaxTokenBytes == 0 {
+		config.MaxTokenBytes = defaultMaxTokenBytes
+	}
+	if config.MaxTokenBytes < 1 || config.MaxTokenBytes > maximumTokenBytes {
+		return Config{}, fmt.Errorf(
+			"%w: token budget is outside 1..%d bytes",
+			ErrInvalidOption,
+			maximumTokenBytes,
+		)
+	}
+	return config, nil
+}
+
+// ValidateConfig validates bearer settings without resolving credentials.
+func ValidateConfig(config Config) error {
+	_, err := NormalizeConfig(config)
+	return err
+}
+
+// Start resolves a valid initial token and then watches complete replacements.
+func (bearer *Bearer) Start(ctx context.Context) error {
+	if bearer == nil || ctx == nil {
+		return fmt.Errorf("%w: bearer or context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	bearer.mu.Lock()
+	if bearer.state != StateNew {
+		bearer.mu.Unlock()
+		return fmt.Errorf("%w: bearer already started or stopped", ErrInvalidOption)
+	}
+	bearer.state = StateStarting
+	bearer.mu.Unlock()
+
+	watchContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	source, err := bearer.manager.Watch(watchContext, bearer.reference)
+	if err != nil {
+		cancel()
+		bearer.failStart(err)
+		return fmt.Errorf("grpc auth: establish token watch: %w", err)
+	}
+	value, err := bearer.manager.Resolve(ctx, bearer.reference)
+	if err == nil {
+		err = bearer.apply(value)
+	}
+	if err != nil {
+		cancel()
+		_ = source.Close()
+		bearer.failStart(err)
+		return fmt.Errorf("grpc auth: load token: %w", err)
+	}
+	bearer.mu.Lock()
+	bearer.state = StateRunning
+	bearer.cancel = cancel
+	bearer.watcher = source
+	bearer.done = make(chan struct{})
+	done := bearer.done
+	bearer.mu.Unlock()
+	go bearer.run(watchContext, source, done)
+	return nil
+}
+
+// Shutdown stops the credential watch and clears the active pointer. It is
+// safe to call repeatedly.
+func (bearer *Bearer) Shutdown(ctx context.Context) error {
+	if bearer == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	bearer.mu.Lock()
+	switch bearer.state {
+	case StateNew, StateFailed:
+		bearer.state = StateStopped
+		bearer.current.Store(nil)
+		bearer.closeSubscribersLocked()
+		bearer.mu.Unlock()
+		return nil
+	case StateStopped:
+		bearer.mu.Unlock()
+		return nil
+	}
+	cancel := bearer.cancel
+	source := bearer.watcher
+	done := bearer.done
+	bearer.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if source != nil {
+		_ = source.Close()
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+// GetRequestMetadata returns the current Authorization header. Errors never
+// contain token material, references, provider versions, or request URIs.
+func (bearer *Bearer) GetRequestMetadata(
+	ctx context.Context,
+	_ ...string,
+) (map[string]string, error) {
+	if bearer == nil || ctx == nil {
+		return nil, fmt.Errorf("%w: bearer or context is nil", ErrInvalidOption)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, cause
+	}
+	current := bearer.current.Load()
+	if current == nil {
+		bearer.mu.Lock()
+		stopped := bearer.state == StateStopped || bearer.state == StateFailed
+		bearer.mu.Unlock()
+		if stopped {
+			return nil, ErrStopped
+		}
+		return nil, ErrCredentialUnavailable
+	}
+	return map[string]string{"authorization": current.authorization}, nil
+}
+
+// RequireTransportSecurity prevents bearer tokens from crossing plaintext
+// gRPC connections.
+func (*Bearer) RequireTransportSecurity() bool { return true }
+
+// Ready reports whether valid last-good credentials are available.
+func (bearer *Bearer) Ready() bool {
+	return bearer != nil && bearer.current.Load() != nil
+}
+
+// SubscribeUpdates implements secret.UpdateSource.
+func (bearer *Bearer) SubscribeUpdates() (secret.UpdateSubscription, error) {
+	if bearer == nil {
+		return nil, fmt.Errorf("%w: bearer is nil", ErrInvalidOption)
+	}
+	bearer.mu.Lock()
+	defer bearer.mu.Unlock()
+	if bearer.state == StateStopped || bearer.state == StateFailed {
+		return nil, ErrStopped
+	}
+	bearer.nextSubscriber++
+	id := bearer.nextSubscriber
+	updates := make(chan uint64, 1)
+	bearer.subscribers[id] = updates
+	return &Subscription{
+		bearer:   bearer,
+		id:       id,
+		baseline: bearer.generation,
+		updates:  updates,
+	}, nil
+}
+
+// Description returns bounded lifecycle and aggregate counters.
+func (bearer *Bearer) Description() Description {
+	if bearer == nil {
+		return Description{State: StateStopped}
+	}
+	bearer.mu.Lock()
+	description := Description{
+		State:    bearer.state,
+		Ready:    bearer.current.Load() != nil,
+		Degraded: bearer.lastError != nil,
+	}
+	bearer.mu.Unlock()
+	description.Reloads = bearer.reloads.Load()
+	description.Reconnects = bearer.reconnects.Load()
+	description.Failures = bearer.failures.Load()
+	return description
+}
+
+// Baseline returns the generation active when the subscription was created.
+func (subscription *Subscription) Baseline() uint64 {
+	if subscription == nil {
+		return 0
+	}
+	return subscription.baseline
+}
+
+// Updates returns a single-slot latest-generation stream.
+func (subscription *Subscription) Updates() <-chan uint64 {
+	if subscription == nil {
+		return nil
+	}
+	return subscription.updates
+}
+
+// Close unregisters the subscription. It is safe to call repeatedly.
+func (subscription *Subscription) Close() {
+	if subscription == nil || subscription.bearer == nil {
+		return
+	}
+	subscription.closeOnce.Do(func() {
+		subscription.bearer.removeSubscriber(subscription.id)
+	})
+}
+
+func (bearer *Bearer) run(
+	ctx context.Context,
+	source secret.Watcher,
+	done chan struct{},
+) {
+	defer func() {
+		bearer.mu.Lock()
+		bearer.state = StateStopped
+		bearer.cancel = nil
+		bearer.watcher = nil
+		bearer.current.Store(nil)
+		bearer.closeSubscribersLocked()
+		close(done)
+		bearer.mu.Unlock()
+	}()
+	for {
+		value, err := source.Next(ctx)
+		if err != nil {
+			if context.Cause(ctx) != nil {
+				return
+			}
+			bearer.record(err)
+			_ = source.Close()
+			source, err = bearer.reconnect(ctx)
+			if err != nil {
+				return
+			}
+			continue
+		}
+		if err := bearer.apply(value); err != nil {
+			bearer.record(err)
+			continue
+		}
+		bearer.record(nil)
+	}
+}
+
+func (bearer *Bearer) reconnect(ctx context.Context) (secret.Watcher, error) {
+	delay := reconnectInitial
+	for {
+		if cause := context.Cause(ctx); cause != nil {
+			return nil, cause
+		}
+		source, err := bearer.manager.Watch(ctx, bearer.reference)
+		if err == nil {
+			value, resolveErr := bearer.manager.Resolve(ctx, bearer.reference)
+			if resolveErr == nil {
+				resolveErr = bearer.apply(value)
+			}
+			if resolveErr == nil {
+				bearer.mu.Lock()
+				bearer.watcher = source
+				bearer.mu.Unlock()
+				bearer.reconnects.Add(1)
+				bearer.record(nil)
+				return source, nil
+			}
+			_ = source.Close()
+			err = resolveErr
+		}
+		bearer.record(err)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			stopAndDrain(timer)
+			return nil, context.Cause(ctx)
+		case <-timer.C:
+		}
+		delay *= 2
+		if delay > reconnectMaximum {
+			delay = reconnectMaximum
+		}
+	}
+}
+
+func (bearer *Bearer) apply(value secret.Value) error {
+	authorization, err := validateToken(value, bearer.maxTokenBytes)
+	if err != nil {
+		return err
+	}
+	bearer.mu.Lock()
+	defer bearer.mu.Unlock()
+	if bearer.version == value.Version() {
+		return nil
+	}
+	bearer.current.Store(&credential{authorization: authorization})
+	bearer.version = value.Version()
+	bearer.generation++
+	for _, updates := range bearer.subscribers {
+		publishGeneration(updates, bearer.generation)
+	}
+	bearer.reloads.Add(1)
+	return nil
+}
+
+func validateToken(value secret.Value, maxBytes int) (string, error) {
+	if err := value.Validate(); err != nil || value.Expired(time.Now()) {
+		return "", fmt.Errorf("%w: resolved token is invalid", ErrInvalidOption)
+	}
+	content := value.Bytes()
+	defer clear(content)
+	tokenContent := secret.TrimLineBreaks(content)
+	if len(tokenContent) == 0 ||
+		len(tokenContent) > maxBytes ||
+		!utf8.Valid(tokenContent) {
+		return "", fmt.Errorf("%w: token violates size or UTF-8 budget", ErrInvalidOption)
+	}
+	token := string(tokenContent)
+	if strings.TrimSpace(token) != token || !validBearerToken(token) {
+		return "", fmt.Errorf("%w: token violates bearer syntax", ErrInvalidOption)
+	}
+	return "Bearer " + token, nil
+}
+
+func validBearerToken(token string) bool {
+	padding := false
+	for _, character := range token {
+		if character == '=' {
+			padding = true
+			continue
+		}
+		if padding ||
+			(character < 'a' || character > 'z') &&
+				(character < 'A' || character > 'Z') &&
+				(character < '0' || character > '9') &&
+				!strings.ContainsRune("-._~+/", character) {
+			return false
+		}
+	}
+	return token != ""
+}
+
+func (bearer *Bearer) failStart(err error) {
+	bearer.mu.Lock()
+	bearer.state = StateFailed
+	bearer.lastError = err
+	bearer.failures.Add(1)
+	bearer.mu.Unlock()
+}
+
+func (bearer *Bearer) record(err error) {
+	bearer.mu.Lock()
+	bearer.lastError = err
+	bearer.mu.Unlock()
+	if err != nil {
+		bearer.failures.Add(1)
+	}
+}
+
+func (bearer *Bearer) removeSubscriber(id uint64) {
+	bearer.mu.Lock()
+	updates, exists := bearer.subscribers[id]
+	if exists {
+		delete(bearer.subscribers, id)
+		close(updates)
+	}
+	bearer.mu.Unlock()
+}
+
+func (bearer *Bearer) closeSubscribersLocked() {
+	for id, updates := range bearer.subscribers {
+		delete(bearer.subscribers, id)
+		close(updates)
+	}
+}
+
+func publishGeneration(updates chan uint64, generation uint64) {
+	select {
+	case <-updates:
+	default:
+	}
+	select {
+	case updates <- generation:
+	default:
+	}
+}
+
+func stopAndDrain(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+var _ secret.UpdateSource = (*Bearer)(nil)

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -1,0 +1,472 @@
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"net/url"
+	"reflect"
+	"time"
+
+	kclient "github.com/keelab/keelith/client"
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/governance/failure"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/selector"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const defaultClientMaxHeaderBytes = 1 * 1024 * 1024
+
+// ClientCall contains a prepared HTTP request and typed-friendly decoder.
+type ClientCall struct {
+	Request   *nethttp.Request
+	Decode    func(context.Context, *nethttp.Response) (any, error)
+	Streaming bool
+}
+
+// ClientOption configures a Client.
+type ClientOption interface {
+	applyClient(*clientOptions) error
+}
+
+type clientOptionFunc func(*clientOptions) error
+
+func (function clientOptionFunc) applyClient(options *clientOptions) error {
+	return function(options)
+}
+
+type clientOptions struct {
+	bundle           *middleware.Bundle
+	metadataPolicy   metadata.Policy
+	maxResponseBytes int64
+	maxHeaderBytes   int
+	propagator       propagation.TextMapPropagator
+	tlsConfig        *tls.Config
+	picker           kclient.Picker
+}
+
+// WithClientMiddleware configures the immutable outbound middleware Bundle.
+func WithClientMiddleware(bundle *middleware.Bundle) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if bundle == nil {
+			return fmt.Errorf("middleware bundle is nil")
+		}
+		options.bundle = bundle
+		return nil
+	})
+}
+
+// WithClientMetadataPolicy configures HTTP header propagation.
+func WithClientMetadataPolicy(policy metadata.Policy) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		options.metadataPolicy = policy
+		return nil
+	})
+}
+
+// WithClientPropagator configures distributed context injection.
+func WithClientPropagator(
+	propagator propagation.TextMapPropagator,
+) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if propagator == nil {
+			return fmt.Errorf("propagator is nil")
+		}
+		options.propagator = propagator
+		return nil
+	})
+}
+
+// WithClientMaxResponseBytes sets the decoded response body budget.
+func WithClientMaxResponseBytes(maxBytes int64) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max response bytes must be positive")
+		}
+		options.maxResponseBytes = maxBytes
+		return nil
+	})
+}
+
+// WithClientMaxHeaderBytes sets the response header budget.
+func WithClientMaxHeaderBytes(maxBytes int) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max header bytes must be positive")
+		}
+		options.maxHeaderBytes = maxBytes
+		return nil
+	})
+}
+
+// WithClientTLS installs a cloned TLS/mTLS profile on a standard Transport.
+func WithClientTLS(config *tls.Config) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if config == nil {
+			return fmt.Errorf("TLS config is nil")
+		}
+		if config.MinVersion < tls.VersionTLS12 {
+			return fmt.Errorf("TLS minimum version must be 1.2 or newer")
+		}
+		options.tlsConfig = config.Clone()
+		return nil
+	})
+}
+
+// WithClientPicker enables per-attempt service discovery and node feedback.
+func WithClientPicker(picker kclient.Picker) ClientOption {
+	return clientOptionFunc(func(options *clientOptions) error {
+		if isNilPicker(picker) {
+			return fmt.Errorf("picker is nil")
+		}
+		options.picker = picker
+		return nil
+	})
+}
+
+// Client executes HTTP calls through Keelith's outbound invocation model.
+type Client struct {
+	client           *nethttp.Client
+	bundle           *middleware.Bundle
+	metadataPolicy   metadata.Policy
+	maxResponseBytes int64
+	maxHeaderBytes   int
+	propagator       propagation.TextMapPropagator
+	picker           kclient.Picker
+}
+
+// NewClient constructs a Client around an explicit standard HTTP client.
+func NewClient(client *nethttp.Client, optionList ...ClientOption) (*Client, error) {
+	if client == nil {
+		return nil, fmt.Errorf("%w: HTTP client is nil", ErrInvalidOption)
+	}
+	options := clientOptions{
+		maxResponseBytes: defaultMaxResponseBytes,
+		maxHeaderBytes:   defaultClientMaxHeaderBytes,
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: client option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyClient(&options); err != nil {
+			return nil, fmt.Errorf("%w: client option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	if options.tlsConfig != nil {
+		cloned := *client
+		switch transport := client.Transport.(type) {
+		case nil:
+			defaultTransport, ok := nethttp.DefaultTransport.(*nethttp.Transport)
+			if !ok {
+				return nil, fmt.Errorf(
+					"%w: default HTTP transport is not standard",
+					ErrInvalidOption,
+				)
+			}
+			transportClone := defaultTransport.Clone()
+			transportClone.TLSClientConfig = options.tlsConfig
+			cloned.Transport = transportClone
+		case *nethttp.Transport:
+			if transport == nil {
+				return nil, fmt.Errorf(
+					"%w: HTTP transport is nil",
+					ErrInvalidOption,
+				)
+			}
+			transportClone := transport.Clone()
+			transportClone.TLSClientConfig = options.tlsConfig
+			cloned.Transport = transportClone
+		default:
+			return nil, fmt.Errorf(
+				"%w: client TLS requires *http.Transport, got %T",
+				ErrInvalidOption,
+				client.Transport,
+			)
+		}
+		client = &cloned
+	}
+	return &Client{
+		client:           client,
+		bundle:           options.bundle,
+		metadataPolicy:   options.metadataPolicy,
+		maxResponseBytes: options.maxResponseBytes,
+		maxHeaderBytes:   options.maxHeaderBytes,
+		propagator:       options.propagator,
+		picker:           options.picker,
+	}, nil
+}
+
+// Invoke executes call through outbound middleware.
+func (client *Client) Invoke(
+	ctx context.Context,
+	target operation.Operation,
+	call ClientCall,
+) (any, error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	if call.Request == nil || call.Request.URL == nil || call.Decode == nil {
+		return nil, ErrInvalidCall
+	}
+	if target.Transport() != "http" {
+		return nil, fmt.Errorf(
+			"%w: operation transport %q is not http",
+			ErrInvalidCall,
+			target.Transport(),
+		)
+	}
+	network := call.Request.URL.Scheme
+	address := call.Request.URL.Host
+	if client.picker != nil {
+		network = ""
+		address = ""
+	}
+	requestInfo, err := newRequestInfo(target, network, address)
+	if err != nil {
+		return nil, fmt.Errorf("%w: request info: %w", ErrInvalidCall, err)
+	}
+	ctx = operation.WithRequestInfo(ctx, requestInfo)
+	handler := middleware.Handler(client.invoke)
+	if client.bundle != nil {
+		handler = client.bundle.Chain()(handler)
+	}
+	return handler(ctx, call)
+}
+
+func (client *Client) invoke(
+	ctx context.Context,
+	request any,
+) (responseValue any, resultErr error) {
+	call, ok := request.(ClientCall)
+	if !ok {
+		return nil, fmt.Errorf("%w: request type %T", ErrInvalidCall, request)
+	}
+	outboundRequest := call.Request.Clone(ctx)
+	if client.picker != nil {
+		target, exists := operation.FromContext(ctx)
+		if !exists {
+			return nil, fmt.Errorf("%w: operation is missing", ErrInvalidCall)
+		}
+		node, done, err := client.picker.Pick(ctx, target)
+		if err != nil {
+			return nil, dependencyFailure(err)
+		}
+		started := time.Now()
+		defer func() {
+			recovered := recover()
+			feedbackErr := resultErr
+			if recovered != nil {
+				feedbackErr = errors.New("http transport: invocation panic")
+			}
+			done(selector.Result{
+				Latency:  time.Since(started),
+				Error:    feedbackErr,
+				Canceled: errors.Is(feedbackErr, context.Canceled),
+				Retried:  operation.AttemptFromContext(ctx) > 1,
+			})
+			if recovered != nil {
+				panic(recovered)
+			}
+		}()
+
+		endpoint, err := selectedEndpoint(node)
+		if err != nil {
+			return nil, failure.MarkTransport(fmt.Errorf(
+				"%w: selected endpoint: %w",
+				ErrInvalidCall,
+				err,
+			))
+		}
+		requestInfo, err := newRequestInfo(
+			target,
+			endpoint.Scheme,
+			endpoint.Host,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("%w: selected request info: %w", ErrInvalidCall, err)
+		}
+		ctx = operation.WithRequestInfo(ctx, requestInfo)
+		outboundRequest = call.Request.Clone(ctx)
+		outboundRequest.URL.Scheme = endpoint.Scheme
+		outboundRequest.URL.Host = endpoint.Host
+	}
+	if client.propagator != nil {
+		client.propagator.Inject(
+			ctx,
+			propagation.HeaderCarrier(outboundRequest.Header),
+		)
+	}
+	if outbound, ok := metadata.Outbound(ctx); ok {
+		if err := client.metadataPolicy.Inject(
+			outbound,
+			httpHeaderCarrier(outboundRequest.Header),
+		); err != nil {
+			return nil, err
+		}
+	}
+	response, err := client.client.Do(outboundRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if headerSize(response.Header) > int64(client.maxHeaderBytes) {
+		return nil, ErrHeaderTooLarge
+	}
+	if !call.Streaming {
+		if response.ContentLength > client.maxResponseBytes {
+			return nil, ErrResponseTooLarge
+		}
+		response.Body = &limitedReadCloser{
+			reader:    response.Body,
+			remaining: client.maxResponseBytes,
+		}
+	}
+	inbound, err := client.metadataPolicy.Extract(httpHeaderCarrier(response.Header))
+	if err != nil {
+		return nil, err
+	}
+	decodeContext := metadata.WithInbound(ctx, inbound)
+	if response.StatusCode >= nethttp.StatusBadRequest {
+		return nil, decodeHTTPError(response)
+	}
+	return call.Decode(decodeContext, response)
+}
+
+func dependencyFailure(err error) error {
+	if err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return failure.MarkTransport(err)
+}
+
+func selectedEndpoint(node selector.Node) (*url.URL, error) {
+	endpoint, err := url.Parse(node.Endpoint())
+	if err != nil ||
+		endpoint.Scheme != "http" && endpoint.Scheme != "https" ||
+		endpoint.Host == "" ||
+		endpoint.User != nil ||
+		endpoint.Opaque != "" ||
+		endpoint.RawQuery != "" ||
+		endpoint.Fragment != "" ||
+		endpoint.RawPath != "" ||
+		endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, fmt.Errorf("unsafe HTTP endpoint %q", node.Endpoint())
+	}
+	return endpoint, nil
+}
+
+func isNilPicker(picker kclient.Picker) bool {
+	if picker == nil {
+		return true
+	}
+	value := reflect.ValueOf(picker)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// InvokeJSON decodes a successful JSON response as T.
+func InvokeJSON[T any](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+) (T, error) {
+	var zero T
+	if client == nil {
+		return zero, fmt.Errorf("%w: client is nil", ErrInvalidCall)
+	}
+	response, err := client.Invoke(ctx, target, ClientCall{
+		Request: request,
+		Decode: func(_ context.Context, response *nethttp.Response) (any, error) {
+			var value T
+			err := json.NewDecoder(response.Body).Decode(&value)
+			return value, err
+		},
+	})
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := response.(T)
+	if !ok {
+		return zero, fmt.Errorf("%w: response type %T", ErrInvalidCall, response)
+	}
+	return typed, nil
+}
+
+func decodeHTTPError(response *nethttp.Response) error {
+	var envelope ErrorEnvelope
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		return kerrors.New(
+			int32(response.StatusCode),
+			"HTTP_"+nethttp.StatusText(response.StatusCode),
+			nethttp.StatusText(response.StatusCode),
+		)
+	}
+	if envelope.Code == 0 {
+		envelope.Code = int32(response.StatusCode)
+	}
+	if envelope.Reason == "" {
+		envelope.Reason = "HTTP_" + nethttp.StatusText(response.StatusCode)
+	}
+	if envelope.Message == "" {
+		envelope.Message = nethttp.StatusText(response.StatusCode)
+	}
+	return kerrors.New(
+		envelope.Code,
+		envelope.Reason,
+		envelope.Message,
+		kerrors.WithMetadata(envelope.Metadata),
+	)
+}
+
+type limitedReadCloser struct {
+	reader    io.ReadCloser
+	remaining int64
+	exceeded  bool
+}
+
+func (reader *limitedReadCloser) Read(destination []byte) (int, error) {
+	if reader.exceeded {
+		return 0, ErrResponseTooLarge
+	}
+	if reader.remaining > 0 {
+		if int64(len(destination)) > reader.remaining {
+			destination = destination[:reader.remaining]
+		}
+		count, err := reader.reader.Read(destination)
+		reader.remaining -= int64(count)
+		return count, err
+	}
+	var probe [1]byte
+	count, err := reader.reader.Read(probe[:])
+	if count > 0 {
+		reader.exceeded = true
+		return 0, ErrResponseTooLarge
+	}
+	return 0, err
+}
+
+func (reader *limitedReadCloser) Close() error {
+	return reader.reader.Close()
+}

--- a/transport/http/context.go
+++ b/transport/http/context.go
@@ -1,0 +1,626 @@
+// Package http provides Keelith's standard-library HTTP transport.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/keelab/keelith/internal/protowkt"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// Decoder converts one HTTP request to a transport-neutral handler request.
+type Decoder func(*nethttp.Request) (any, error)
+
+// Encoder writes one transport-neutral handler response.
+type Encoder func(context.Context, nethttp.ResponseWriter, any) error
+
+// NoBody is a Decoder for requests without an application body.
+func NoBody(*nethttp.Request) (any, error) {
+	return nil, nil
+}
+
+// DecodeJSON returns a strict JSON request Decoder for T.
+func DecodeJSON[T any]() Decoder {
+	return func(request *nethttp.Request) (any, error) {
+		var value T
+		decoder := json.NewDecoder(request.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&value); err != nil {
+			return nil, err
+		}
+		if err := ensureJSONEOF(decoder); err != nil {
+			return nil, err
+		}
+		return value, nil
+	}
+}
+
+// ProtoDecodeOption configures Protobuf HTTP binding.
+type ProtoDecodeOption interface {
+	applyProtoDecode(*protoDecodeOptions) error
+}
+
+type protoDecodeOptionFunc func(*protoDecodeOptions) error
+
+func (function protoDecodeOptionFunc) applyProtoDecode(
+	options *protoDecodeOptions,
+) error {
+	return function(options)
+}
+
+type protoDecodeOptions struct {
+	bodyField         string
+	allowUnknownQuery bool
+	queryDisabled     bool
+	pathBindings      []protoPathBinding
+	pathTemplate      string
+}
+
+// WithProtoBody decodes a strict protojson body before path/query overlays.
+func WithProtoBody() ProtoDecodeOption {
+	return protoDecodeOptionFunc(func(options *protoDecodeOptions) error {
+		options.bodyField = "*"
+		return nil
+	})
+}
+
+// WithProtoBodyField decodes the JSON body into one Protobuf field path.
+func WithProtoBodyField(fieldPath string) ProtoDecodeOption {
+	return protoDecodeOptionFunc(func(options *protoDecodeOptions) error {
+		if !validProtoFieldPath(fieldPath) || fieldPath == "*" {
+			return fmt.Errorf("http: invalid proto body field %q", fieldPath)
+		}
+		options.bodyField = fieldPath
+		return nil
+	})
+}
+
+// WithUnknownProtoQuery allows query keys absent from the input message.
+func WithUnknownProtoQuery() ProtoDecodeOption {
+	return protoDecodeOptionFunc(func(options *protoDecodeOptions) error {
+		options.allowUnknownQuery = true
+		return nil
+	})
+}
+
+// WithProtoQueryDisabled rejects every non-empty URL query. Generated
+// google.api.http adapters use it with body:"*", where all non-path request
+// fields belong to the JSON body.
+func WithProtoQueryDisabled() ProtoDecodeOption {
+	return protoDecodeOptionFunc(func(options *protoDecodeOptions) error {
+		options.queryDisabled = true
+		return nil
+	})
+}
+
+// WithProtoPathField binds one Protobuf scalar field path from a router path
+// value name. Generated adapters use an internal-safe value name for nested
+// google.api.http fields.
+func WithProtoPathField(fieldPath string, valueName string) ProtoDecodeOption {
+	return protoDecodeOptionFunc(func(options *protoDecodeOptions) error {
+		if !validProtoFieldPath(fieldPath) ||
+			!validProtoPathValueName(valueName) {
+			return fmt.Errorf(
+				"http: invalid proto path binding %q=%q",
+				fieldPath,
+				valueName,
+			)
+		}
+		if len(options.pathBindings) >= maximumProtoFieldPathSegments {
+			return fmt.Errorf("http: too many proto path bindings")
+		}
+		options.pathBindings = append(options.pathBindings, protoPathBinding{
+			fieldPath: fieldPath,
+			valueName: valueName,
+		})
+		return nil
+	})
+}
+
+// WithProtoPathTemplate binds every google.api.http path variable from the
+// request's original escaped path. It supports assigned resource-name
+// patterns and preserves encoded slashes captured by a terminal "**".
+func WithProtoPathTemplate(pathTemplate string) ProtoDecodeOption {
+	return protoDecodeOptionFunc(func(options *protoDecodeOptions) error {
+		if err := validateProtoPathTemplate(pathTemplate); err != nil {
+			return err
+		}
+		options.pathTemplate = pathTemplate
+		return nil
+	})
+}
+
+// DecodeProto binds protojson body, path values, and query parameters to one
+// Protobuf request. Path/query values overlay body values.
+func DecodeProto[T proto.Message](
+	factory func() T,
+	optionList ...ProtoDecodeOption,
+) Decoder {
+	return func(request *nethttp.Request) (any, error) {
+		if request == nil || factory == nil {
+			return nil, fmt.Errorf("http: proto request or factory is nil")
+		}
+		options := protoDecodeOptions{}
+		for index, option := range optionList {
+			if option == nil {
+				return nil, fmt.Errorf("http: proto decode option %d is nil", index)
+			}
+			if err := option.applyProtoDecode(&options); err != nil {
+				return nil, fmt.Errorf(
+					"http: proto decode option %d: %w",
+					index,
+					err,
+				)
+			}
+		}
+		if options.pathTemplate != "" && len(options.pathBindings) > 0 {
+			return nil, fmt.Errorf(
+				"http: proto path template and field bindings conflict",
+			)
+		}
+		message := factory()
+		if isNilProto(message) {
+			return nil, fmt.Errorf("http: proto factory returned nil")
+		}
+		reflection := message.ProtoReflect()
+		var bodyPath []protoreflect.FieldDescriptor
+		if options.bodyField != "" {
+			payload, err := io.ReadAll(request.Body)
+			if err != nil {
+				return nil, err
+			}
+			rawHTTPBody := false
+			if options.bodyField != "*" {
+				bodyPath, err = resolveProtoFieldPath(
+					reflection,
+					options.bodyField,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if protoFieldPathUsesHTTPBody(bodyPath) {
+					rawHTTPBody = true
+				} else {
+					payload, err = wrapProtoBodyField(payload, bodyPath)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else if isProtoHTTPBodyDescriptor(reflection.Descriptor()) {
+				rawHTTPBody = true
+			}
+			if rawHTTPBody {
+				if err := UnmarshalProtoHTTPBody(
+					payload,
+					message,
+					strings.TrimPrefix(options.bodyField, "*"),
+					request.Header.Get("Content-Type"),
+				); err != nil {
+					return nil, err
+				}
+			} else if len(bytes.TrimSpace(payload)) > 0 {
+				if err := (protojson.UnmarshalOptions{
+					DiscardUnknown: false,
+				}).Unmarshal(payload, message); err != nil {
+					return nil, err
+				}
+			}
+		}
+		var pathFields [][]protoreflect.FieldDescriptor
+		var pathErr error
+		if options.pathTemplate != "" {
+			pathFields, pathErr = bindProtoPathTemplate(
+				request,
+				reflection,
+				options.pathTemplate,
+			)
+		} else {
+			pathFields, pathErr = bindPathValues(
+				request,
+				reflection,
+				options.pathBindings,
+			)
+		}
+		if pathErr != nil {
+			return nil, pathErr
+		}
+		if len(bodyPath) > 0 {
+			for _, pathField := range pathFields {
+				if protoFieldPathsOverlap(pathField, bodyPath) {
+					return nil, fmt.Errorf(
+						"http: proto body field %q overlaps request path field %q",
+						options.bodyField,
+						pathField[len(pathField)-1].Name(),
+					)
+				}
+			}
+		}
+		if options.queryDisabled && request.URL.RawQuery != "" {
+			return nil, fmt.Errorf("http: proto query is disabled for this route")
+		}
+		query, err := url.ParseQuery(request.URL.RawQuery)
+		if err != nil {
+			return nil, fmt.Errorf("http: invalid query: %w", err)
+		}
+		if err := bindQuery(
+			reflection,
+			query,
+			options.allowUnknownQuery,
+			bodyPath,
+			pathFields,
+		); err != nil {
+			return nil, err
+		}
+		return message, nil
+	}
+}
+
+// EncodeJSON serializes response as application/json.
+func EncodeJSON(
+	_ context.Context,
+	writer nethttp.ResponseWriter,
+	response any,
+) error {
+	writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	return json.NewEncoder(writer).Encode(response)
+}
+
+// EncodeProto serializes a Protobuf response with canonical protojson names.
+func EncodeProto(
+	_ context.Context,
+	writer nethttp.ResponseWriter,
+	response any,
+) error {
+	payload, err := MarshalProtoResponseBody(response, "")
+	if err != nil {
+		return err
+	}
+	writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	payload = append(payload, '\n')
+	_, err = writer.Write(payload)
+	return err
+}
+
+// EncodeProtoResponseBody returns an Encoder that projects one
+// google.api.HttpRule.response_body field path.
+func EncodeProtoResponseBody(responseBody string) Encoder {
+	return func(
+		_ context.Context,
+		writer nethttp.ResponseWriter,
+		response any,
+	) error {
+		payload, err := MarshalProtoResponseBody(response, responseBody)
+		if err != nil {
+			return err
+		}
+		writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+		payload = append(payload, '\n')
+		_, err = writer.Write(payload)
+		return err
+	}
+}
+
+// EncodeProtoHTTPBody returns an Encoder that writes google.api.HttpBody data
+// as the raw HTTP entity rather than ProtoJSON. responseBody may select one
+// nested singular HttpBody field.
+func EncodeProtoHTTPBody(responseBody string) Encoder {
+	return func(
+		_ context.Context,
+		writer nethttp.ResponseWriter,
+		response any,
+	) error {
+		contentType, payload, err := MarshalProtoHTTPBody(response, responseBody)
+		if err != nil {
+			return err
+		}
+		writer.Header().Set("Content-Type", contentType)
+		_, err = writer.Write(payload)
+		return err
+	}
+}
+
+// EncodeText serializes string or byte responses as text/plain.
+func EncodeText(
+	_ context.Context,
+	writer nethttp.ResponseWriter,
+	response any,
+) error {
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	switch value := response.(type) {
+	case string:
+		_, err := io.WriteString(writer, value)
+		return err
+	case []byte:
+		_, err := writer.Write(value)
+		return err
+	default:
+		_, err := fmt.Fprint(writer, value)
+		return err
+	}
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	err := decoder.Decode(&extra)
+	if err == io.EOF {
+		return nil
+	}
+	if err == nil {
+		return fmt.Errorf("http: request contains multiple JSON values")
+	}
+	return err
+}
+
+func bindPathValues(
+	request *nethttp.Request,
+	message protoreflect.Message,
+	bindings []protoPathBinding,
+) ([][]protoreflect.FieldDescriptor, error) {
+	if len(bindings) > 0 {
+		return bindDeclaredPathValues(request, message, bindings)
+	}
+	result := make([][]protoreflect.FieldDescriptor, 0)
+	fields := message.Descriptor().Fields()
+	for index := range fields.Len() {
+		field := fields.Get(index)
+		value := request.PathValue(string(field.Name()))
+		if value == "" && field.JSONName() != string(field.Name()) {
+			value = request.PathValue(field.JSONName())
+		}
+		if value == "" {
+			continue
+		}
+		if field.IsList() || field.IsMap() {
+			return nil, fmt.Errorf(
+				"http: path field %q must be scalar",
+				field.Name(),
+			)
+		}
+		parsed, err := parseProtoScalar(message, field, value)
+		if err != nil {
+			return nil, fmt.Errorf("http: path field %q: %w", field.Name(), err)
+		}
+		if err := setProtoBoundField(message, field, parsed, "path"); err != nil {
+			return nil, fmt.Errorf("http: path field %q: %w", field.Name(), err)
+		}
+		result = append(result, []protoreflect.FieldDescriptor{field})
+	}
+	return result, nil
+}
+
+func bindDeclaredPathValues(
+	request *nethttp.Request,
+	message protoreflect.Message,
+	bindings []protoPathBinding,
+) ([][]protoreflect.FieldDescriptor, error) {
+	result := make([][]protoreflect.FieldDescriptor, 0, len(bindings))
+	seenFields := make(map[string]struct{}, len(bindings))
+	seenValues := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		path, err := resolveProtoPathField(message, binding.fieldPath)
+		if err != nil {
+			return nil, err
+		}
+		fieldKey := protoFieldPathKey(path)
+		if _, duplicate := seenFields[fieldKey]; duplicate {
+			return nil, fmt.Errorf(
+				"http: duplicate proto path field %q",
+				binding.fieldPath,
+			)
+		}
+		if _, duplicate := seenValues[binding.valueName]; duplicate {
+			return nil, fmt.Errorf(
+				"http: duplicate router path value %q",
+				binding.valueName,
+			)
+		}
+		seenFields[fieldKey] = struct{}{}
+		seenValues[binding.valueName] = struct{}{}
+		value := request.PathValue(binding.valueName)
+		if value == "" {
+			continue
+		}
+		field := path[len(path)-1]
+		parent, _ := protoPathParent(message, path, true)
+		parsed, err := parseProtoScalar(parent, field, value)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"http: path field %q: %w",
+				binding.fieldPath,
+				err,
+			)
+		}
+		if err := setProtoBoundField(parent, field, parsed, "path"); err != nil {
+			return nil, fmt.Errorf(
+				"http: path field %q: %w",
+				binding.fieldPath,
+				err,
+			)
+		}
+		result = append(result, path)
+	}
+	return result, nil
+}
+
+func bindQuery(
+	message protoreflect.Message,
+	query url.Values,
+	allowUnknown bool,
+	bodyPath []protoreflect.FieldDescriptor,
+	pathFields [][]protoreflect.FieldDescriptor,
+) error {
+	if len(query) > maxProtoQueryValues {
+		return fmt.Errorf(
+			"http: query exceeds maximum field count %d",
+			maxProtoQueryValues,
+		)
+	}
+	keys := make([]string, 0, len(query))
+	for key := range query {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	valueCount := 0
+	for _, key := range keys {
+		values := query[key]
+		valueCount += len(values)
+		if valueCount > maxProtoQueryValues {
+			return fmt.Errorf(
+				"http: query exceeds maximum value count %d",
+				maxProtoQueryValues,
+			)
+		}
+		fieldPath, known, err := resolveProtoQueryPath(
+			message.Descriptor(),
+			key,
+		)
+		if err != nil {
+			if protoFieldPathsOverlap(fieldPath, bodyPath) {
+				return fmt.Errorf(
+					"http: query field %q is already bound by the request body",
+					key,
+				)
+			}
+			return err
+		}
+		if !known {
+			if allowUnknown {
+				continue
+			}
+			return fmt.Errorf("http: unknown query field %q", key)
+		}
+		if protoFieldPathsOverlap(fieldPath, bodyPath) {
+			return fmt.Errorf(
+				"http: query field %q is already bound by the request body",
+				key,
+			)
+		}
+		for _, pathField := range pathFields {
+			if sameProtoFieldPath(fieldPath, pathField) {
+				return fmt.Errorf(
+					"http: query field %q is already bound by the request path",
+					key,
+				)
+			}
+		}
+		parent := mutableProtoQueryParent(message, fieldPath)
+		field := fieldPath[len(fieldPath)-1]
+		if field.IsList() {
+			list := parent.Mutable(field).List()
+			list.Truncate(0)
+			for _, raw := range values {
+				parsed, err := parseProtoScalar(parent, field, raw)
+				if err != nil {
+					return fmt.Errorf("http: query field %q: %w", key, err)
+				}
+				list.Append(parsed)
+			}
+			continue
+		}
+		if len(values) != 1 {
+			return fmt.Errorf("http: query field %q occurs multiple times", key)
+		}
+		parsed, err := parseProtoScalar(parent, field, values[0])
+		if err != nil {
+			return fmt.Errorf("http: query field %q: %w", key, err)
+		}
+		if err := setProtoBoundField(parent, field, parsed, "query"); err != nil {
+			return fmt.Errorf("http: query field %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func parseProtoScalar(
+	parent protoreflect.Message,
+	field protoreflect.FieldDescriptor,
+	raw string,
+) (protoreflect.Value, error) {
+	if field.Message() != nil {
+		kind := protowkt.QueryKindFor(string(field.Message().FullName()))
+		if kind == protowkt.QueryUnsupported {
+			return protoreflect.Value{}, fmt.Errorf(
+				"field kind %s is unsupported",
+				field.Kind(),
+			)
+		}
+		payload, err := protowkt.QueryToJSON(kind, raw)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+		if parent == nil || !parent.IsValid() {
+			return protoreflect.Value{}, fmt.Errorf("message parent is invalid")
+		}
+		message := parent.NewField(field).Message()
+		if err := (protojson.UnmarshalOptions{
+			DiscardUnknown: false,
+		}).Unmarshal(payload, message.Interface()); err != nil {
+			return protoreflect.Value{}, err
+		}
+		return protoreflect.ValueOfMessage(message), nil
+	}
+	switch field.Kind() {
+	case protoreflect.BoolKind:
+		value, err := strconv.ParseBool(raw)
+		return protoreflect.ValueOfBool(value), err
+	case protoreflect.EnumKind:
+		if value := field.Enum().Values().ByName(protoreflect.Name(raw)); value != nil {
+			return protoreflect.ValueOfEnum(value.Number()), nil
+		}
+		number, err := strconv.ParseInt(raw, 10, 32)
+		return protoreflect.ValueOfEnum(protoreflect.EnumNumber(number)), err
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind,
+		protoreflect.Sfixed32Kind:
+		value, err := strconv.ParseInt(raw, 10, 32)
+		return protoreflect.ValueOfInt32(int32(value)), err
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind,
+		protoreflect.Sfixed64Kind:
+		value, err := strconv.ParseInt(raw, 10, 64)
+		return protoreflect.ValueOfInt64(value), err
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		value, err := strconv.ParseUint(raw, 10, 32)
+		return protoreflect.ValueOfUint32(uint32(value)), err
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		value, err := strconv.ParseUint(raw, 10, 64)
+		return protoreflect.ValueOfUint64(value), err
+	case protoreflect.FloatKind:
+		value, err := strconv.ParseFloat(raw, 32)
+		return protoreflect.ValueOfFloat32(float32(value)), err
+	case protoreflect.DoubleKind:
+		value, err := strconv.ParseFloat(raw, 64)
+		return protoreflect.ValueOfFloat64(value), err
+	case protoreflect.StringKind:
+		return protoreflect.ValueOfString(raw), nil
+	case protoreflect.BytesKind:
+		value, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			value, err = base64.RawStdEncoding.DecodeString(raw)
+		}
+		return protoreflect.ValueOfBytes(value), err
+	default:
+		return protoreflect.Value{}, fmt.Errorf(
+			"field kind %s is unsupported",
+			field.Kind(),
+		)
+	}
+}
+
+func isNilProto(message proto.Message) bool {
+	if message == nil {
+		return true
+	}
+	reflection := message.ProtoReflect()
+	return !reflection.IsValid()
+}

--- a/transport/http/continuation/client.go
+++ b/transport/http/continuation/client.go
@@ -1,0 +1,623 @@
+// Package continuationhttp implements the continuation v1 HTTP profile.
+package continuationhttp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strconv"
+	"time"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/programmable/continuation"
+	transporthttp "github.com/keelab/keelith/transport/http"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	continuationReconnectDelay     = 10 * time.Millisecond
+	continuationClientCloseTimeout = 250 * time.Millisecond
+)
+
+var (
+	// ErrInvalidContinuationProtocol reports an inconsistent or unsupported
+	// continuation response.
+	ErrInvalidContinuationProtocol = errors.New(
+		"http transport: invalid continuation protocol",
+	)
+	// ErrContinuationTerminal reports a durable terminal state that is not a
+	// successful completion.
+	ErrContinuationTerminal = errors.New(
+		"http transport: continuation did not complete successfully",
+	)
+)
+
+// ContinuationClient is the complete outbound client for the versioned
+// continuation HTTP profile.
+type ContinuationClient struct {
+	client    *transporthttp.Client
+	baseURL   string
+	start     operation.Operation
+	attach    operation.Operation
+	signal    operation.Operation
+	cancel    operation.Operation
+	eventSize int
+}
+
+// ContinuationClientStream validates one Attach SSE connection.
+type ContinuationClientStream struct {
+	stream    *transporthttp.SSEClientStream[*continuationv1.AttachResponse]
+	callID    string
+	operation string
+	after     uint64
+}
+
+// NewContinuationClient constructs a profile client on an existing Keelith
+// HTTP Client so outbound middleware, metadata, discovery, and TLS are reused.
+func NewContinuationClient(
+	client *transporthttp.Client,
+	baseURL string,
+) (*ContinuationClient, error) {
+	if client == nil {
+		return nil, fmt.Errorf(
+			"%w: continuation client is nil",
+			transporthttp.ErrInvalidCall,
+		)
+	}
+	normalized, err := transporthttp.NormalizeClientBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	start, err := newContinuationHTTPOperation("Start", operation.KindUnary)
+	if err != nil {
+		return nil, err
+	}
+	attach, err := newContinuationHTTPOperation(
+		"Attach",
+		operation.KindServerStream,
+	)
+	if err != nil {
+		return nil, err
+	}
+	signal, err := newContinuationHTTPOperation("Signal", operation.KindUnary)
+	if err != nil {
+		return nil, err
+	}
+	cancel, err := newContinuationHTTPOperation("Cancel", operation.KindUnary)
+	if err != nil {
+		return nil, err
+	}
+	return &ContinuationClient{
+		client:    client,
+		baseURL:   normalized,
+		start:     start,
+		attach:    attach,
+		signal:    signal,
+		cancel:    cancel,
+		eventSize: defaultContinuationEventBytes,
+	}, nil
+}
+
+// Start creates one durable call and returns either an accepted or inline
+// terminal response.
+func (client *ContinuationClient) Start(
+	ctx context.Context,
+	callID continuation.CallID,
+	target continuation.Operation,
+	input []byte,
+) (*continuationv1.StartResponse, error) {
+	if err := client.validateCall(ctx, callID, target); err != nil {
+		return nil, err
+	}
+	if len(input) > maxContinuationPayloadBytes {
+		return nil, transporthttp.ErrRequestTooLarge
+	}
+	message := &continuationv1.StartRequest{
+		CallId:    callID.String(),
+		Operation: target.String(),
+		Input:     append([]byte(nil), input...),
+	}
+	request, err := transporthttp.NewProtoRequest(
+		ctx,
+		client.baseURL,
+		nethttp.MethodPost,
+		ContinuationRoutePrefix,
+		message,
+		"*",
+	)
+	if err != nil {
+		return nil, err
+	}
+	response, err := transporthttp.InvokeProto(
+		ctx,
+		client.client,
+		client.start,
+		request,
+		func() *continuationv1.StartResponse {
+			return &continuationv1.StartResponse{}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateContinuationStartResponse(
+		response,
+		callID.String(),
+		target.String(),
+	); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Attach opens one validated SSE connection after an exclusive sequence.
+func (client *ContinuationClient) Attach(
+	ctx context.Context,
+	callID continuation.CallID,
+	after uint64,
+) (*ContinuationClientStream, error) {
+	if client == nil || ctx == nil ||
+		!validContinuationHTTPIdentity(
+			callID.String(),
+			maxContinuationCallIDBytes,
+		) {
+		return nil, fmt.Errorf(
+			"%w: invalid continuation Attach request",
+			transporthttp.ErrInvalidCall,
+		)
+	}
+	request, err := nethttp.NewRequestWithContext(
+		ctx,
+		nethttp.MethodGet,
+		client.baseURL+ContinuationRoutePrefix+"/"+
+			callID.String()+"/events",
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build Attach request: %w", transporthttp.ErrInvalidCall, err)
+	}
+	request.Header.Set("Accept", "text/event-stream")
+	options := []transporthttp.SSEClientOption{
+		transporthttp.WithSSEClientMaxEventBytes(client.eventSize),
+	}
+	if after > 0 {
+		options = append(
+			options,
+			transporthttp.WithSSELastEventID(strconv.FormatUint(after, 10)),
+		)
+	}
+	stream, err := transporthttp.OpenProtoSSE(
+		ctx,
+		client.client,
+		client.attach,
+		request,
+		func() *continuationv1.AttachResponse {
+			return &continuationv1.AttachResponse{}
+		},
+		options...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &ContinuationClientStream{
+		stream: stream,
+		callID: callID.String(),
+		after:  after,
+	}, nil
+}
+
+// Signal submits one idempotent external signal.
+func (client *ContinuationClient) Signal(
+	ctx context.Context,
+	callID continuation.CallID,
+	commandID string,
+	payload []byte,
+) (*continuationv1.SignalResponse, error) {
+	if client == nil || ctx == nil ||
+		!validContinuationHTTPIdentity(
+			callID.String(),
+			maxContinuationCallIDBytes,
+		) ||
+		!validContinuationHTTPIdentity(
+			commandID,
+			maxContinuationCommandBytes,
+		) {
+		return nil, fmt.Errorf(
+			"%w: invalid continuation Signal request",
+			transporthttp.ErrInvalidCall,
+		)
+	}
+	if len(payload) > maxContinuationPayloadBytes {
+		return nil, transporthttp.ErrRequestTooLarge
+	}
+	message := &continuationv1.SignalRequest{
+		CallId:    callID.String(),
+		CommandId: commandID,
+		Payload:   append([]byte(nil), payload...),
+	}
+	request, err := transporthttp.NewProtoRequest(
+		ctx,
+		client.baseURL,
+		nethttp.MethodPost,
+		continuationSignalPattern,
+		message,
+		"*",
+	)
+	if err != nil {
+		return nil, err
+	}
+	response, err := transporthttp.InvokeProto(
+		ctx,
+		client.client,
+		client.signal,
+		request,
+		func() *continuationv1.SignalResponse {
+			return &continuationv1.SignalResponse{}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateContinuationCommandSnapshot(
+		response.GetSnapshot(),
+		callID.String(),
+	); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Cancel submits one idempotent cooperative cancellation request.
+func (client *ContinuationClient) Cancel(
+	ctx context.Context,
+	callID continuation.CallID,
+	commandID string,
+) (*continuationv1.CancelResponse, error) {
+	if client == nil || ctx == nil ||
+		!validContinuationHTTPIdentity(
+			callID.String(),
+			maxContinuationCallIDBytes,
+		) ||
+		!validContinuationHTTPIdentity(
+			commandID,
+			maxContinuationCommandBytes,
+		) {
+		return nil, fmt.Errorf(
+			"%w: invalid continuation Cancel request",
+			transporthttp.ErrInvalidCall,
+		)
+	}
+	payload, err := protojson.Marshal(&continuationv1.CancelRequest{
+		CallId:    callID.String(),
+		CommandId: commandID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode Cancel request: %w", transporthttp.ErrInvalidCall, err)
+	}
+	request, err := nethttp.NewRequestWithContext(
+		ctx,
+		nethttp.MethodDelete,
+		client.baseURL+ContinuationRoutePrefix+"/"+callID.String(),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build Cancel request: %w", transporthttp.ErrInvalidCall, err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := transporthttp.InvokeProto(
+		ctx,
+		client.client,
+		client.cancel,
+		request,
+		func() *continuationv1.CancelResponse {
+			return &continuationv1.CancelResponse{}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateContinuationCommandSnapshot(
+		response.GetSnapshot(),
+		callID.String(),
+	); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Call starts a fixed durable operation, reconnects Attach after validated
+// frames, and returns the successful terminal payload.
+func (client *ContinuationClient) Call(
+	ctx context.Context,
+	callID continuation.CallID,
+	target continuation.Operation,
+	input []byte,
+) ([]byte, error) {
+	response, err := client.Start(ctx, callID, target, input)
+	if err != nil {
+		return nil, err
+	}
+	if response.GetSnapshot().GetTerminal() {
+		return continuationCompletedPayload(
+			response.GetSnapshot(),
+			response.GetTerminalFrame(),
+		)
+	}
+
+	after := response.GetSnapshot().GetSequence()
+	for {
+		stream, attachErr := client.Attach(ctx, callID, after)
+		if attachErr != nil {
+			return nil, attachErr
+		}
+		for {
+			response, receiveErr := stream.Recv()
+			if receiveErr != nil {
+				closeContinuationClientStream(stream)
+				if !errors.Is(receiveErr, io.EOF) {
+					return nil, receiveErr
+				}
+				break
+			}
+			page := response.GetPage()
+			frame := page.GetFrames()[0]
+			if page.GetSnapshot().GetOperation() != target.String() {
+				closeContinuationClientStream(stream)
+				return nil, fmt.Errorf(
+					"%w: Attach operation changed",
+					ErrInvalidContinuationProtocol,
+				)
+			}
+			after = frame.GetSequence()
+			if page.GetSnapshot().GetTerminal() &&
+				after == page.GetSnapshot().GetSequence() {
+				closeContinuationClientStream(stream)
+				return continuationCompletedPayload(
+					page.GetSnapshot(),
+					frame,
+				)
+			}
+		}
+		timer := time.NewTimer(continuationReconnectDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, context.Cause(ctx)
+		case <-timer.C:
+		}
+	}
+}
+
+// Recv returns the next strictly contiguous, profile-valid Attach page.
+func (stream *ContinuationClientStream) Recv() (*continuationv1.AttachResponse, error) {
+	if stream == nil || stream.stream == nil {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	message, err := stream.stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	response := message.Value()
+	page := response.GetPage()
+	if page == nil || len(page.GetFrames()) != 1 {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	frame := page.GetFrames()[0]
+	if message.Name() != continuationEvent ||
+		frame == nil ||
+		frame.GetSequence() != stream.after+1 ||
+		message.ID() != strconv.FormatUint(frame.GetSequence(), 10) ||
+		frame.GetKind() == continuationv1.FrameKind_FRAME_KIND_UNSPECIFIED ||
+		len(frame.GetPayload()) > maxContinuationPayloadBytes ||
+		page.GetNextSequence() != frame.GetSequence()+1 {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	snapshot := page.GetSnapshot()
+	operationName, err := validateContinuationSnapshot(
+		snapshot,
+		stream.callID,
+	)
+	if err != nil ||
+		snapshot.GetSequence() < frame.GetSequence() ||
+		page.GetFrameFloor() != snapshot.GetFrameFloor() ||
+		page.GetTerminal() != snapshot.GetTerminal() {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	if stream.operation == "" {
+		stream.operation = operationName
+	} else if stream.operation != operationName {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	if frame.GetSequence() == snapshot.GetSequence() &&
+		snapshot.GetTerminal() &&
+		!continuationTerminalFrameMatches(snapshot, frame) {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	if !snapshot.GetTerminal() && continuationFrameKindTerminal(frame.GetKind()) {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	stream.after = frame.GetSequence()
+	return response, nil
+}
+
+// Close closes the current Attach connection.
+func (stream *ContinuationClientStream) Close(ctx context.Context) error {
+	if stream == nil || stream.stream == nil {
+		return nil
+	}
+	return stream.stream.Close(ctx)
+}
+
+func (client *ContinuationClient) validateCall(
+	ctx context.Context,
+	callID continuation.CallID,
+	target continuation.Operation,
+) error {
+	if client == nil || ctx == nil ||
+		!validContinuationHTTPIdentity(
+			callID.String(),
+			maxContinuationCallIDBytes,
+		) ||
+		len(target.String()) > maxContinuationOperationBytes {
+		return fmt.Errorf(
+			"%w: invalid continuation call",
+			transporthttp.ErrInvalidCall,
+		)
+	}
+	if _, err := continuation.NewOperation(target.String()); err != nil {
+		return fmt.Errorf("%w: invalid continuation operation", transporthttp.ErrInvalidCall)
+	}
+	return nil
+}
+
+func validateContinuationStartResponse(
+	response *continuationv1.StartResponse,
+	callID string,
+	operationName string,
+) error {
+	if response == nil {
+		return ErrInvalidContinuationProtocol
+	}
+	gotOperation, err := validateContinuationSnapshot(
+		response.GetSnapshot(),
+		callID,
+	)
+	if err != nil || gotOperation != operationName {
+		return ErrInvalidContinuationProtocol
+	}
+	frame := response.GetTerminalFrame()
+	if response.GetSnapshot().GetTerminal() {
+		if !continuationTerminalFrameMatches(response.GetSnapshot(), frame) {
+			return ErrInvalidContinuationProtocol
+		}
+	} else if frame != nil {
+		return ErrInvalidContinuationProtocol
+	}
+	return nil
+}
+
+func validateContinuationCommandSnapshot(
+	snapshot *continuationv1.Snapshot,
+	callID string,
+) error {
+	_, err := validateContinuationSnapshot(snapshot, callID)
+	return err
+}
+
+func validateContinuationSnapshot(
+	snapshot *continuationv1.Snapshot,
+	callID string,
+) (string, error) {
+	if snapshot == nil ||
+		snapshot.GetCallId() != callID ||
+		snapshot.GetRevision() == 0 ||
+		snapshot.GetSequence() == 0 ||
+		snapshot.GetFrameFloor() == 0 ||
+		snapshot.GetFrameFloor() > snapshot.GetSequence()+1 {
+		return "", ErrInvalidContinuationProtocol
+	}
+	if _, err := continuation.NewCallID(snapshot.GetCallId()); err != nil {
+		return "", ErrInvalidContinuationProtocol
+	}
+	target, err := continuation.NewOperation(snapshot.GetOperation())
+	if err != nil {
+		return "", ErrInvalidContinuationProtocol
+	}
+	terminal, valid := continuationStatusTerminal(snapshot.GetStatus())
+	if !valid || terminal != snapshot.GetTerminal() {
+		return "", ErrInvalidContinuationProtocol
+	}
+	return target.String(), nil
+}
+
+func continuationStatusTerminal(
+	status continuationv1.CallStatus,
+) (bool, bool) {
+	switch status {
+	case continuationv1.CallStatus_CALL_STATUS_ACCEPTED,
+		continuationv1.CallStatus_CALL_STATUS_RUNNING,
+		continuationv1.CallStatus_CALL_STATUS_WAITING,
+		continuationv1.CallStatus_CALL_STATUS_SUSPENDED,
+		continuationv1.CallStatus_CALL_STATUS_CANCEL_REQUESTED:
+		return false, true
+	case continuationv1.CallStatus_CALL_STATUS_COMPLETED,
+		continuationv1.CallStatus_CALL_STATUS_FAILED,
+		continuationv1.CallStatus_CALL_STATUS_CANCELED,
+		continuationv1.CallStatus_CALL_STATUS_EXPIRED:
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+func continuationTerminalFrameMatches(
+	snapshot *continuationv1.Snapshot,
+	frame *continuationv1.Frame,
+) bool {
+	if snapshot == nil ||
+		frame == nil ||
+		frame.GetSequence() != snapshot.GetSequence() ||
+		len(frame.GetPayload()) > maxContinuationPayloadBytes {
+		return false
+	}
+	switch snapshot.GetStatus() {
+	case continuationv1.CallStatus_CALL_STATUS_COMPLETED:
+		return frame.GetKind() ==
+			continuationv1.FrameKind_FRAME_KIND_COMPLETED
+	case continuationv1.CallStatus_CALL_STATUS_FAILED:
+		return frame.GetKind() ==
+			continuationv1.FrameKind_FRAME_KIND_FAILED
+	case continuationv1.CallStatus_CALL_STATUS_CANCELED:
+		return frame.GetKind() ==
+			continuationv1.FrameKind_FRAME_KIND_CANCELED
+	case continuationv1.CallStatus_CALL_STATUS_EXPIRED:
+		return frame.GetKind() ==
+			continuationv1.FrameKind_FRAME_KIND_EXPIRED
+	default:
+		return false
+	}
+}
+
+func continuationFrameKindTerminal(kind continuationv1.FrameKind) bool {
+	switch kind {
+	case continuationv1.FrameKind_FRAME_KIND_COMPLETED,
+		continuationv1.FrameKind_FRAME_KIND_FAILED,
+		continuationv1.FrameKind_FRAME_KIND_CANCELED,
+		continuationv1.FrameKind_FRAME_KIND_EXPIRED:
+		return true
+	default:
+		return false
+	}
+}
+
+func continuationCompletedPayload(
+	snapshot *continuationv1.Snapshot,
+	frame *continuationv1.Frame,
+) ([]byte, error) {
+	if !continuationTerminalFrameMatches(snapshot, frame) {
+		return nil, ErrInvalidContinuationProtocol
+	}
+	if snapshot.GetStatus() !=
+		continuationv1.CallStatus_CALL_STATUS_COMPLETED {
+		return nil, fmt.Errorf(
+			"%w: status %s",
+			ErrContinuationTerminal,
+			snapshot.GetStatus().String(),
+		)
+	}
+	return append([]byte(nil), frame.GetPayload()...), nil
+}
+
+func closeContinuationClientStream(stream *ContinuationClientStream) {
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		continuationClientCloseTimeout,
+	)
+	defer cancel()
+	_ = stream.Close(ctx)
+}

--- a/transport/http/continuation/continuation.go
+++ b/transport/http/continuation/continuation.go
@@ -1,0 +1,1253 @@
+package continuationhttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	continuationv1 "github.com/keelab/keelith/api/continuation/v1"
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+	"github.com/keelab/keelith/programmable/continuation"
+	"github.com/keelab/keelith/security/authz"
+	transporthttp "github.com/keelab/keelith/transport/http"
+	ksse "github.com/keelab/keelith/transport/sse"
+)
+
+const (
+	// ContinuationProtocolVersion is the stable wire version emitted and
+	// required by the continuation HTTP profile.
+	ContinuationProtocolVersion = "v1"
+	// ContinuationRoutePrefix is the versioned root for continuation calls.
+	ContinuationRoutePrefix = "/keelith.continuation.v1/continuations"
+
+	continuationAttachPattern = ContinuationRoutePrefix + "/{call_id}/events"
+	continuationSignalPattern = ContinuationRoutePrefix + "/{call_id}:signal"
+	continuationCancelPattern = ContinuationRoutePrefix + "/{call_id}"
+
+	continuationService = "keelith.continuation.v1.ContinuationService"
+	continuationEvent   = "continuation.frame.v1"
+
+	defaultContinuationPollInterval = 250 * time.Millisecond
+	defaultContinuationPageSize     = 100
+	defaultContinuationEventBytes   = ksse.MaximumEventBytes
+	defaultContinuationInlineBudget = 50 * time.Millisecond
+	defaultContinuationInlineSteps  = 64
+
+	maxContinuationPageSize       = 1000
+	maxContinuationCallIDBytes    = 256
+	maxContinuationCommandBytes   = 256
+	maxContinuationOperationBytes = 512
+	maxContinuationWorkflowBytes  = 256
+	maxContinuationPayloadBytes   = 1024 * 1024
+	maxContinuationRequestBytes   = 1536 * 1024
+)
+
+// ContinuationRuntime is the transport-facing durable continuation API.
+//
+// *continuation.Runtime implements this interface directly. An application
+// adapter may synchronously finish StartCall and return a terminal Snapshot;
+// the HTTP start route then responds with 200 instead of 202.
+type ContinuationRuntime interface {
+	StartCall(
+		context.Context,
+		continuation.CallID,
+		continuation.Operation,
+		[]byte,
+	) (continuation.Snapshot, error)
+	Attach(
+		context.Context,
+		continuation.CallID,
+		uint64,
+		int,
+	) (continuation.Attachment, error)
+	SubmitSignal(
+		context.Context,
+		continuation.CallID,
+		string,
+		[]byte,
+	) (continuation.Snapshot, error)
+	RequestCancel(
+		context.Context,
+		continuation.CallID,
+		string,
+	) (continuation.Snapshot, error)
+}
+
+// ContinuationInlineRuntime is the optional synchronous fast path used by the
+// Start route. Implementations must persist the call before executing it and
+// return a non-terminal Snapshot when the budget is exhausted.
+type ContinuationInlineRuntime interface {
+	StartCallInline(
+		context.Context,
+		continuation.CallID,
+		continuation.Operation,
+		[]byte,
+		continuation.InlineBudget,
+	) (continuation.Snapshot, error)
+}
+
+type continuationWorkflowRuntime interface {
+	StartWorkflow(
+		context.Context,
+		continuation.CallID,
+		continuation.Operation,
+		string,
+		[]byte,
+	) (continuation.Snapshot, error)
+}
+
+// ContinuationRouteOption configures continuation route polling and bounds.
+type ContinuationRouteOption interface {
+	applyContinuationRoute(*continuationRouteOptions) error
+}
+
+type continuationRouteOptionFunc func(*continuationRouteOptions) error
+
+func (function continuationRouteOptionFunc) applyContinuationRoute(
+	options *continuationRouteOptions,
+) error {
+	return function(options)
+}
+
+type continuationRouteOptions struct {
+	pollInterval time.Duration
+	pageSize     int
+	eventBytes   int
+	inlineBudget continuation.InlineBudget
+	publicAccess bool
+	authorizer   authz.Authorizer
+	ownerships   continuation.OwnershipStore
+	accessSet    bool
+}
+
+// WithContinuationPublicAccess explicitly keeps the versioned continuation
+// routes unauthenticated.
+func WithContinuationPublicAccess() ContinuationRouteOption {
+	return continuationRouteOptionFunc(func(
+		options *continuationRouteOptions,
+	) error {
+		if options.accessSet {
+			return fmt.Errorf("continuation access policy is duplicated")
+		}
+		options.publicAccess = true
+		options.accessSet = true
+		return nil
+	})
+}
+
+// WithContinuationAuthorizer enables principal-bound CallID ownership and
+// delegates each resource/action decision to authorizer.
+func WithContinuationAuthorizer(
+	authorizer authz.Authorizer,
+	ownerships continuation.OwnershipStore,
+) ContinuationRouteOption {
+	return continuationRouteOptionFunc(func(
+		options *continuationRouteOptions,
+	) error {
+		if options.accessSet || isNilContinuationValue(authorizer) ||
+			isNilContinuationValue(ownerships) {
+			return fmt.Errorf("continuation access policy is invalid")
+		}
+		options.authorizer = authorizer
+		options.ownerships = ownerships
+		options.accessSet = true
+		return nil
+	})
+}
+
+// WithContinuationPollInterval sets the idle Attach polling interval.
+func WithContinuationPollInterval(interval time.Duration) ContinuationRouteOption {
+	return continuationRouteOptionFunc(func(
+		options *continuationRouteOptions,
+	) error {
+		if interval < time.Millisecond || interval > time.Minute {
+			return fmt.Errorf(
+				"continuation poll interval is outside supported bounds",
+			)
+		}
+		options.pollInterval = interval
+		return nil
+	})
+}
+
+// WithContinuationPageSize sets the bounded number of frames loaded per poll.
+func WithContinuationPageSize(size int) ContinuationRouteOption {
+	return continuationRouteOptionFunc(func(
+		options *continuationRouteOptions,
+	) error {
+		if size < 1 || size > maxContinuationPageSize {
+			return fmt.Errorf(
+				"continuation page size is outside supported bounds",
+			)
+		}
+		options.pageSize = size
+		return nil
+	})
+}
+
+// WithContinuationMaxEventBytes sets the fully rendered SSE event budget.
+func WithContinuationMaxEventBytes(maximum int) ContinuationRouteOption {
+	return continuationRouteOptionFunc(func(
+		options *continuationRouteOptions,
+	) error {
+		if maximum < 256 || maximum > ksse.MaximumEventBytes {
+			return fmt.Errorf(
+				"continuation event size is outside supported bounds",
+			)
+		}
+		options.eventBytes = maximum
+		return nil
+	})
+}
+
+// WithContinuationInlineBudget sets the synchronous Start execution budget.
+func WithContinuationInlineBudget(
+	budget continuation.InlineBudget,
+) ContinuationRouteOption {
+	return continuationRouteOptionFunc(func(
+		options *continuationRouteOptions,
+	) error {
+		if budget.Duration < time.Millisecond ||
+			budget.Duration > 5*time.Second ||
+			budget.MaxTransitions < 1 ||
+			budget.MaxTransitions > 10_000 {
+			return fmt.Errorf(
+				"continuation inline budget is outside supported bounds",
+			)
+		}
+		options.inlineBudget = budget
+		return nil
+	})
+}
+
+// RegisterContinuationRoutes installs the versioned start, Attach SSE, Signal,
+// and Cancel endpoints through Router's public registration API.
+func RegisterContinuationRoutes(
+	router *transporthttp.Router,
+	runtime ContinuationRuntime,
+	optionList ...ContinuationRouteOption,
+) error {
+	if router == nil || isNilContinuationRuntime(runtime) {
+		return fmt.Errorf(
+			"%w: continuation router or runtime is nil",
+			transporthttp.ErrInvalidRoute,
+		)
+	}
+	options := continuationRouteOptions{
+		pollInterval: defaultContinuationPollInterval,
+		pageSize:     defaultContinuationPageSize,
+		eventBytes:   defaultContinuationEventBytes,
+		inlineBudget: continuation.InlineBudget{
+			Duration:       defaultContinuationInlineBudget,
+			MaxTransitions: defaultContinuationInlineSteps,
+		},
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return fmt.Errorf(
+				"%w: continuation option %d is nil",
+				transporthttp.ErrInvalidRoute,
+				index,
+			)
+		}
+		if err := option.applyContinuationRoute(&options); err != nil {
+			return fmt.Errorf(
+				"%w: continuation option %d: %w",
+				transporthttp.ErrInvalidRoute,
+				index,
+				err,
+			)
+		}
+	}
+	if !options.accessSet {
+		return fmt.Errorf(
+			"%w: continuation access policy must be explicit",
+			transporthttp.ErrInvalidRoute,
+		)
+	}
+	service, serviceErr := continuation.NewService(
+		continuation.ServiceConfig{
+			Runtime:      runtime,
+			PublicAccess: options.publicAccess,
+			Authorizer:   options.authorizer,
+			Ownerships:   options.ownerships,
+		},
+	)
+	if serviceErr != nil {
+		return fmt.Errorf(
+			"%w: continuation access: %w",
+			transporthttp.ErrInvalidRoute,
+			serviceErr,
+		)
+	}
+	runtime = service
+	sseEncoder, err := transporthttp.NewSSEEncoder(transporthttp.SSEConfig{
+		MaxEventBytes: options.eventBytes,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: continuation SSE: %w", transporthttp.ErrInvalidRoute, err)
+	}
+	streamEncoder := continuationSSEEncoder(sseEncoder)
+
+	startOperation, err := newContinuationHTTPOperation(
+		"Start",
+		operation.KindUnary,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", transporthttp.ErrInvalidRoute, err)
+	}
+	attachOperation, err := newContinuationHTTPOperation(
+		"Attach",
+		operation.KindServerStream,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", transporthttp.ErrInvalidRoute, err)
+	}
+	signalOperation, err := newContinuationHTTPOperation(
+		"Signal",
+		operation.KindUnary,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", transporthttp.ErrInvalidRoute, err)
+	}
+	cancelOperation, err := newContinuationHTTPOperation(
+		"Cancel",
+		operation.KindUnary,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", transporthttp.ErrInvalidRoute, err)
+	}
+
+	if err := router.Handle(
+		nethttp.MethodPost,
+		ContinuationRoutePrefix,
+		startOperation,
+		decodeContinuationStart(),
+		handleContinuationStart(runtime, options.inlineBudget),
+		encodeContinuationStart,
+	); err != nil {
+		return err
+	}
+	if err := router.Handle(
+		nethttp.MethodGet,
+		continuationAttachPattern,
+		attachOperation,
+		decodeContinuationAttach,
+		handleContinuationAttach(runtime, options),
+		streamEncoder,
+		transporthttp.WithStreaming(),
+	); err != nil {
+		return err
+	}
+	if err := router.HandleTemplate(
+		nethttp.MethodPost,
+		continuationSignalPattern,
+		signalOperation,
+		decodeContinuationSignal(),
+		handleContinuationSignal(runtime),
+		transporthttp.EncodeProto,
+	); err != nil {
+		return err
+	}
+	if err := router.Handle(
+		nethttp.MethodDelete,
+		continuationCancelPattern,
+		cancelOperation,
+		decodeContinuationCancel(),
+		handleContinuationCancel(runtime),
+		transporthttp.EncodeProto,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+type continuationStartRequest struct {
+	callID          continuation.CallID
+	operation       continuation.Operation
+	workflowVersion string
+	input           []byte
+}
+
+type continuationCommandRequest struct {
+	callID    continuation.CallID
+	commandID string
+	payload   []byte
+}
+
+type continuationAttachRequest struct {
+	callID continuation.CallID
+	after  uint64
+}
+
+type continuationStartResponse struct {
+	status  int
+	message *continuationv1.StartResponse
+}
+
+type continuationStreamResponse struct {
+	stream transporthttp.ServerSentEvents
+	cancel context.CancelFunc
+}
+
+func decodeContinuationStart() transporthttp.Decoder {
+	decode := boundedContinuationDecoder(transporthttp.DecodeProto(
+		func() *continuationv1.StartRequest {
+			return &continuationv1.StartRequest{}
+		},
+		transporthttp.WithProtoBody(),
+		transporthttp.WithProtoQueryDisabled(),
+	))
+	return func(request *nethttp.Request) (any, error) {
+		decoded, err := decode(request)
+		if err != nil {
+			return nil, err
+		}
+		message, ok := decoded.(*continuationv1.StartRequest)
+		if !ok {
+			return nil, fmt.Errorf("continuation: invalid start request")
+		}
+		if len(message.GetInput()) > maxContinuationPayloadBytes {
+			return nil, transporthttp.ErrRequestTooLarge
+		}
+		callID, err := newContinuationHTTPCallID(message.GetCallId())
+		if err != nil {
+			return nil, err
+		}
+		if len(message.GetOperation()) > maxContinuationOperationBytes {
+			return nil, fmt.Errorf("continuation: operation is too long")
+		}
+		target, err := continuation.NewOperation(message.GetOperation())
+		if err != nil {
+			return nil, fmt.Errorf("continuation: invalid operation")
+		}
+		workflowVersion := message.GetWorkflowVersion()
+		if workflowVersion != "" && !validContinuationHTTPIdentity(
+			workflowVersion,
+			maxContinuationWorkflowBytes,
+		) {
+			return nil, fmt.Errorf("continuation: invalid workflow version")
+		}
+		return continuationStartRequest{
+			callID:          callID,
+			operation:       target,
+			workflowVersion: workflowVersion,
+			input:           append([]byte(nil), message.GetInput()...),
+		}, nil
+	}
+}
+
+func decodeContinuationSignal() transporthttp.Decoder {
+	decode := boundedContinuationDecoder(transporthttp.DecodeProto(
+		func() *continuationv1.SignalRequest {
+			return &continuationv1.SignalRequest{}
+		},
+		transporthttp.WithProtoBody(),
+		transporthttp.WithProtoPathTemplate(continuationSignalPattern),
+		transporthttp.WithProtoQueryDisabled(),
+	))
+	return func(request *nethttp.Request) (any, error) {
+		decoded, err := decode(request)
+		if err != nil {
+			return nil, err
+		}
+		message, ok := decoded.(*continuationv1.SignalRequest)
+		if !ok {
+			return nil, fmt.Errorf("continuation: invalid signal request")
+		}
+		if len(message.GetPayload()) > maxContinuationPayloadBytes {
+			return nil, transporthttp.ErrRequestTooLarge
+		}
+		callID, err := newContinuationHTTPCallID(message.GetCallId())
+		if err != nil {
+			return nil, err
+		}
+		if !validContinuationHTTPIdentity(
+			message.GetCommandId(),
+			maxContinuationCommandBytes,
+		) {
+			return nil, fmt.Errorf("continuation: invalid command ID")
+		}
+		return continuationCommandRequest{
+			callID:    callID,
+			commandID: message.GetCommandId(),
+			payload:   append([]byte(nil), message.GetPayload()...),
+		}, nil
+	}
+}
+
+func decodeContinuationCancel() transporthttp.Decoder {
+	decode := boundedContinuationDecoder(transporthttp.DecodeProto(
+		func() *continuationv1.CancelRequest {
+			return &continuationv1.CancelRequest{}
+		},
+		transporthttp.WithProtoBody(),
+		transporthttp.WithProtoPathField("call_id", "call_id"),
+		transporthttp.WithProtoQueryDisabled(),
+	))
+	return func(request *nethttp.Request) (any, error) {
+		decoded, err := decode(request)
+		if err != nil {
+			return nil, err
+		}
+		message, ok := decoded.(*continuationv1.CancelRequest)
+		if !ok {
+			return nil, fmt.Errorf("continuation: invalid cancel request")
+		}
+		callID, err := newContinuationHTTPCallID(message.GetCallId())
+		if err != nil {
+			return nil, err
+		}
+		if !validContinuationHTTPIdentity(
+			message.GetCommandId(),
+			maxContinuationCommandBytes,
+		) {
+			return nil, fmt.Errorf("continuation: invalid command ID")
+		}
+		return continuationCommandRequest{
+			callID:    callID,
+			commandID: message.GetCommandId(),
+		}, nil
+	}
+}
+
+func decodeContinuationAttach(request *nethttp.Request) (any, error) {
+	if request == nil ||
+		request.URL == nil ||
+		request.URL.RawQuery != "" {
+		return nil, fmt.Errorf("continuation: invalid Attach request")
+	}
+	callID, err := newContinuationHTTPCallID(request.PathValue("call_id"))
+	if err != nil {
+		return nil, err
+	}
+	decoded, err := transporthttp.DecodeSSERequest(request)
+	if err != nil {
+		return nil, err
+	}
+	sseRequest, ok := decoded.(transporthttp.SSERequest)
+	if !ok {
+		return nil, fmt.Errorf("continuation: invalid SSE request")
+	}
+	after := uint64(0)
+	if sseRequest.LastEventID() != "" {
+		after, err = strconv.ParseUint(sseRequest.LastEventID(), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"continuation: Last-Event-ID is not a sequence",
+			)
+		}
+	}
+	return continuationAttachRequest{callID: callID, after: after}, nil
+}
+
+func boundedContinuationDecoder(decoder transporthttp.Decoder) transporthttp.Decoder {
+	return func(request *nethttp.Request) (any, error) {
+		if request == nil || request.Body == nil || decoder == nil {
+			return nil, fmt.Errorf("continuation: invalid request body")
+		}
+		if request.ContentLength > maxContinuationRequestBytes {
+			return nil, transporthttp.ErrRequestTooLarge
+		}
+		request.Body = nethttp.MaxBytesReader(
+			nil,
+			request.Body,
+			maxContinuationRequestBytes,
+		)
+		return decoder(request)
+	}
+}
+
+func handleContinuationStart(
+	runtime ContinuationRuntime,
+	inlineBudget continuation.InlineBudget,
+) middleware.Handler {
+	return func(
+		ctx context.Context,
+		request any,
+	) (any, error) {
+		decoded, ok := request.(continuationStartRequest)
+		if !ok {
+			return nil, continuationRequestError()
+		}
+		var snapshot continuation.Snapshot
+		var err error
+		if decoded.workflowVersion != "" {
+			workflow, ok := runtime.(continuationWorkflowRuntime)
+			if !ok {
+				return nil, continuationRequestError()
+			}
+			snapshot, err = workflow.StartWorkflow(
+				ctx,
+				decoded.callID,
+				decoded.operation,
+				decoded.workflowVersion,
+				decoded.input,
+			)
+		} else if inline, ok := runtime.(ContinuationInlineRuntime); ok {
+			snapshot, err = inline.StartCallInline(
+				ctx,
+				decoded.callID,
+				decoded.operation,
+				decoded.input,
+				inlineBudget,
+			)
+		} else {
+			snapshot, err = runtime.StartCall(
+				ctx,
+				decoded.callID,
+				decoded.operation,
+				decoded.input,
+			)
+		}
+		if err != nil {
+			return nil, continuationHTTPError(err)
+		}
+		status := nethttp.StatusAccepted
+		if snapshot.Status().Terminal() {
+			status = nethttp.StatusOK
+		}
+		return continuationStartResponse{
+			status: status,
+			message: &continuationv1.StartResponse{
+				Snapshot:      continuationProtoSnapshot(snapshot),
+				TerminalFrame: continuationProtoTerminalFrame(snapshot),
+			},
+		}, nil
+	}
+}
+
+func encodeContinuationStart(
+	ctx context.Context,
+	writer nethttp.ResponseWriter,
+	response any,
+) error {
+	encoded, ok := response.(continuationStartResponse)
+	if !ok || encoded.message == nil {
+		return fmt.Errorf("continuation: invalid Start response")
+	}
+	writer.WriteHeader(encoded.status)
+	return transporthttp.EncodeProto(ctx, writer, encoded.message)
+}
+
+func handleContinuationSignal(
+	runtime ContinuationRuntime,
+) middleware.Handler {
+	return func(
+		ctx context.Context,
+		request any,
+	) (any, error) {
+		decoded, ok := request.(continuationCommandRequest)
+		if !ok {
+			return nil, continuationRequestError()
+		}
+		snapshot, err := runtime.SubmitSignal(
+			ctx,
+			decoded.callID,
+			decoded.commandID,
+			decoded.payload,
+		)
+		if err != nil {
+			return nil, continuationHTTPError(err)
+		}
+		return &continuationv1.SignalResponse{
+			Snapshot: continuationProtoSnapshot(snapshot),
+		}, nil
+	}
+}
+
+func handleContinuationCancel(
+	runtime ContinuationRuntime,
+) middleware.Handler {
+	return func(
+		ctx context.Context,
+		request any,
+	) (any, error) {
+		decoded, ok := request.(continuationCommandRequest)
+		if !ok {
+			return nil, continuationRequestError()
+		}
+		snapshot, err := runtime.RequestCancel(
+			ctx,
+			decoded.callID,
+			decoded.commandID,
+		)
+		if err != nil {
+			return nil, continuationHTTPError(err)
+		}
+		return &continuationv1.CancelResponse{
+			Snapshot: continuationProtoSnapshot(snapshot),
+		}, nil
+	}
+}
+
+func handleContinuationAttach(
+	runtime ContinuationRuntime,
+	options continuationRouteOptions,
+) middleware.Handler {
+	return func(
+		ctx context.Context,
+		request any,
+	) (any, error) {
+		decoded, ok := request.(continuationAttachRequest)
+		if !ok {
+			return nil, continuationRequestError()
+		}
+		initial, err := runtime.Attach(
+			ctx,
+			decoded.callID,
+			decoded.after,
+			options.pageSize,
+		)
+		if err != nil {
+			return nil, continuationHTTPError(err)
+		}
+		streamContext, cancel := context.WithCancel(ctx)
+		events := make(chan transporthttp.SSEEvent)
+		failures := make(chan error, 1)
+		stream, err := transporthttp.NewServerSentEvents(events, failures)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		go pumpContinuationEvents(
+			streamContext,
+			runtime,
+			decoded.callID,
+			decoded.after,
+			options,
+			initial,
+			events,
+			failures,
+		)
+		return continuationStreamResponse{
+			stream: stream,
+			cancel: cancel,
+		}, nil
+	}
+}
+
+func continuationSSEEncoder(encoder transporthttp.Encoder) transporthttp.Encoder {
+	return func(
+		ctx context.Context,
+		writer nethttp.ResponseWriter,
+		response any,
+	) error {
+		stream, ok := response.(continuationStreamResponse)
+		if !ok || stream.cancel == nil || encoder == nil {
+			return fmt.Errorf("continuation: invalid Attach response")
+		}
+		defer stream.cancel()
+		return encoder(ctx, writer, stream.stream)
+	}
+}
+
+func pumpContinuationEvents(
+	ctx context.Context,
+	runtime ContinuationRuntime,
+	callID continuation.CallID,
+	after uint64,
+	options continuationRouteOptions,
+	initial continuation.Attachment,
+	events chan<- transporthttp.SSEEvent,
+	failures chan<- error,
+) {
+	defer close(events)
+	defer close(failures)
+	attachment := initial
+	for {
+		if err := validateContinuationAttachment(
+			attachment,
+			after,
+			options.pageSize,
+		); err != nil {
+			sendContinuationFailure(ctx, failures, err)
+			return
+		}
+		for _, frame := range attachment.Frames {
+			event, err := continuationFrameEvent(frame, attachment.Snapshot)
+			if err != nil {
+				sendContinuationFailure(ctx, failures, err)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case events <- event:
+			}
+			after = frame.Sequence()
+		}
+		if attachment.Terminal &&
+			after == attachment.Snapshot.Sequence() {
+			return
+		}
+		if after < attachment.Snapshot.Sequence() {
+			var err error
+			attachment, err = runtime.Attach(
+				ctx,
+				callID,
+				after,
+				options.pageSize,
+			)
+			if err != nil {
+				if context.Cause(ctx) == nil {
+					sendContinuationFailure(
+						ctx,
+						failures,
+						continuationHTTPError(err),
+					)
+				}
+				return
+			}
+			continue
+		}
+
+		timer := time.NewTimer(options.pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		var err error
+		attachment, err = runtime.Attach(
+			ctx,
+			callID,
+			after,
+			options.pageSize,
+		)
+		if err != nil {
+			if context.Cause(ctx) == nil {
+				sendContinuationFailure(
+					ctx,
+					failures,
+					continuationHTTPError(err),
+				)
+			}
+			return
+		}
+	}
+}
+
+func validateContinuationAttachment(
+	attachment continuation.Attachment,
+	after uint64,
+	limit int,
+) error {
+	if len(attachment.Frames) > limit ||
+		attachment.Snapshot.Sequence() < after {
+		return fmt.Errorf("continuation: invalid Attach page")
+	}
+	expected := after + 1
+	for _, frame := range attachment.Frames {
+		if frame.Sequence() != expected {
+			return fmt.Errorf("continuation: non-contiguous Attach page")
+		}
+		expected++
+	}
+	if len(attachment.Frames) == 0 &&
+		attachment.Snapshot.Sequence() > after {
+		return fmt.Errorf("continuation: empty Attach page before cursor")
+	}
+	return nil
+}
+
+func sendContinuationFailure(
+	ctx context.Context,
+	failures chan<- error,
+	err error,
+) {
+	select {
+	case <-ctx.Done():
+	case failures <- err:
+	}
+}
+
+func continuationFrameEvent(
+	frame continuation.Frame,
+	snapshot continuation.Snapshot,
+) (transporthttp.SSEEvent, error) {
+	return transporthttp.NewSSEProtoEvent(
+		strconv.FormatUint(frame.Sequence(), 10),
+		continuationEvent,
+		&continuationv1.AttachResponse{
+			Page: &continuationv1.Page{
+				Snapshot: continuationProtoSnapshot(snapshot),
+				Frames: []*continuationv1.Frame{{
+					Sequence: frame.Sequence(),
+					Kind:     continuationProtoFrameKind(frame.Kind()),
+					Payload:  frame.Payload(),
+				}},
+				NextSequence: frame.Sequence() + 1,
+				FrameFloor:   snapshot.FrameFloor(),
+				Terminal:     snapshot.Status().Terminal(),
+			},
+		},
+		0,
+	)
+}
+
+func continuationProtoSnapshot(
+	snapshot continuation.Snapshot,
+) *continuationv1.Snapshot {
+	return &continuationv1.Snapshot{
+		CallId:     snapshot.CallID().String(),
+		Operation:  snapshot.Operation().String(),
+		Status:     continuationProtoStatus(snapshot.Status()),
+		Revision:   snapshot.Revision(),
+		Fence:      snapshot.Fence(),
+		Sequence:   snapshot.Sequence(),
+		FrameFloor: snapshot.FrameFloor(),
+		Terminal:   snapshot.Status().Terminal(),
+		ReadyAt:    continuationReadyAt(snapshot.ReadyAt()),
+		Workflow:   continuationProtoWorkflow(snapshot),
+	}
+}
+
+func continuationReadyAt(readyAt time.Time) string {
+	if readyAt.IsZero() {
+		return ""
+	}
+	return readyAt.UTC().Format(time.RFC3339Nano)
+}
+
+func continuationProtoWorkflow(
+	snapshot continuation.Snapshot,
+) *continuationv1.Workflow {
+	workflow, ok := snapshot.Workflow()
+	if !ok {
+		return nil
+	}
+	nodes := workflow.Nodes()
+	encoded := &continuationv1.Workflow{
+		Version:     workflow.Version(),
+		Fingerprint: workflow.Fingerprint(),
+		StartedAt:   workflow.StartedAt().UTC().Format(time.RFC3339Nano),
+		Nodes:       make([]*continuationv1.WorkflowNode, len(nodes)),
+	}
+	for index, node := range nodes {
+		encoded.Nodes[index] = &continuationv1.WorkflowNode{
+			Id:           node.ID(),
+			Kind:         continuationProtoWorkflowNodeKind(node.Kind()),
+			Status:       continuationProtoWorkflowNodeStatus(node.Status()),
+			Attempt:      node.Attempt(),
+			ChildCallId:  node.ChildCallID().String(),
+			ReadyAt:      continuationReadyAt(node.ReadyAt()),
+			FailureClass: node.FailureClass(),
+		}
+	}
+	return encoded
+}
+
+func continuationProtoWorkflowNodeKind(
+	kind continuation.WorkflowNodeKind,
+) continuationv1.WorkflowNodeKind {
+	switch kind {
+	case continuation.WorkflowNodeMachine:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_MACHINE
+	case continuation.WorkflowNodeTimer:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_TIMER
+	case continuation.WorkflowNodeChild:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_CHILD
+	case continuation.WorkflowNodeJoin:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_JOIN
+	default:
+		return continuationv1.WorkflowNodeKind_WORKFLOW_NODE_KIND_UNSPECIFIED
+	}
+}
+
+func continuationProtoWorkflowNodeStatus(
+	status continuation.WorkflowNodeStatus,
+) continuationv1.WorkflowNodeStatus {
+	switch status {
+	case continuation.WorkflowNodePending:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_PENDING
+	case continuation.WorkflowNodeRunning:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_RUNNING
+	case continuation.WorkflowNodeWaiting:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_WAITING
+	case continuation.WorkflowNodeSucceeded:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_SUCCEEDED
+	case continuation.WorkflowNodeFailed:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_FAILED
+	case continuation.WorkflowNodeSkipped:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_SKIPPED
+	default:
+		return continuationv1.WorkflowNodeStatus_WORKFLOW_NODE_STATUS_UNSPECIFIED
+	}
+}
+
+func continuationProtoTerminalFrame(
+	snapshot continuation.Snapshot,
+) *continuationv1.Frame {
+	if !snapshot.Status().Terminal() {
+		return nil
+	}
+	frames := snapshot.Frames()
+	if len(frames) == 0 {
+		return nil
+	}
+	frame := frames[len(frames)-1]
+	var expected continuation.FrameKind
+	switch snapshot.Status() {
+	case continuation.StatusCompleted:
+		expected = continuation.FrameCompleted
+	case continuation.StatusFailed:
+		expected = continuation.FrameFailed
+	case continuation.StatusCanceled:
+		expected = continuation.FrameCanceled
+	case continuation.StatusExpired:
+		expected = continuation.FrameExpired
+	default:
+		return nil
+	}
+	if frame.Kind() != expected ||
+		frame.Sequence() != snapshot.Sequence() {
+		return nil
+	}
+	return &continuationv1.Frame{
+		Sequence: frame.Sequence(),
+		Kind:     continuationProtoFrameKind(frame.Kind()),
+		Payload:  frame.Payload(),
+	}
+}
+
+func continuationProtoStatus(
+	status continuation.Status,
+) continuationv1.CallStatus {
+	switch status {
+	case continuation.StatusAccepted:
+		return continuationv1.CallStatus_CALL_STATUS_ACCEPTED
+	case continuation.StatusRunning:
+		return continuationv1.CallStatus_CALL_STATUS_RUNNING
+	case continuation.StatusWaiting:
+		return continuationv1.CallStatus_CALL_STATUS_WAITING
+	case continuation.StatusSuspended:
+		return continuationv1.CallStatus_CALL_STATUS_SUSPENDED
+	case continuation.StatusCancelRequested:
+		return continuationv1.CallStatus_CALL_STATUS_CANCEL_REQUESTED
+	case continuation.StatusCompleted:
+		return continuationv1.CallStatus_CALL_STATUS_COMPLETED
+	case continuation.StatusFailed:
+		return continuationv1.CallStatus_CALL_STATUS_FAILED
+	case continuation.StatusCanceled:
+		return continuationv1.CallStatus_CALL_STATUS_CANCELED
+	case continuation.StatusExpired:
+		return continuationv1.CallStatus_CALL_STATUS_EXPIRED
+	default:
+		return continuationv1.CallStatus_CALL_STATUS_UNSPECIFIED
+	}
+}
+
+func continuationProtoFrameKind(
+	kind continuation.FrameKind,
+) continuationv1.FrameKind {
+	switch kind {
+	case continuation.FrameAccepted:
+		return continuationv1.FrameKind_FRAME_KIND_ACCEPTED
+	case continuation.FrameEvent:
+		return continuationv1.FrameKind_FRAME_KIND_EVENT
+	case continuation.FrameWaiting:
+		return continuationv1.FrameKind_FRAME_KIND_WAITING
+	case continuation.FrameSignal:
+		return continuationv1.FrameKind_FRAME_KIND_SIGNAL
+	case continuation.FrameSuspended:
+		return continuationv1.FrameKind_FRAME_KIND_SUSPENDED
+	case continuation.FrameCancelRequested:
+		return continuationv1.FrameKind_FRAME_KIND_CANCEL_REQUESTED
+	case continuation.FrameCompleted:
+		return continuationv1.FrameKind_FRAME_KIND_COMPLETED
+	case continuation.FrameFailed:
+		return continuationv1.FrameKind_FRAME_KIND_FAILED
+	case continuation.FrameCanceled:
+		return continuationv1.FrameKind_FRAME_KIND_CANCELED
+	case continuation.FrameExpired:
+		return continuationv1.FrameKind_FRAME_KIND_EXPIRED
+	case continuation.FrameWorkflowChild:
+		return continuationv1.FrameKind_FRAME_KIND_WORKFLOW_CHILD
+	default:
+		return continuationv1.FrameKind_FRAME_KIND_UNSPECIFIED
+	}
+}
+
+func newContinuationHTTPCallID(
+	value string,
+) (continuation.CallID, error) {
+	if !validContinuationHTTPIdentity(value, maxContinuationCallIDBytes) {
+		return continuation.CallID{}, fmt.Errorf("continuation: invalid call ID")
+	}
+	callID, err := continuation.NewCallID(value)
+	if err != nil {
+		return continuation.CallID{}, fmt.Errorf("continuation: invalid call ID")
+	}
+	return callID, nil
+}
+
+func validContinuationHTTPIdentity(value string, maximum int) bool {
+	if value == "" ||
+		len(value) > maximum ||
+		strings.TrimSpace(value) != value {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			character == '-' ||
+			character == '.' ||
+			character == '_' ||
+			character == '~' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func newContinuationHTTPOperation(
+	method string,
+	kind operation.Kind,
+) (operation.Operation, error) {
+	return operation.New("http", continuationService, method, kind)
+}
+
+func continuationRequestError() error {
+	return kerrors.New(
+		nethttp.StatusBadRequest,
+		"INVALID_CONTINUATION_REQUEST",
+		"continuation request is invalid",
+	)
+}
+
+func continuationHTTPError(err error) error {
+	switch {
+	case errors.Is(err, continuation.ErrAuthenticationRequired):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusUnauthorized,
+			"CONTINUATION_AUTHENTICATION_REQUIRED",
+			"continuation authentication is required",
+		)
+	case errors.Is(err, continuation.ErrAccessDenied):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusForbidden,
+			"CONTINUATION_ACCESS_DENIED",
+			"continuation access is denied",
+		)
+	case errors.Is(err, continuation.ErrAuthorizationFailed):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusInternalServerError,
+			"CONTINUATION_AUTHORIZATION_FAILED",
+			"continuation authorization failed",
+		)
+	case errors.Is(err, continuation.ErrNotFound):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusNotFound,
+			"CONTINUATION_NOT_FOUND",
+			"continuation call was not found",
+		)
+	case errors.Is(err, continuation.ErrCursorAhead):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusConflict,
+			"CURSOR_AHEAD",
+			"continuation cursor is ahead of durable state",
+		)
+	case errors.Is(err, continuation.ErrGap):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusGone,
+			"RETENTION_GAP",
+			"continuation frames are no longer retained",
+		)
+	case errors.Is(err, continuation.ErrTimerNotReady):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusConflict,
+			"TIMER_NOT_READY",
+			"continuation timer is not ready",
+		)
+	case errors.Is(err, continuation.ErrHistoryBudget):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusRequestEntityTooLarge,
+			"HISTORY_BUDGET_EXCEEDED",
+			"continuation history exceeds its payload budget",
+		)
+	case errors.Is(err, continuation.ErrAlreadyExists),
+		errors.Is(err, continuation.ErrConflict),
+		errors.Is(err, continuation.ErrCommandConflict),
+		errors.Is(err, continuation.ErrTransition),
+		errors.Is(err, continuation.ErrTerminal),
+		errors.Is(err, continuation.ErrLeaseHeld),
+		errors.Is(err, continuation.ErrLeaseLost),
+		errors.Is(err, continuation.ErrStaleFence),
+		errors.Is(err, continuation.ErrNotReady):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusConflict,
+			"CONTINUATION_CONFLICT",
+			"continuation state conflicts with the request",
+		)
+	case errors.Is(err, continuation.ErrInvalidIdentity),
+		errors.Is(err, continuation.ErrInvalidFrame),
+		errors.Is(err, continuation.ErrInvalidRuntime),
+		errors.Is(err, continuation.ErrInvalidAttach),
+		errors.Is(err, continuation.ErrInvalidStore),
+		errors.Is(err, continuation.ErrMachineNotFound),
+		errors.Is(err, continuation.ErrInvalidWorkflow),
+		errors.Is(err, continuation.ErrWorkflowCycle),
+		errors.Is(err, continuation.ErrInvalidHistory):
+		return kerrors.Wrap(
+			err,
+			nethttp.StatusBadRequest,
+			"INVALID_CONTINUATION_REQUEST",
+			"continuation request is invalid",
+		)
+	default:
+		return err
+	}
+}
+
+func isNilContinuationValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflection := reflect.ValueOf(value)
+	switch reflection.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return reflection.IsNil()
+	default:
+		return false
+	}
+}
+
+func isNilContinuationRuntime(runtime ContinuationRuntime) bool {
+	if runtime == nil {
+		return true
+	}
+	value := reflect.ValueOf(runtime)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/transport/http/dependency.go
+++ b/transport/http/dependency.go
@@ -1,0 +1,767 @@
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	kclient "github.com/keelab/keelith/client"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/registry"
+	"github.com/keelab/keelith/selector"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const defaultHTTPDependencyRollbackTimeout = 5 * time.Second
+
+var (
+	// ErrDependencyNotRunning reports an invocation outside the component's
+	// active lifecycle window.
+	ErrDependencyNotRunning = errors.New("http transport: dependency not running")
+)
+
+// ManagedDependencyState is the bounded HTTP dependency lifecycle state.
+type ManagedDependencyState string
+
+const (
+	// ManagedDependencyNew is the state before the dependency starts.
+	ManagedDependencyNew ManagedDependencyState = "new"
+	// ManagedDependencyRunning is the active request-serving state.
+	ManagedDependencyRunning ManagedDependencyState = "running"
+	// ManagedDependencyDraining rejects new calls while existing calls finish.
+	ManagedDependencyDraining ManagedDependencyState = "draining"
+	// ManagedDependencyStopped is the terminal lifecycle state.
+	ManagedDependencyStopped ManagedDependencyState = "stopped"
+)
+
+// DependencySelectorFactory creates one service-scoped selector over the
+// exact endpoint schemes allowed by a managed HTTP dependency.
+type DependencySelectorFactory func(
+	schemes []string,
+	options ...selector.Option,
+) (selector.Selector, error)
+
+// TransportFactory returns a distinct RoundTripper for one managed
+// dependency. Implementations that return shared custom transports retain
+// ownership of those transports; standard *http.Transport values should be
+// cloned by the factory.
+type TransportFactory func() (nethttp.RoundTripper, error)
+
+// ManagedDependencyConfig defines one lifecycle-owned typed HTTP dependency.
+type ManagedDependencyConfig struct {
+	Name                  string
+	Service               string
+	Schemes               []string
+	Discovery             registry.Discovery
+	Outbound              *kclient.Outbound
+	SelectorFactory       DependencySelectorFactory
+	SelectorOptions       []selector.Option
+	TransportFactory      TransportFactory
+	ComponentDependencies []string
+	ReconnectMin          time.Duration
+	ReconnectMax          time.Duration
+	MaxStale              time.Duration
+	RollbackTimeout       time.Duration
+	MetadataPolicy        metadata.Policy
+	Propagator            propagation.TextMapPropagator
+	MaxResponseBytes      int64
+	MaxHeaderBytes        int
+}
+
+// ManagedDependencyFactoryConfig defines application-instance defaults shared
+// by generated HTTP dependency bindings.
+type ManagedDependencyFactoryConfig struct {
+	Schemes               []string
+	Discovery             registry.Discovery
+	Outbound              *kclient.Outbound
+	SelectorFactory       DependencySelectorFactory
+	SelectorOptions       []selector.Option
+	TransportFactory      TransportFactory
+	ComponentDependencies []string
+	ReconnectMin          time.Duration
+	ReconnectMax          time.Duration
+	MaxStale              time.Duration
+	RollbackTimeout       time.Duration
+	MetadataPolicy        metadata.Policy
+	Propagator            propagation.TextMapPropagator
+	MaxResponseBytes      int64
+	MaxHeaderBytes        int
+}
+
+// ManagedDependencyDescription is a bounded immutable diagnostic snapshot.
+type ManagedDependencyDescription struct {
+	Name            string
+	Service         string
+	State           ManagedDependencyState
+	Schemes         int
+	ActiveRequests  int
+	PreferenceTiers int
+	Router          kclient.Description
+}
+
+// ManagedDependency owns one complete discovery-routed HTTP client path.
+//
+// The generated base URL is a non-routable placeholder. Client.Invoke replaces
+// scheme and authority from the selected Node on every attempt.
+type ManagedDependency struct {
+	name         string
+	service      string
+	schemes      []string
+	dependencies []string
+	router       *kclient.Router
+	gate         *managedDependencyTransport
+	client       *Client
+	baseURL      string
+	rollback     time.Duration
+	preference   int
+}
+
+// ManagedDependencyFactory creates independent service-scoped HTTP clients.
+// The factory itself owns no watcher, transport, or goroutine.
+type ManagedDependencyFactory struct {
+	config ManagedDependencyFactoryConfig
+}
+
+// NewStandardTransportFactory builds independent standard transports with an
+// optional cloned TLS 1.2+ configuration. A nil TLS config uses system roots
+// for HTTPS and also permits explicitly selected HTTP endpoints.
+func NewStandardTransportFactory(
+	config *tls.Config,
+) (TransportFactory, error) {
+	if config != nil && config.MinVersion < tls.VersionTLS12 {
+		return nil, fmt.Errorf(
+			"%w: TLS minimum version must be 1.2 or newer",
+			ErrInvalidOption,
+		)
+	}
+	var frozen *tls.Config
+	if config != nil {
+		frozen = config.Clone()
+	}
+	return func() (nethttp.RoundTripper, error) {
+		standard, ok := nethttp.DefaultTransport.(*nethttp.Transport)
+		if !ok || standard == nil {
+			return nil, fmt.Errorf(
+				"%w: default HTTP transport is not standard",
+				ErrInvalidOption,
+			)
+		}
+		transport := standard.Clone()
+		if frozen != nil {
+			transport.TLSClientConfig = frozen.Clone()
+		}
+		return transport, nil
+	}, nil
+}
+
+// NewManagedDependencyFactory validates shared generated-binding inputs.
+func NewManagedDependencyFactory(
+	config ManagedDependencyFactoryConfig,
+) (*ManagedDependencyFactory, error) {
+	if isNilManagedDependencyValue(config.Discovery) {
+		return nil, fmt.Errorf("%w: discovery is nil", ErrInvalidOption)
+	}
+	if config.Outbound == nil {
+		return nil, fmt.Errorf("%w: outbound is nil", ErrInvalidOption)
+	}
+	schemes, err := normalizeManagedHTTPSchemes(config.Schemes)
+	if err != nil {
+		return nil, err
+	}
+	dependencies, err := validateManagedHTTPDependencies(
+		"",
+		config.ComponentDependencies,
+	)
+	if err != nil {
+		return nil, err
+	}
+	selectorOptions, err := copyManagedHTTPSelectorOptions(config.SelectorOptions)
+	if err != nil {
+		return nil, err
+	}
+	if config.RollbackTimeout < 0 ||
+		config.MaxResponseBytes < 0 ||
+		config.MaxHeaderBytes < 0 {
+		return nil, fmt.Errorf(
+			"%w: timeout and byte budgets must not be negative",
+			ErrInvalidOption,
+		)
+	}
+	config.Schemes = schemes
+	config.ComponentDependencies = dependencies
+	config.SelectorOptions = selectorOptions
+	return &ManagedDependencyFactory{config: config}, nil
+}
+
+// New creates one managed dependency with a distinct Router, selector,
+// standard client, and transport lifecycle.
+func (factory *ManagedDependencyFactory) New(
+	name string,
+	service string,
+) (*ManagedDependency, error) {
+	if factory == nil {
+		return nil, fmt.Errorf(
+			"%w: managed dependency factory is nil",
+			ErrInvalidOption,
+		)
+	}
+	config := factory.config
+	return NewManagedDependency(ManagedDependencyConfig{
+		Name:                  name,
+		Service:               service,
+		Schemes:               config.Schemes,
+		Discovery:             config.Discovery,
+		Outbound:              config.Outbound,
+		SelectorFactory:       config.SelectorFactory,
+		SelectorOptions:       config.SelectorOptions,
+		TransportFactory:      config.TransportFactory,
+		ComponentDependencies: config.ComponentDependencies,
+		ReconnectMin:          config.ReconnectMin,
+		ReconnectMax:          config.ReconnectMax,
+		MaxStale:              config.MaxStale,
+		RollbackTimeout:       config.RollbackTimeout,
+		MetadataPolicy:        config.MetadataPolicy,
+		Propagator:            config.Propagator,
+		MaxResponseBytes:      config.MaxResponseBytes,
+		MaxHeaderBytes:        config.MaxHeaderBytes,
+	})
+}
+
+// NewManagedDependency assembles a service-scoped dynamic HTTP client.
+func NewManagedDependency(
+	config ManagedDependencyConfig,
+) (*ManagedDependency, error) {
+	name := strings.TrimSpace(config.Name)
+	service := strings.TrimSpace(config.Service)
+	if !validManagedHTTPName(name) || !validManagedHTTPName(service) {
+		return nil, fmt.Errorf(
+			"%w: dependency name or service is malformed",
+			ErrInvalidOption,
+		)
+	}
+	if isNilManagedDependencyValue(config.Discovery) {
+		return nil, fmt.Errorf("%w: discovery is nil", ErrInvalidOption)
+	}
+	if config.Outbound == nil {
+		return nil, fmt.Errorf("%w: outbound is nil", ErrInvalidOption)
+	}
+	schemes, err := normalizeManagedHTTPSchemes(config.Schemes)
+	if err != nil {
+		return nil, err
+	}
+	dependencies, err := validateManagedHTTPDependencies(
+		name,
+		config.ComponentDependencies,
+	)
+	if err != nil {
+		return nil, err
+	}
+	selectorOptions, err := copyManagedHTTPSelectorOptions(config.SelectorOptions)
+	if err != nil {
+		return nil, err
+	}
+	selectorOptions = append(
+		config.Outbound.SelectorOptions(),
+		selectorOptions...,
+	)
+	selectorFactory := config.SelectorFactory
+	if selectorFactory == nil {
+		selectorFactory = func(
+			schemes []string,
+			options ...selector.Option,
+		) (selector.Selector, error) {
+			return selector.NewP2CForSchemes(schemes, options...)
+		}
+	}
+	selected, err := selectorFactory(schemes, selectorOptions...)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create selector: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	if isNilManagedDependencyValue(selected) {
+		return nil, fmt.Errorf(
+			"%w: selector factory returned nil",
+			ErrInvalidOption,
+		)
+	}
+	preferenceTiers := 0
+	if describer, ok := selected.(selector.PreferenceDescriber); ok {
+		preferenceTiers = describer.PreferenceTierCount()
+	}
+	router, err := kclient.NewRouter(kclient.RouterConfig{
+		Name:         name + ".router",
+		Service:      service,
+		Discovery:    config.Discovery,
+		Selector:     selected,
+		ReconnectMin: config.ReconnectMin,
+		ReconnectMax: config.ReconnectMax,
+		MaxStale:     config.MaxStale,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create router: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	transportFactory := config.TransportFactory
+	if transportFactory == nil {
+		transportFactory, err = NewStandardTransportFactory(nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	baseTransport, err := transportFactory()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create HTTP transport: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	if isNilManagedDependencyValue(baseTransport) {
+		return nil, fmt.Errorf(
+			"%w: transport factory returned nil",
+			ErrInvalidOption,
+		)
+	}
+	gate := newManagedDependencyTransport(baseTransport)
+	standardClient := &nethttp.Client{
+		Transport: gate,
+		CheckRedirect: func(
+			_ *nethttp.Request,
+			_ []*nethttp.Request,
+		) error {
+			return nethttp.ErrUseLastResponse
+		},
+	}
+	clientOptions := []ClientOption{
+		WithClientMiddleware(config.Outbound.Middleware()),
+		WithClientMetadataPolicy(config.MetadataPolicy),
+		WithClientPicker(router),
+	}
+	if config.Propagator != nil {
+		clientOptions = append(
+			clientOptions,
+			WithClientPropagator(config.Propagator),
+		)
+	}
+	if config.MaxResponseBytes < 0 || config.MaxHeaderBytes < 0 {
+		return nil, fmt.Errorf(
+			"%w: response budgets must not be negative",
+			ErrInvalidOption,
+		)
+	}
+	if config.MaxResponseBytes > 0 {
+		clientOptions = append(
+			clientOptions,
+			WithClientMaxResponseBytes(config.MaxResponseBytes),
+		)
+	}
+	if config.MaxHeaderBytes > 0 {
+		clientOptions = append(
+			clientOptions,
+			WithClientMaxHeaderBytes(config.MaxHeaderBytes),
+		)
+	}
+	transport, err := NewClient(standardClient, clientOptions...)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: create client transport: %w",
+			ErrInvalidOption,
+			err,
+		)
+	}
+	rollback := config.RollbackTimeout
+	if rollback == 0 {
+		rollback = defaultHTTPDependencyRollbackTimeout
+	}
+	if rollback <= 0 {
+		return nil, fmt.Errorf(
+			"%w: rollback timeout must be positive",
+			ErrInvalidOption,
+		)
+	}
+	return &ManagedDependency{
+		name:         name,
+		service:      service,
+		schemes:      schemes,
+		dependencies: dependencies,
+		router:       router,
+		gate:         gate,
+		client:       transport,
+		baseURL:      schemes[0] + "://keelith.invalid",
+		rollback:     rollback,
+		preference:   preferenceTiers,
+	}, nil
+}
+
+// Name returns the stable App component name.
+func (dependency *ManagedDependency) Name() string {
+	if dependency == nil {
+		return ""
+	}
+	return dependency.name
+}
+
+// Service returns the exact Protobuf service identity.
+func (dependency *ManagedDependency) Service() string {
+	if dependency == nil {
+		return ""
+	}
+	return dependency.service
+}
+
+// Dependencies returns explicit App component prerequisites.
+func (dependency *ManagedDependency) Dependencies() []string {
+	if dependency == nil {
+		return nil
+	}
+	return append([]string(nil), dependency.dependencies...)
+}
+
+// Client returns the typed generated-client-compatible HTTP transport.
+func (dependency *ManagedDependency) Client() *Client {
+	if dependency == nil {
+		return nil
+	}
+	return dependency.client
+}
+
+// BaseURL returns a non-routable URL used only to construct typed requests.
+// Every invocation replaces its scheme and authority with the selected Node.
+func (dependency *ManagedDependency) BaseURL() string {
+	if dependency == nil {
+		return ""
+	}
+	return dependency.baseURL
+}
+
+// Start loads the first discovery snapshot before accepting requests.
+func (dependency *ManagedDependency) Start(ctx context.Context) error {
+	if dependency == nil {
+		return fmt.Errorf("%w: managed dependency is nil", ErrInvalidOption)
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	if err := dependency.router.Start(ctx); err != nil {
+		return fmt.Errorf("http transport: start dependency router: %w", err)
+	}
+	if err := dependency.gate.start(); err != nil {
+		rollbackCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			dependency.rollback,
+		)
+		defer cancel()
+		return errors.Join(err, dependency.router.Stop(rollbackCtx))
+	}
+	return nil
+}
+
+// Stop rejects new requests, drains active RoundTrips, closes idle
+// connections, and finally closes the discovery watcher.
+func (dependency *ManagedDependency) Stop(ctx context.Context) error {
+	if dependency == nil {
+		return nil
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	transportErr := dependency.gate.stop(ctx)
+	routerErr := dependency.router.Stop(ctx)
+	return errors.Join(transportErr, routerErr)
+}
+
+// Describe returns detailed local diagnostics without endpoint or metadata
+// values.
+func (dependency *ManagedDependency) Describe() ManagedDependencyDescription {
+	if dependency == nil {
+		return ManagedDependencyDescription{}
+	}
+	state, active := dependency.gate.describe()
+	return ManagedDependencyDescription{
+		Name:            dependency.name,
+		Service:         dependency.service,
+		State:           state,
+		Schemes:         len(dependency.schemes),
+		ActiveRequests:  active,
+		PreferenceTiers: dependency.preference,
+		Router:          dependency.router.Describe(),
+	}
+}
+
+type managedDependencyTransport struct {
+	base nethttp.RoundTripper
+
+	mu      sync.Mutex
+	state   ManagedDependencyState
+	active  int
+	drained chan struct{}
+}
+
+func newManagedDependencyTransport(
+	base nethttp.RoundTripper,
+) *managedDependencyTransport {
+	return &managedDependencyTransport{
+		base:    base,
+		state:   ManagedDependencyNew,
+		drained: make(chan struct{}),
+	}
+}
+
+func (transport *managedDependencyTransport) start() error {
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	if transport.state != ManagedDependencyNew {
+		return fmt.Errorf(
+			"%w: dependency state is %s",
+			ErrDependencyNotRunning,
+			transport.state,
+		)
+	}
+	transport.state = ManagedDependencyRunning
+	return nil
+}
+
+func (transport *managedDependencyTransport) RoundTrip(
+	request *nethttp.Request,
+) (*nethttp.Response, error) {
+	transport.mu.Lock()
+	if transport.state != ManagedDependencyRunning {
+		state := transport.state
+		transport.mu.Unlock()
+		return nil, fmt.Errorf(
+			"%w: dependency state is %s",
+			ErrDependencyNotRunning,
+			state,
+		)
+	}
+	transport.active++
+	transport.mu.Unlock()
+	response, err := transport.base.RoundTrip(request)
+	if err != nil || response == nil || response.Body == nil {
+		transport.finish()
+		return response, err
+	}
+	response.Body = &managedDependencyBody{
+		body:   response.Body,
+		finish: transport.finish,
+	}
+	return response, nil
+}
+
+type managedDependencyBody struct {
+	body   io.ReadCloser
+	finish func()
+	once   sync.Once
+}
+
+func (body *managedDependencyBody) Read(destination []byte) (int, error) {
+	count, err := body.body.Read(destination)
+	if err != nil {
+		body.complete()
+	}
+	return count, err
+}
+
+func (body *managedDependencyBody) Close() error {
+	err := body.body.Close()
+	body.complete()
+	return err
+}
+
+func (body *managedDependencyBody) complete() {
+	body.once.Do(body.finish)
+}
+
+func (transport *managedDependencyTransport) finish() {
+	closeConnections := false
+	transport.mu.Lock()
+	if transport.active > 0 {
+		transport.active--
+	}
+	if transport.active == 0 &&
+		transport.state == ManagedDependencyDraining {
+		transport.state = ManagedDependencyStopped
+		close(transport.drained)
+		closeConnections = true
+	}
+	transport.mu.Unlock()
+	if closeConnections {
+		transport.closeIdleConnections()
+	}
+}
+
+func (transport *managedDependencyTransport) stop(ctx context.Context) error {
+	transport.mu.Lock()
+	switch transport.state {
+	case ManagedDependencyNew:
+		transport.state = ManagedDependencyStopped
+		close(transport.drained)
+		transport.mu.Unlock()
+		transport.closeIdleConnections()
+		return nil
+	case ManagedDependencyStopped:
+		transport.mu.Unlock()
+		return nil
+	case ManagedDependencyRunning:
+		transport.state = ManagedDependencyDraining
+		if transport.active == 0 {
+			transport.state = ManagedDependencyStopped
+			close(transport.drained)
+		}
+	}
+	drained := transport.drained
+	stopped := transport.state == ManagedDependencyStopped
+	transport.mu.Unlock()
+	if stopped {
+		transport.closeIdleConnections()
+		return nil
+	}
+	select {
+	case <-drained:
+		transport.closeIdleConnections()
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (transport *managedDependencyTransport) describe() (
+	ManagedDependencyState,
+	int,
+) {
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	return transport.state, transport.active
+}
+
+func (transport *managedDependencyTransport) closeIdleConnections() {
+	if closer, ok := transport.base.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+func normalizeManagedHTTPSchemes(schemes []string) ([]string, error) {
+	if len(schemes) == 0 || len(schemes) > 2 {
+		return nil, fmt.Errorf(
+			"%w: HTTP endpoint scheme count must be within 1..2",
+			ErrInvalidOption,
+		)
+	}
+	result := make([]string, 0, len(schemes))
+	seen := make(map[string]struct{}, len(schemes))
+	for _, scheme := range schemes {
+		normalized := strings.ToLower(strings.TrimSpace(scheme))
+		if normalized != "http" && normalized != "https" {
+			return nil, fmt.Errorf(
+				"%w: unsupported HTTP endpoint scheme %q",
+				ErrInvalidOption,
+				scheme,
+			)
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: HTTP endpoint scheme %q is duplicated",
+				ErrInvalidOption,
+				normalized,
+			)
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	return result, nil
+}
+
+func copyManagedHTTPSelectorOptions(
+	options []selector.Option,
+) ([]selector.Option, error) {
+	result := append([]selector.Option(nil), options...)
+	for index, option := range result {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: selector option %d is nil",
+				ErrInvalidOption,
+				index,
+			)
+		}
+	}
+	return result, nil
+}
+
+func validateManagedHTTPDependencies(
+	name string,
+	dependencies []string,
+) ([]string, error) {
+	result := make([]string, len(dependencies))
+	seen := make(map[string]struct{}, len(dependencies))
+	for index, dependency := range dependencies {
+		if strings.TrimSpace(dependency) != dependency ||
+			!validManagedHTTPName(dependency) ||
+			name != "" && dependency == name {
+			return nil, fmt.Errorf(
+				"%w: component dependency %d is malformed",
+				ErrInvalidOption,
+				index,
+			)
+		}
+		if _, duplicate := seen[dependency]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: component dependency %q is duplicated",
+				ErrInvalidOption,
+				dependency,
+			)
+		}
+		seen[dependency] = struct{}{}
+		result[index] = dependency
+	}
+	return result, nil
+}
+
+func validManagedHTTPName(value string) bool {
+	if value == "" || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNilManagedDependencyValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+var _ nethttp.RoundTripper = (*managedDependencyTransport)(nil)

--- a/transport/http/error.go
+++ b/transport/http/error.go
@@ -1,0 +1,160 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"sort"
+	"strings"
+
+	kerrors "github.com/keelab/keelith/errors"
+)
+
+var (
+	// ErrInvalidOption means a transport option is unsafe or incomplete.
+	ErrInvalidOption = errors.New("http transport: invalid option")
+	// ErrInvalidRoute means a route identity, codec, or handler is invalid.
+	ErrInvalidRoute = errors.New("http transport: invalid route")
+	// ErrAlreadyStarted means Server.Start was called more than once.
+	ErrAlreadyStarted = errors.New("http transport: server already started")
+	// ErrNilContext means a public operation received a nil context.
+	ErrNilContext = errors.New("http transport: nil context")
+	// ErrRequestTooLarge means an HTTP request body exceeded its budget.
+	ErrRequestTooLarge = errors.New("http transport: request body too large")
+	// ErrResponseTooLarge means an HTTP response body exceeded its budget.
+	ErrResponseTooLarge = errors.New("http transport: response body too large")
+	// ErrHeaderTooLarge means HTTP headers exceeded their budget.
+	ErrHeaderTooLarge = errors.New("http transport: headers too large")
+	// ErrInvalidCall means a ClientCall is incomplete.
+	ErrInvalidCall = errors.New("http transport: invalid client call")
+)
+
+// ErrorEncoder writes a transport-neutral error to HTTP.
+type ErrorEncoder func(context.Context, nethttp.ResponseWriter, error)
+
+// ErrorEnvelope is Keelith's default HTTP JSON error representation.
+type ErrorEnvelope struct {
+	Code     int32             `json:"code"`
+	Reason   string            `json:"reason"`
+	Message  string            `json:"message"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+func newErrorEncoder(allowedMetadata []string) ErrorEncoder {
+	allowed := make(map[string]struct{}, len(allowedMetadata))
+	for _, key := range allowedMetadata {
+		allowed[strings.ToLower(key)] = struct{}{}
+	}
+	return func(
+		_ context.Context,
+		writer nethttp.ResponseWriter,
+		err error,
+	) {
+		status, envelope := errorEnvelope(err, allowed)
+		writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		writer.WriteHeader(status)
+		_ = json.NewEncoder(writer).Encode(envelope)
+	}
+}
+
+func errorEnvelope(
+	err error,
+	allowedMetadata map[string]struct{},
+) (int, ErrorEnvelope) {
+	var frameworkErr *kerrors.Error
+	if errors.As(err, &frameworkErr) {
+		status := statusFromCode(frameworkErr.Code())
+		return status, ErrorEnvelope{
+			Code:     frameworkErr.Code(),
+			Reason:   frameworkErr.Reason(),
+			Message:  frameworkErr.Message(),
+			Metadata: filterErrorMetadata(frameworkErr.Metadata(), allowedMetadata),
+		}
+	}
+
+	status := nethttp.StatusInternalServerError
+	reason := "INTERNAL"
+	message := "internal server error"
+	var maxBytesError *nethttp.MaxBytesError
+	switch {
+	case errors.As(err, &maxBytesError), errors.Is(err, ErrRequestTooLarge):
+		status = nethttp.StatusRequestEntityTooLarge
+		reason = "REQUEST_TOO_LARGE"
+		message = "request body exceeds configured limit"
+	case errors.Is(err, ErrHeaderTooLarge):
+		status = nethttp.StatusRequestHeaderFieldsTooLarge
+		reason = "HEADER_TOO_LARGE"
+		message = "request headers exceed configured limit"
+	case errors.Is(err, ErrResponseTooLarge):
+		reason = "RESPONSE_TOO_LARGE"
+		message = "response body exceeds configured limit"
+	default:
+		var syntaxError *json.SyntaxError
+		var typeError *json.UnmarshalTypeError
+		if errors.As(err, &syntaxError) ||
+			errors.As(err, &typeError) ||
+			errors.Is(err, io.ErrUnexpectedEOF) {
+			status = nethttp.StatusBadRequest
+			reason = "INVALID_REQUEST"
+			message = "request body is invalid"
+		}
+	}
+	return status, ErrorEnvelope{
+		Code:    int32(status),
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func statusFromCode(code int32) int {
+	if code >= nethttp.StatusBadRequest && code <= 599 {
+		return int(code)
+	}
+	return nethttp.StatusInternalServerError
+}
+
+func filterErrorMetadata(
+	source map[string]string,
+	allowed map[string]struct{},
+) map[string]string {
+	if len(source) == 0 || len(allowed) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for key, value := range source {
+		normalized := strings.ToLower(key)
+		if _, ok := allowed[normalized]; ok {
+			result[normalized] = value
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func validateErrorMetadata(keys []string) ([]string, error) {
+	normalized := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		value := strings.ToLower(strings.TrimSpace(key))
+		if value == "" {
+			return nil, fmt.Errorf("%w: error metadata key is empty", ErrInvalidOption)
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate error metadata key %q",
+				ErrInvalidOption,
+				value,
+			)
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}

--- a/transport/http/proto_binding.go
+++ b/transport/http/proto_binding.go
@@ -1,0 +1,183 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	maximumProtoFieldPathBytes    = 1024
+	maximumProtoFieldPathSegments = 16
+)
+
+func resolveProtoFieldPath(
+	message protoreflect.Message,
+	path string,
+) ([]protoreflect.FieldDescriptor, error) {
+	if !message.IsValid() || !validProtoFieldPath(path) {
+		return nil, fmt.Errorf("http: invalid proto field path %q", path)
+	}
+	segments := strings.Split(path, ".")
+	result := make([]protoreflect.FieldDescriptor, 0, len(segments))
+	descriptor := message.Descriptor()
+	for index, segment := range segments {
+		field := lookupProtoField(descriptor.Fields(), segment)
+		if field == nil {
+			return nil, fmt.Errorf(
+				"http: proto body field %q is absent from %s",
+				strings.Join(segments[:index+1], "."),
+				descriptor.FullName(),
+			)
+		}
+		result = append(result, field)
+		if index == len(segments)-1 {
+			continue
+		}
+		if field.IsList() || field.IsMap() || field.Message() == nil {
+			return nil, fmt.Errorf(
+				"http: proto body field %q is not a singular message",
+				strings.Join(segments[:index+1], "."),
+			)
+		}
+		descriptor = field.Message()
+	}
+	return result, nil
+}
+
+func validProtoFieldPath(path string) bool {
+	if path == "" || len(path) > maximumProtoFieldPathBytes ||
+		!utf8.ValidString(path) || strings.TrimSpace(path) != path {
+		return false
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) > maximumProtoFieldPathSegments {
+		return false
+	}
+	for _, segment := range segments {
+		if segment == "" {
+			return false
+		}
+		for index, character := range segment {
+			if unicode.IsControl(character) ||
+				index == 0 && !isProtoFieldStart(character) ||
+				index > 0 && !isProtoFieldContinue(character) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isProtoFieldStart(character rune) bool {
+	return character == '_' ||
+		character >= 'a' && character <= 'z' ||
+		character >= 'A' && character <= 'Z'
+}
+
+func isProtoFieldContinue(character rune) bool {
+	return isProtoFieldStart(character) ||
+		character >= '0' && character <= '9'
+}
+
+func lookupProtoField(
+	fields protoreflect.FieldDescriptors,
+	name string,
+) protoreflect.FieldDescriptor {
+	if field := fields.ByName(protoreflect.Name(name)); field != nil {
+		return field
+	}
+	for index := range fields.Len() {
+		field := fields.Get(index)
+		if field.JSONName() == name {
+			return field
+		}
+	}
+	return nil
+}
+
+func wrapProtoBodyField(
+	payload []byte,
+	path []protoreflect.FieldDescriptor,
+) ([]byte, error) {
+	payload = bytes.TrimSpace(payload)
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	if !json.Valid(payload) {
+		return nil, fmt.Errorf("http: proto body field contains invalid JSON")
+	}
+	result := append([]byte(nil), payload...)
+	for index := len(path) - 1; index >= 0; index-- {
+		key, err := json.Marshal(path[index].JSONName())
+		if err != nil {
+			return nil, fmt.Errorf("http: encode proto body field: %w", err)
+		}
+		wrapped := make([]byte, 0, len(key)+len(result)+3)
+		wrapped = append(wrapped, '{')
+		wrapped = append(wrapped, key...)
+		wrapped = append(wrapped, ':')
+		wrapped = append(wrapped, result...)
+		wrapped = append(wrapped, '}')
+		result = wrapped
+	}
+	return result, nil
+}
+
+func marshalProtoBodyField(
+	message protoreflect.Message,
+	path []protoreflect.FieldDescriptor,
+) ([]byte, error) {
+	payload, err := (protojson.MarshalOptions{
+		UseProtoNames:   false,
+		EmitUnpopulated: true,
+	}).Marshal(message.Interface())
+	if err != nil {
+		return nil, fmt.Errorf("http: encode proto body field: %w", err)
+	}
+	current := json.RawMessage(payload)
+	for _, field := range path {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(current, &object); err != nil {
+			return nil, fmt.Errorf("http: select proto body field: %w", err)
+		}
+		selected, exists := object[field.JSONName()]
+		if !exists {
+			return []byte("null"), nil
+		}
+		current = selected
+	}
+	return append([]byte(nil), current...), nil
+}
+
+func setProtoBoundField(
+	parent protoreflect.Message,
+	field protoreflect.FieldDescriptor,
+	value protoreflect.Value,
+	source string,
+) error {
+	if parent == nil || !parent.IsValid() || field == nil {
+		return fmt.Errorf("http: invalid proto %s field binding", source)
+	}
+	oneof := field.ContainingOneof()
+	if oneof != nil && !oneof.IsSynthetic() {
+		if current := parent.WhichOneof(oneof); current != nil &&
+			current.Number() != field.Number() {
+			return fmt.Errorf(
+				"http: proto %s field %q conflicts with active oneof %q member %q",
+				source,
+				field.Name(),
+				oneof.Name(),
+				current.Name(),
+			)
+		}
+	}
+	parent.Set(field, value)
+	return nil
+}

--- a/transport/http/proto_client.go
+++ b/transport/http/proto_client.go
@@ -1,0 +1,480 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/keelab/keelith/internal/httptemplate"
+	"github.com/keelab/keelith/internal/protowkt"
+	"github.com/keelab/keelith/operation"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// NormalizeClientBaseURL validates and normalizes a generated client's base
+// URL. A path prefix is allowed; credentials, query, and fragments are not.
+func NormalizeClientBaseURL(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	parsed, err := url.Parse(value)
+	if err != nil ||
+		parsed.Scheme != "http" && parsed.Scheme != "https" ||
+		parsed.Host == "" ||
+		parsed.User != nil ||
+		parsed.Opaque != "" ||
+		parsed.RawQuery != "" ||
+		parsed.Fragment != "" {
+		return "", fmt.Errorf("%w: unsafe HTTP base URL %q", ErrInvalidCall, raw)
+	}
+	if strings.Contains(parsed.Path, "..") {
+		return "", fmt.Errorf("%w: unsafe HTTP base path", ErrInvalidCall)
+	}
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
+	parsed.RawPath = strings.TrimSuffix(parsed.RawPath, "/")
+	return parsed.String(), nil
+}
+
+// NewProtoRequest creates one generated-client request from an annotated
+// Protobuf mapping.
+//
+// body may be empty, "*", or a Protobuf field path. Path/body fields are
+// removed from query parameters. Path fields are also removed from an "*"
+// body and overlay the request on the server.
+func NewProtoRequest(
+	ctx context.Context,
+	baseURL string,
+	method string,
+	pathTemplate string,
+	input proto.Message,
+	body string,
+) (*nethttp.Request, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: context is nil", ErrInvalidCall)
+	}
+	if isNilProto(input) {
+		return nil, fmt.Errorf("%w: proto request is nil", ErrInvalidCall)
+	}
+	normalizedBase, err := NormalizeClientBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	method = strings.ToUpper(strings.TrimSpace(method))
+	switch method {
+	case nethttp.MethodGet, nethttp.MethodPost, nethttp.MethodPut,
+		nethttp.MethodPatch, nethttp.MethodDelete, nethttp.MethodHead,
+		nethttp.MethodOptions:
+	default:
+		return nil, fmt.Errorf(
+			"%w: unsupported HTTP method %q",
+			ErrInvalidCall,
+			method,
+		)
+	}
+	if body != "" && body != "*" && !validProtoFieldPath(body) {
+		return nil, fmt.Errorf(
+			"%w: unsupported proto body mapping %q",
+			ErrInvalidCall,
+			body,
+		)
+	}
+	if (method == nethttp.MethodGet || method == nethttp.MethodDelete ||
+		method == nethttp.MethodHead) &&
+		body != "" {
+		return nil, fmt.Errorf(
+			"%w: %s request cannot have a body",
+			ErrInvalidCall,
+			method,
+		)
+	}
+
+	reflection := input.ProtoReflect()
+	rawPath, pathFields, err := expandProtoPath(pathTemplate, reflection)
+	if err != nil {
+		return nil, err
+	}
+	target, err := joinProtoClientURL(normalizedBase, rawPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var content io.Reader
+	contentType := ""
+	queryExclusions := append(
+		[][]protoreflect.FieldDescriptor(nil),
+		pathFields...,
+	)
+	if body == "*" {
+		message := proto.Clone(input)
+		cloned := message.ProtoReflect()
+		for _, fieldPath := range pathFields {
+			clearProtoFieldPath(cloned, fieldPath)
+		}
+		var payload []byte
+		var marshalErr error
+		if isProtoHTTPBodyDescriptor(cloned.Descriptor()) {
+			contentType, payload, marshalErr = MarshalProtoHTTPBody(message, "")
+		} else {
+			payload, marshalErr = (protojson.MarshalOptions{
+				UseProtoNames:   false,
+				EmitUnpopulated: false,
+			}).Marshal(message)
+		}
+		if marshalErr != nil {
+			return nil, fmt.Errorf(
+				"%w: encode proto request: %w",
+				ErrInvalidCall,
+				marshalErr,
+			)
+		}
+		content = bytes.NewReader(payload)
+	} else {
+		if body != "" {
+			bodyPath, bodyErr := resolveProtoFieldPath(reflection, body)
+			if bodyErr != nil {
+				return nil, bodyErr
+			}
+			for _, pathField := range pathFields {
+				if protoFieldPathsOverlap(pathField, bodyPath) {
+					return nil, fmt.Errorf(
+						"%w: proto body field %q overlaps an HTTP path field",
+						ErrInvalidCall,
+						body,
+					)
+				}
+			}
+			var payload []byte
+			var marshalErr error
+			if protoFieldPathUsesHTTPBody(bodyPath) {
+				contentType, payload, marshalErr = MarshalProtoHTTPBody(input, body)
+			} else {
+				payload, marshalErr = marshalProtoBodyField(reflection, bodyPath)
+			}
+			if marshalErr != nil {
+				return nil, marshalErr
+			}
+			content = bytes.NewReader(payload)
+			queryExclusions = append(
+				queryExclusions,
+				bodyPath,
+			)
+		}
+		query, queryErr := protoQuery(reflection, queryExclusions)
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		target.RawQuery = query.Encode()
+	}
+
+	request, err := nethttp.NewRequestWithContext(
+		ctx,
+		method,
+		target.String(),
+		content,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build proto request: %w", ErrInvalidCall, err)
+	}
+	request.Header.Set("Accept", "application/json")
+	if body != "" {
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		request.Header.Set("Content-Type", contentType)
+	}
+	return request, nil
+}
+
+// InvokeProto invokes a generated request and strictly decodes protojson.
+func InvokeProto[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+) (T, error) {
+	return invokeProto(ctx, client, target, request, factory, "")
+}
+
+// InvokeProtoResponseBody invokes a generated request and reconstructs one
+// google.api.HttpRule.response_body field path into the output message.
+func InvokeProtoResponseBody[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+	responseBody string,
+) (T, error) {
+	return invokeProto(ctx, client, target, request, factory, responseBody)
+}
+
+// InvokeProtoHTTPBody invokes a generated request and reconstructs a raw
+// google.api.HttpBody response or selected nested HttpBody field.
+func InvokeProtoHTTPBody[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+	responseBody string,
+) (T, error) {
+	var zero T
+	if client == nil || request == nil || factory == nil {
+		return zero, fmt.Errorf(
+			"%w: proto client, request, or factory is nil",
+			ErrInvalidCall,
+		)
+	}
+	request.Header.Set("Accept", "*/*")
+	response, err := client.Invoke(ctx, target, ClientCall{
+		Request: request,
+		Decode: func(
+			_ context.Context,
+			response *nethttp.Response,
+		) (any, error) {
+			message := factory()
+			if isNilProto(message) {
+				return nil, fmt.Errorf(
+					"%w: proto response factory returned nil",
+					ErrInvalidCall,
+				)
+			}
+			payload, readErr := io.ReadAll(response.Body)
+			if readErr != nil {
+				return nil, readErr
+			}
+			if unmarshalErr := UnmarshalProtoHTTPBody(
+				payload,
+				message,
+				responseBody,
+				response.Header.Get("Content-Type"),
+			); unmarshalErr != nil {
+				return nil, unmarshalErr
+			}
+			return message, nil
+		},
+	})
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := response.(T)
+	if !ok || isNilProto(typed) {
+		return zero, fmt.Errorf(
+			"%w: proto response type %T",
+			ErrInvalidCall,
+			response,
+		)
+	}
+	return typed, nil
+}
+
+func invokeProto[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+	responseBody string,
+) (T, error) {
+	var zero T
+	if client == nil || request == nil || factory == nil {
+		return zero, fmt.Errorf(
+			"%w: proto client, request, or factory is nil",
+			ErrInvalidCall,
+		)
+	}
+	response, err := client.Invoke(ctx, target, ClientCall{
+		Request: request,
+		Decode: func(
+			_ context.Context,
+			response *nethttp.Response,
+		) (any, error) {
+			message := factory()
+			if isNilProto(message) {
+				return nil, fmt.Errorf(
+					"%w: proto response factory returned nil",
+					ErrInvalidCall,
+				)
+			}
+			payload, readErr := io.ReadAll(response.Body)
+			if readErr != nil {
+				return nil, readErr
+			}
+			if unmarshalErr := UnmarshalProtoResponseBody(
+				payload,
+				message,
+				responseBody,
+			); unmarshalErr != nil {
+				return nil, unmarshalErr
+			}
+			return message, nil
+		},
+	})
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := response.(T)
+	if !ok || isNilProto(typed) {
+		return zero, fmt.Errorf(
+			"%w: proto response type %T",
+			ErrInvalidCall,
+			response,
+		)
+	}
+	return typed, nil
+}
+
+func expandProtoPath(
+	template string,
+	message protoreflect.Message,
+) (string, [][]protoreflect.FieldDescriptor, error) {
+	parsedTemplate, err := httptemplate.Parse(template)
+	if err != nil {
+		return "", nil, fmt.Errorf(
+			"%w: unsafe HTTP path template %q: %w",
+			ErrInvalidCall,
+			template,
+			err,
+		)
+	}
+	selected := make([][]protoreflect.FieldDescriptor, 0)
+	values := make(map[string]string)
+	for _, variable := range parsedTemplate.Variables() {
+		fieldPath, resolveErr := resolveProtoPathField(message, variable.FieldPath)
+		if resolveErr != nil {
+			return "", nil, fmt.Errorf(
+				"%w: path field %q: %w",
+				ErrInvalidCall,
+				variable.FieldPath,
+				resolveErr,
+			)
+		}
+		parent, exists := protoPathParent(message, fieldPath, false)
+		field := fieldPath[len(fieldPath)-1]
+		if variable.RequiresString() && field.Kind() != protoreflect.StringKind {
+			return "", nil, fmt.Errorf(
+				"%w: assigned path field %q must be string",
+				ErrInvalidCall,
+				variable.FieldPath,
+			)
+		}
+		if !exists || !parent.Has(field) {
+			return "", nil, fmt.Errorf(
+				"%w: path field %q is empty",
+				ErrInvalidCall,
+				variable.FieldPath,
+			)
+		}
+		formatted, formatErr := formatProtoScalar(field, parent.Get(field))
+		if formatErr != nil {
+			return "", nil, fmt.Errorf(
+				"%w: path field %q: %w",
+				ErrInvalidCall,
+				variable.FieldPath,
+				formatErr,
+			)
+		}
+		values[variable.FieldPath] = formatted
+		selected = append(selected, fieldPath)
+	}
+	result, err := parsedTemplate.Expand(values)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %w", ErrInvalidCall, err)
+	}
+	return result, selected, nil
+}
+
+func joinProtoClientURL(baseURL, rawPath string) (*url.URL, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse base URL: %w", ErrInvalidCall, err)
+	}
+	combinedRaw := strings.TrimSuffix(base.EscapedPath(), "/") + rawPath
+	combinedPath, err := url.PathUnescape(combinedRaw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid escaped HTTP path", ErrInvalidCall)
+	}
+	base.Path = combinedPath
+	base.RawPath = combinedRaw
+	return base, nil
+}
+
+func protoQuery(
+	message protoreflect.Message,
+	excluded [][]protoreflect.FieldDescriptor,
+) (url.Values, error) {
+	query := make(url.Values)
+	projection := proto.Clone(message.Interface()).ProtoReflect()
+	for _, fieldPath := range excluded {
+		clearProtoFieldPath(projection, fieldPath)
+	}
+	valueCount := 0
+	stack := map[protoreflect.FullName]struct{}{
+		message.Descriptor().FullName(): {},
+	}
+	if err := appendProtoQuery(
+		projection,
+		"",
+		query,
+		&valueCount,
+		stack,
+		1,
+	); err != nil {
+		return nil, err
+	}
+	return query, nil
+}
+
+func formatProtoScalar(
+	field protoreflect.FieldDescriptor,
+	value protoreflect.Value,
+) (string, error) {
+	if field.Message() != nil {
+		kind := protowkt.QueryKindFor(string(field.Message().FullName()))
+		if kind == protowkt.QueryUnsupported {
+			return "", fmt.Errorf("field kind %s is unsupported", field.Kind())
+		}
+		payload, err := (protojson.MarshalOptions{
+			UseProtoNames:   false,
+			EmitUnpopulated: false,
+		}).Marshal(value.Message().Interface())
+		if err != nil {
+			return "", fmt.Errorf("encode well-known query scalar: %w", err)
+		}
+		return protowkt.JSONToQuery(kind, payload)
+	}
+	switch field.Kind() {
+	case protoreflect.BoolKind:
+		return strconv.FormatBool(value.Bool()), nil
+	case protoreflect.EnumKind:
+		enum := field.Enum().Values().ByNumber(value.Enum())
+		if enum == nil {
+			return strconv.FormatInt(int64(value.Enum()), 10), nil
+		}
+		return string(enum.Name()), nil
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind,
+		protoreflect.Sfixed32Kind, protoreflect.Int64Kind,
+		protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return strconv.FormatInt(value.Int(), 10), nil
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind,
+		protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return strconv.FormatUint(value.Uint(), 10), nil
+	case protoreflect.FloatKind:
+		return strconv.FormatFloat(value.Float(), 'g', -1, 32), nil
+	case protoreflect.DoubleKind:
+		return strconv.FormatFloat(value.Float(), 'g', -1, 64), nil
+	case protoreflect.StringKind:
+		return value.String(), nil
+	case protoreflect.BytesKind:
+		return base64.StdEncoding.EncodeToString(value.Bytes()), nil
+	default:
+		return "", fmt.Errorf("field kind %s is unsupported", field.Kind())
+	}
+}

--- a/transport/http/proto_http_body.go
+++ b/transport/http/proto_http_body.go
@@ -1,0 +1,182 @@
+package http
+
+import (
+	"fmt"
+	"mime"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	protoHTTPBodyFullName            protoreflect.FullName = "google.api.HttpBody"
+	defaultProtoHTTPContentType      string                = "application/octet-stream"
+	maximumProtoHTTPContentTypeBytes int                   = 512
+)
+
+// MarshalProtoHTTPBody extracts the wire media type and raw payload from a
+// google.api.HttpBody response. responseBody may select a nested singular
+// HttpBody field from a larger output message.
+func MarshalProtoHTTPBody(
+	response any,
+	responseBody string,
+) (string, []byte, error) {
+	message, ok := response.(proto.Message)
+	if !ok || isNilProto(message) {
+		return "", nil, fmt.Errorf(
+			"http: response type %T is not a Protobuf message",
+			response,
+		)
+	}
+	selected, err := selectProtoHTTPBody(message, responseBody, false)
+	if err != nil {
+		return "", nil, err
+	}
+	if selected == nil {
+		return defaultProtoHTTPContentType, nil, nil
+	}
+	contentTypeField, dataField, err := protoHTTPBodyFields(selected.Descriptor())
+	if err != nil {
+		return "", nil, err
+	}
+	contentType, err := normalizeProtoHTTPContentType(
+		selected.Get(contentTypeField).String(),
+	)
+	if err != nil {
+		return "", nil, err
+	}
+	payload := append([]byte(nil), selected.Get(dataField).Bytes()...)
+	return contentType, payload, nil
+}
+
+// UnmarshalProtoHTTPBody assigns one raw HTTP payload to a
+// google.api.HttpBody message or selected nested field. Extensions are not
+// represented on the HTTP wire and are left untouched.
+func UnmarshalProtoHTTPBody(
+	payload []byte,
+	message proto.Message,
+	responseBody string,
+	contentType string,
+) error {
+	if isNilProto(message) {
+		return fmt.Errorf("http: Protobuf HttpBody is nil")
+	}
+	normalized, err := normalizeProtoHTTPContentType(contentType)
+	if err != nil {
+		return err
+	}
+	selected, err := selectProtoHTTPBody(message, responseBody, true)
+	if err != nil {
+		return err
+	}
+	if selected == nil {
+		return fmt.Errorf("http: cannot allocate HttpBody field %q", responseBody)
+	}
+	contentTypeField, dataField, err := protoHTTPBodyFields(selected.Descriptor())
+	if err != nil {
+		return err
+	}
+	selected.Set(contentTypeField, protoreflect.ValueOfString(normalized))
+	selected.Set(
+		dataField,
+		protoreflect.ValueOfBytes(append([]byte(nil), payload...)),
+	)
+	return nil
+}
+
+func selectProtoHTTPBody(
+	message proto.Message,
+	fieldPath string,
+	mutable bool,
+) (protoreflect.Message, error) {
+	root := message.ProtoReflect()
+	if fieldPath == "" {
+		if !isProtoHTTPBodyDescriptor(root.Descriptor()) {
+			return nil, fmt.Errorf(
+				"http: Protobuf message %s is not google.api.HttpBody",
+				root.Descriptor().FullName(),
+			)
+		}
+		return root, nil
+	}
+	path, err := resolveProtoFieldPath(root, fieldPath)
+	if err != nil {
+		return nil, err
+	}
+	field := path[len(path)-1]
+	if field.IsList() || field.IsMap() ||
+		!isProtoHTTPBodyDescriptor(field.Message()) {
+		return nil, fmt.Errorf(
+			"http: proto field %q is not a singular google.api.HttpBody",
+			fieldPath,
+		)
+	}
+	parent, exists := protoPathParent(root, path, mutable)
+	if !exists {
+		return nil, nil
+	}
+	if mutable {
+		return parent.Mutable(field).Message(), nil
+	}
+	if !parent.Has(field) {
+		return nil, nil
+	}
+	return parent.Get(field).Message(), nil
+}
+
+func isProtoHTTPBodyDescriptor(
+	descriptor protoreflect.MessageDescriptor,
+) bool {
+	return descriptor != nil && descriptor.FullName() == protoHTTPBodyFullName
+}
+
+func protoFieldPathUsesHTTPBody(
+	path []protoreflect.FieldDescriptor,
+) bool {
+	if len(path) == 0 {
+		return false
+	}
+	field := path[len(path)-1]
+	return !field.IsList() && !field.IsMap() &&
+		isProtoHTTPBodyDescriptor(field.Message())
+}
+
+func protoHTTPBodyFields(
+	descriptor protoreflect.MessageDescriptor,
+) (protoreflect.FieldDescriptor, protoreflect.FieldDescriptor, error) {
+	if !isProtoHTTPBodyDescriptor(descriptor) {
+		return nil, nil, fmt.Errorf(
+			"http: Protobuf message %s is not google.api.HttpBody",
+			descriptor.FullName(),
+		)
+	}
+	contentType := descriptor.Fields().ByName("content_type")
+	data := descriptor.Fields().ByName("data")
+	if contentType == nil || contentType.IsList() || contentType.IsMap() ||
+		contentType.Kind() != protoreflect.StringKind ||
+		data == nil || data.IsList() || data.IsMap() ||
+		data.Kind() != protoreflect.BytesKind {
+		return nil, nil, fmt.Errorf(
+			"http: invalid google.api.HttpBody descriptor %s",
+			descriptor.FullName(),
+		)
+	}
+	return contentType, data, nil
+}
+
+func normalizeProtoHTTPContentType(value string) (string, error) {
+	if value == "" {
+		return defaultProtoHTTPContentType, nil
+	}
+	if len(value) > maximumProtoHTTPContentTypeBytes ||
+		strings.ContainsAny(value, "\r\n\x00") ||
+		strings.TrimSpace(value) != value {
+		return "", fmt.Errorf("http: invalid HttpBody Content-Type %q", value)
+	}
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || mediaType == "" {
+		return "", fmt.Errorf("http: invalid HttpBody Content-Type %q", value)
+	}
+	return mime.FormatMediaType(mediaType, parameters), nil
+}

--- a/transport/http/proto_path.go
+++ b/transport/http/proto_path.go
@@ -1,0 +1,197 @@
+package http
+
+import (
+	"fmt"
+	nethttp "net/http"
+	"strings"
+
+	"github.com/keelab/keelith/internal/httptemplate"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type protoPathBinding struct {
+	fieldPath string
+	valueName string
+}
+
+func resolveProtoPathField(
+	message protoreflect.Message,
+	fieldPath string,
+) ([]protoreflect.FieldDescriptor, error) {
+	if !message.IsValid() || !validProtoFieldPath(fieldPath) {
+		return nil, fmt.Errorf("http: invalid proto path field %q", fieldPath)
+	}
+	segments := strings.Split(fieldPath, ".")
+	result := make([]protoreflect.FieldDescriptor, 0, len(segments))
+	descriptor := message.Descriptor()
+	for index, segment := range segments {
+		field := lookupProtoField(descriptor.Fields(), segment)
+		if field == nil {
+			return nil, fmt.Errorf(
+				"http: proto path field %q is absent from %s",
+				strings.Join(segments[:index+1], "."),
+				descriptor.FullName(),
+			)
+		}
+		result = append(result, field)
+		last := index == len(segments)-1
+		if last {
+			if field.IsList() || field.IsMap() || field.Message() != nil {
+				return nil, fmt.Errorf(
+					"http: proto path field %q must be scalar",
+					fieldPath,
+				)
+			}
+			continue
+		}
+		if field.IsList() || field.IsMap() || field.Message() == nil {
+			return nil, fmt.Errorf(
+				"http: proto path field %q is not a singular message",
+				strings.Join(segments[:index+1], "."),
+			)
+		}
+		descriptor = field.Message()
+	}
+	return result, nil
+}
+
+func protoPathParent(
+	message protoreflect.Message,
+	path []protoreflect.FieldDescriptor,
+	mutable bool,
+) (protoreflect.Message, bool) {
+	current := message
+	for _, field := range path[:len(path)-1] {
+		if !mutable && !current.Has(field) {
+			return nil, false
+		}
+		if mutable {
+			current = current.Mutable(field).Message()
+		} else {
+			current = current.Get(field).Message()
+		}
+	}
+	return current, true
+}
+
+func clearProtoFieldPath(
+	message protoreflect.Message,
+	path []protoreflect.FieldDescriptor,
+) {
+	if len(path) == 0 {
+		return
+	}
+	parent, exists := protoPathParent(message, path, false)
+	if !exists {
+		return
+	}
+	parent.Clear(path[len(path)-1])
+}
+
+func sameProtoFieldPath(
+	left []protoreflect.FieldDescriptor,
+	right []protoreflect.FieldDescriptor,
+) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index].FullName() != right[index].FullName() {
+			return false
+		}
+	}
+	return true
+}
+
+func protoFieldPathsOverlap(
+	left []protoreflect.FieldDescriptor,
+	right []protoreflect.FieldDescriptor,
+) bool {
+	if len(left) == 0 || len(right) == 0 {
+		return false
+	}
+	limit := len(left)
+	if len(right) < limit {
+		limit = len(right)
+	}
+	for index := 0; index < limit; index++ {
+		if left[index].FullName() != right[index].FullName() {
+			return false
+		}
+	}
+	return true
+}
+
+func protoFieldPathKey(path []protoreflect.FieldDescriptor) string {
+	parts := make([]string, 0, len(path))
+	for _, field := range path {
+		parts = append(parts, string(field.FullName()))
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func validProtoPathValueName(value string) bool {
+	return validProtoFieldPath(value) && !strings.Contains(value, ".")
+}
+
+func validateProtoPathTemplate(raw string) error {
+	if _, err := httptemplate.Parse(raw); err != nil {
+		return fmt.Errorf("http: invalid proto path template: %w", err)
+	}
+	return nil
+}
+
+func bindProtoPathTemplate(
+	request *nethttp.Request,
+	message protoreflect.Message,
+	raw string,
+) ([][]protoreflect.FieldDescriptor, error) {
+	template, err := httptemplate.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("http: invalid proto path template: %w", err)
+	}
+	if request == nil || request.URL == nil {
+		return nil, fmt.Errorf("http: request path is unavailable")
+	}
+	values, err := template.Match(request.URL.EscapedPath())
+	if err != nil {
+		return nil, fmt.Errorf("http: proto path template: %w", err)
+	}
+	variables := template.Variables()
+	result := make([][]protoreflect.FieldDescriptor, 0, len(variables))
+	for _, variable := range variables {
+		path, resolveErr := resolveProtoPathField(message, variable.FieldPath)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		field := path[len(path)-1]
+		if variable.RequiresString() && field.Kind() != protoreflect.StringKind {
+			return nil, fmt.Errorf(
+				"http: assigned proto path field %q must be string",
+				variable.FieldPath,
+			)
+		}
+		parent, _ := protoPathParent(message, path, true)
+		parsed, parseErr := parseProtoScalar(
+			parent,
+			field,
+			values[variable.FieldPath],
+		)
+		if parseErr != nil {
+			return nil, fmt.Errorf(
+				"http: path field %q: %w",
+				variable.FieldPath,
+				parseErr,
+			)
+		}
+		if err := setProtoBoundField(parent, field, parsed, "path"); err != nil {
+			return nil, fmt.Errorf(
+				"http: path field %q: %w",
+				variable.FieldPath,
+				err,
+			)
+		}
+		result = append(result, path)
+	}
+	return result, nil
+}

--- a/transport/http/proto_query.go
+++ b/transport/http/proto_query.go
@@ -1,0 +1,223 @@
+package http
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/keelab/keelith/internal/protowkt"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	maxProtoQueryDepth  = 16
+	maxProtoQueryValues = 256
+)
+
+func resolveProtoQueryPath(
+	descriptor protoreflect.MessageDescriptor,
+	path string,
+) ([]protoreflect.FieldDescriptor, bool, error) {
+	if !validProtoFieldPath(path) {
+		return nil, false, fmt.Errorf("http: invalid query field path %q", path)
+	}
+	segments := strings.Split(path, ".")
+	fields := make([]protoreflect.FieldDescriptor, 0, len(segments))
+	current := descriptor
+	for index, segment := range segments {
+		field := lookupProtoField(current.Fields(), segment)
+		if field == nil {
+			return nil, false, nil
+		}
+		fields = append(fields, field)
+		last := index == len(segments)-1
+		if last {
+			queryKind := protowkt.QueryUnsupported
+			if field.Message() != nil {
+				queryKind = protowkt.QueryKindFor(
+					string(field.Message().FullName()),
+				)
+			}
+			if field.IsMap() || field.IsList() && field.Message() != nil ||
+				field.Message() != nil && queryKind == protowkt.QueryUnsupported {
+				return fields, true, fmt.Errorf(
+					"http: query field %q has unsupported message/map type",
+					path,
+				)
+			}
+			continue
+		}
+		if field.IsList() || field.IsMap() || field.Message() == nil ||
+			protowkt.QueryKindFor(string(field.Message().FullName())) !=
+				protowkt.QueryUnsupported {
+			return fields, true, fmt.Errorf(
+				"http: query field %q has unsupported message/map type",
+				path,
+			)
+		}
+		current = field.Message()
+	}
+	return fields, true, nil
+}
+
+func mutableProtoQueryParent(
+	message protoreflect.Message,
+	fields []protoreflect.FieldDescriptor,
+) protoreflect.Message {
+	current := message
+	for _, field := range fields[:len(fields)-1] {
+		current = current.Mutable(field).Message()
+	}
+	return current
+}
+
+func appendProtoQuery(
+	message protoreflect.Message,
+	prefix string,
+	query url.Values,
+	values *int,
+	stack map[protoreflect.FullName]struct{},
+	depth int,
+) error {
+	if depth > maxProtoQueryDepth {
+		return fmt.Errorf(
+			"%w: query field %q exceeds maximum nesting depth %d",
+			ErrInvalidCall,
+			prefix,
+			maxProtoQueryDepth,
+		)
+	}
+	fields := message.Descriptor().Fields()
+	for index := range fields.Len() {
+		field := fields.Get(index)
+		name := field.JSONName()
+		if prefix != "" {
+			name = prefix + "." + name
+		}
+		if field.IsMap() {
+			if message.Get(field).Map().Len() > 0 {
+				return unsupportedProtoQueryShape(name)
+			}
+			continue
+		}
+		if field.Message() != nil {
+			queryKind := protowkt.QueryKindFor(
+				string(field.Message().FullName()),
+			)
+			if queryKind != protowkt.QueryUnsupported {
+				if field.IsList() {
+					if message.Get(field).List().Len() > 0 {
+						return unsupportedProtoQueryShape(name)
+					}
+					continue
+				}
+				if !message.Has(field) {
+					continue
+				}
+				if err := reserveProtoQueryValue(values, name); err != nil {
+					return err
+				}
+				value, err := formatProtoScalar(field, message.Get(field))
+				if err != nil {
+					return fmt.Errorf(
+						"%w: query field %q: %w",
+						ErrInvalidCall,
+						name,
+						err,
+					)
+				}
+				query.Set(name, value)
+				continue
+			}
+			if field.IsList() {
+				if message.Get(field).List().Len() > 0 {
+					return unsupportedProtoQueryShape(name)
+				}
+				continue
+			}
+			if !message.Has(field) {
+				continue
+			}
+			fullName := field.Message().FullName()
+			if _, recursive := stack[fullName]; recursive {
+				return fmt.Errorf(
+					"%w: query field %q has recursive message type %s",
+					ErrInvalidCall,
+					name,
+					fullName,
+				)
+			}
+			stack[fullName] = struct{}{}
+			err := appendProtoQuery(
+				message.Get(field).Message(),
+				name,
+				query,
+				values,
+				stack,
+				depth+1,
+			)
+			delete(stack, fullName)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		if field.IsList() {
+			list := message.Get(field).List()
+			for item := range list.Len() {
+				if err := reserveProtoQueryValue(values, name); err != nil {
+					return err
+				}
+				value, err := formatProtoScalar(field, list.Get(item))
+				if err != nil {
+					return fmt.Errorf(
+						"%w: query field %q: %w",
+						ErrInvalidCall,
+						name,
+						err,
+					)
+				}
+				query.Add(name, value)
+			}
+			continue
+		}
+		if !message.Has(field) {
+			continue
+		}
+		if err := reserveProtoQueryValue(values, name); err != nil {
+			return err
+		}
+		value, err := formatProtoScalar(field, message.Get(field))
+		if err != nil {
+			return fmt.Errorf(
+				"%w: query field %q: %w",
+				ErrInvalidCall,
+				name,
+				err,
+			)
+		}
+		query.Set(name, value)
+	}
+	return nil
+}
+
+func reserveProtoQueryValue(values *int, field string) error {
+	*values++
+	if *values > maxProtoQueryValues {
+		return fmt.Errorf(
+			"%w: query field %q exceeds maximum value count %d",
+			ErrInvalidCall,
+			field,
+			maxProtoQueryValues,
+		)
+	}
+	return nil
+}
+
+func unsupportedProtoQueryShape(field string) error {
+	return fmt.Errorf(
+		"%w: query field %q has unsupported message/map type",
+		ErrInvalidCall,
+		field,
+	)
+}

--- a/transport/http/proto_response_body.go
+++ b/transport/http/proto_response_body.go
@@ -1,0 +1,107 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// ValidateProtoResponseBody validates one optional standard
+// google.api.HttpRule response_body field against a concrete output message.
+func ValidateProtoResponseBody(message proto.Message, responseBody string) error {
+	if isNilProto(message) {
+		return fmt.Errorf("http: Protobuf response is nil")
+	}
+	if responseBody == "" {
+		return nil
+	}
+	_, err := protoResponseBodyPath(message.ProtoReflect(), responseBody)
+	return err
+}
+
+// MarshalProtoResponseBody encodes a complete Protobuf response or one
+// field path selected by google.api.HttpRule.response_body.
+func MarshalProtoResponseBody(response any, responseBody string) ([]byte, error) {
+	message, ok := response.(proto.Message)
+	if !ok || isNilProto(message) {
+		return nil, fmt.Errorf(
+			"http: response type %T is not a Protobuf message",
+			response,
+		)
+	}
+	if responseBody == "" {
+		payload, err := (protojson.MarshalOptions{
+			UseProtoNames:   false,
+			EmitUnpopulated: false,
+		}).Marshal(message)
+		if err != nil {
+			return nil, err
+		}
+		return payload, nil
+	}
+	path, err := protoResponseBodyPath(message.ProtoReflect(), responseBody)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := marshalProtoBodyField(
+		message.ProtoReflect(),
+		path,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("http: encode proto response body: %w", err)
+	}
+	return payload, nil
+}
+
+// UnmarshalProtoResponseBody decodes a complete Protobuf response or wraps a
+// selected response_body field path back into its output message.
+func UnmarshalProtoResponseBody(
+	payload []byte,
+	message proto.Message,
+	responseBody string,
+) error {
+	if isNilProto(message) {
+		return fmt.Errorf("http: Protobuf response is nil")
+	}
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return ValidateProtoResponseBody(message, responseBody)
+	}
+	if responseBody != "" {
+		path, err := protoResponseBodyPath(message.ProtoReflect(), responseBody)
+		if err != nil {
+			return err
+		}
+		trimmed, err = wrapProtoBodyField(
+			trimmed,
+			path,
+		)
+		if err != nil {
+			return fmt.Errorf("http: decode proto response body: %w", err)
+		}
+	}
+	if err := (protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}).Unmarshal(trimmed, message); err != nil {
+		return err
+	}
+	return nil
+}
+
+func protoResponseBodyPath(
+	message protoreflect.Message,
+	responseBody string,
+) ([]protoreflect.FieldDescriptor, error) {
+	path, err := resolveProtoFieldPath(message, responseBody)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"http: invalid proto response body field %q: %w",
+			responseBody,
+			err,
+		)
+	}
+	return path, nil
+}

--- a/transport/http/request_info.go
+++ b/transport/http/request_info.go
@@ -1,0 +1,20 @@
+package http
+
+import (
+	"github.com/keelab/keelith/operation"
+)
+
+func newRequestInfo(
+	target operation.Operation,
+	network string,
+	address string,
+) (operation.RequestInfo, error) {
+	if network == "" || address == "" {
+		return operation.NewRequestInfo(target)
+	}
+	peer, err := operation.NewPeer(network, address)
+	if err != nil {
+		return operation.RequestInfo{}, err
+	}
+	return operation.NewRequestInfo(target, operation.WithPeer(peer))
+}

--- a/transport/http/router.go
+++ b/transport/http/router.go
@@ -1,6 +1,774 @@
-// Package http adapts standard HTTP routes to transport-neutral handlers.
 package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	kerrors "github.com/keelab/keelith/errors"
+	"github.com/keelab/keelith/internal/httptemplate"
+	"github.com/keelab/keelith/metadata"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const defaultMaxResponseBytes = int64(4 * 1024 * 1024)
+
+// RouterOption configures a Router.
+type RouterOption interface {
+	applyRouter(*routerOptions) error
+}
+
+type routerOptionFunc func(*routerOptions) error
+
+func (function routerOptionFunc) applyRouter(options *routerOptions) error {
+	return function(options)
+}
+
+type routerOptions struct {
+	bundle            *middleware.Bundle
+	metadataPolicy    metadata.Policy
+	maxResponseBytes  int64
+	errorEncoder      ErrorEncoder
+	errorMetadataKeys []string
+	propagator        propagation.TextMapPropagator
+}
+
+// WithMiddleware configures the immutable inbound middleware Bundle.
+func WithMiddleware(bundle *middleware.Bundle) RouterOption {
+	return routerOptionFunc(func(options *routerOptions) error {
+		if bundle == nil {
+			return fmt.Errorf("middleware bundle is nil")
+		}
+		options.bundle = bundle
+		return nil
+	})
+}
+
+// WithMetadataPolicy configures inbound HTTP header propagation.
+func WithMetadataPolicy(policy metadata.Policy) RouterOption {
+	return routerOptionFunc(func(options *routerOptions) error {
+		options.metadataPolicy = policy
+		return nil
+	})
+}
+
+// WithPropagator configures distributed context extraction.
+func WithPropagator(propagator propagation.TextMapPropagator) RouterOption {
+	return routerOptionFunc(func(options *routerOptions) error {
+		if propagator == nil {
+			return fmt.Errorf("propagator is nil")
+		}
+		options.propagator = propagator
+		return nil
+	})
+}
+
+// WithMaxResponseBytes sets the ordinary response body budget.
+func WithMaxResponseBytes(maxBytes int64) RouterOption {
+	return routerOptionFunc(func(options *routerOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max response bytes must be positive")
+		}
+		options.maxResponseBytes = maxBytes
+		return nil
+	})
+}
+
+// WithErrorMetadata allows selected framework Error metadata on the wire.
+func WithErrorMetadata(keys ...string) RouterOption {
+	snapshot := append([]string(nil), keys...)
+	return routerOptionFunc(func(options *routerOptions) error {
+		normalized, err := validateErrorMetadata(snapshot)
+		if err != nil {
+			return err
+		}
+		options.errorMetadataKeys = normalized
+		return nil
+	})
+}
+
+// WithErrorEncoder replaces the default JSON error encoder.
+func WithErrorEncoder(encoder ErrorEncoder) RouterOption {
+	return routerOptionFunc(func(options *routerOptions) error {
+		if encoder == nil {
+			return fmt.Errorf("error encoder is nil")
+		}
+		options.errorEncoder = encoder
+		return nil
+	})
+}
+
+// RouteOption configures one route.
+type RouteOption interface {
+	applyRoute(*routeOptions) error
+}
+
+type routeOptionFunc func(*routeOptions) error
+
+func (function routeOptionFunc) applyRoute(options *routeOptions) error {
+	return function(options)
+}
+
+type routeOptions struct {
+	streaming bool
+}
+
+// WithStreaming disables ordinary response buffering for a route.
+func WithStreaming() RouteOption {
+	return routeOptionFunc(func(options *routeOptions) error {
+		options.streaming = true
+		return nil
+	})
+}
 
 // Router maps standard HTTP routes to transport-neutral handlers.
 type Router struct {
+	mux              *nethttp.ServeMux
+	bundle           *middleware.Bundle
+	metadataPolicy   metadata.Policy
+	maxResponseBytes int64
+	errorEncoder     ErrorEncoder
+	propagator       propagation.TextMapPropagator
+
+	mu             sync.RWMutex
+	routes         map[string]struct{}
+	templateRoutes []templateRoute
+}
+
+type templateRoute struct {
+	method      string
+	template    *httptemplate.Template
+	handler     nethttp.Handler
+	specificity int
+}
+
+// NewRouter validates options and creates an isolated Router.
+func NewRouter(optionList ...RouterOption) (*Router, error) {
+	options := routerOptions{maxResponseBytes: defaultMaxResponseBytes}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: router option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyRouter(&options); err != nil {
+			return nil, fmt.Errorf("%w: router option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+	if options.errorEncoder == nil {
+		options.errorEncoder = newErrorEncoder(options.errorMetadataKeys)
+	}
+	return &Router{
+		mux:              nethttp.NewServeMux(),
+		bundle:           options.bundle,
+		metadataPolicy:   options.metadataPolicy,
+		maxResponseBytes: options.maxResponseBytes,
+		errorEncoder:     options.errorEncoder,
+		propagator:       options.propagator,
+		routes:           make(map[string]struct{}),
+	}, nil
+}
+
+// HandleTemplate registers a google.api.http path whose variable is followed
+// by a custom verb. Go ServeMux requires wildcards to occupy a full segment,
+// so these routes use a small exact matcher while ordinary routes remain on
+// ServeMux.
+func (router *Router) HandleTemplate(
+	method string,
+	pathTemplate string,
+	target operation.Operation,
+	decoder Decoder,
+	handler middleware.Handler,
+	encoder Encoder,
+	optionList ...RouteOption,
+) error {
+	if router == nil {
+		return fmt.Errorf("%w: router is nil", ErrInvalidRoute)
+	}
+	normalizedMethod := strings.ToUpper(strings.TrimSpace(method))
+	template, err := httptemplate.Parse(pathTemplate)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: custom-verb template %q: %w",
+			ErrInvalidRoute,
+			pathTemplate,
+			err,
+		)
+	}
+	if normalizedMethod == "" || template.Verb == "" ||
+		!template.EndsWithVariable() {
+		return fmt.Errorf(
+			"%w: method %q or custom-verb template %q is invalid",
+			ErrInvalidRoute,
+			method,
+			pathTemplate,
+		)
+	}
+	if target.Transport() != "http" {
+		return fmt.Errorf(
+			"%w: operation transport %q is not http",
+			ErrInvalidRoute,
+			target.Transport(),
+		)
+	}
+	if decoder == nil || handler == nil || encoder == nil {
+		return fmt.Errorf("%w: route codec or handler is nil", ErrInvalidRoute)
+	}
+	settings := routeOptions{}
+	for index, option := range optionList {
+		if option == nil {
+			return fmt.Errorf("%w: route option %d is nil", ErrInvalidRoute, index)
+		}
+		if err := option.applyRoute(&settings); err != nil {
+			return fmt.Errorf(
+				"%w: route option %d: %w",
+				ErrInvalidRoute,
+				index,
+				err,
+			)
+		}
+	}
+	key, err := canonicalTemplateRouteKey(normalizedMethod, template)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidRoute, err)
+	}
+	routeHandler := router.route(
+		target,
+		decoder,
+		handler,
+		encoder,
+		settings.streaming,
+	)
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	if _, duplicate := router.routes[key]; duplicate {
+		return fmt.Errorf("%w: duplicate %s", ErrInvalidRoute, key)
+	}
+	specificity := templateRouteSpecificity(template)
+	for _, existing := range router.templateRoutes {
+		if templateMethodsOverlap(existing.method, normalizedMethod) &&
+			existing.specificity == specificity &&
+			templateRoutesOverlap(existing.template, template) {
+			return fmt.Errorf(
+				"%w: ambiguous custom-verb template %s %s",
+				ErrInvalidRoute,
+				normalizedMethod,
+				pathTemplate,
+			)
+		}
+	}
+	router.routes[key] = struct{}{}
+	router.templateRoutes = append(router.templateRoutes, templateRoute{
+		method:      normalizedMethod,
+		template:    template,
+		handler:     routeHandler,
+		specificity: specificity,
+	})
+	return nil
+}
+
+// Handle registers one route with its stable Operation and codecs.
+func (router *Router) Handle(
+	method string,
+	pattern string,
+	target operation.Operation,
+	decoder Decoder,
+	handler middleware.Handler,
+	encoder Encoder,
+	optionList ...RouteOption,
+) error {
+	if router == nil {
+		return fmt.Errorf("%w: router is nil", ErrInvalidRoute)
+	}
+	normalizedMethod := strings.ToUpper(strings.TrimSpace(method))
+	if normalizedMethod == "" || !strings.HasPrefix(pattern, "/") {
+		return fmt.Errorf(
+			"%w: method %q or pattern %q is invalid",
+			ErrInvalidRoute,
+			method,
+			pattern,
+		)
+	}
+	if target.Transport() != "http" {
+		return fmt.Errorf(
+			"%w: operation transport %q is not http",
+			ErrInvalidRoute,
+			target.Transport(),
+		)
+	}
+	if decoder == nil || handler == nil || encoder == nil {
+		return fmt.Errorf("%w: route codec or handler is nil", ErrInvalidRoute)
+	}
+	settings := routeOptions{}
+	for index, option := range optionList {
+		if option == nil {
+			return fmt.Errorf("%w: route option %d is nil", ErrInvalidRoute, index)
+		}
+		if err := option.applyRoute(&settings); err != nil {
+			return fmt.Errorf("%w: route option %d: %w", ErrInvalidRoute, index, err)
+		}
+	}
+
+	key := normalizedMethod + " " + pattern
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	if _, duplicate := router.routes[key]; duplicate {
+		return fmt.Errorf("%w: duplicate %s", ErrInvalidRoute, key)
+	}
+	routeHandler := router.route(target, decoder, handler, encoder, settings.streaming)
+	if err := registerRoute(router.mux, key, routeHandler); err != nil {
+		return err
+	}
+	router.routes[key] = struct{}{}
+	return nil
+}
+
+// ServeHTTP dispatches a request to a registered route.
+func (router *Router) ServeHTTP(
+	writer nethttp.ResponseWriter,
+	request *nethttp.Request,
+) {
+	if router == nil || request == nil || request.URL == nil {
+		nethttp.Error(writer, "invalid request", nethttp.StatusBadRequest)
+		return
+	}
+	if !unsafeTemplateDispatchPath(request.URL.EscapedPath()) {
+		if candidate := router.matchTemplateRoute(request); candidate != nil {
+			_, muxPattern := router.mux.Handler(request)
+			if candidate.specificity > serveMuxPatternSpecificity(muxPattern) {
+				candidate.handler.ServeHTTP(writer, request)
+				return
+			}
+		}
+	}
+	router.mux.ServeHTTP(writer, request)
+}
+
+func (router *Router) matchTemplateRoute(
+	request *nethttp.Request,
+) *templateRoute {
+	method := strings.ToUpper(request.Method)
+	router.mu.RLock()
+	routes := append([]templateRoute(nil), router.templateRoutes...)
+	router.mu.RUnlock()
+	var selected *templateRoute
+	for index := range routes {
+		route := &routes[index]
+		if route.method != method && (route.method != "GET" || method != "HEAD") {
+			continue
+		}
+		if _, err := route.template.Match(request.URL.EscapedPath()); err != nil {
+			continue
+		}
+		exactMethod := route.method == method
+		selectedExactMethod := selected != nil && selected.method == method
+		if selected == nil ||
+			exactMethod && !selectedExactMethod ||
+			exactMethod == selectedExactMethod &&
+				route.specificity > selected.specificity {
+			selected = route
+		}
+	}
+	return selected
+}
+
+func canonicalTemplateRouteKey(
+	method string,
+	template *httptemplate.Template,
+) (string, error) {
+	route, err := template.Render(func(_ int, _ int, multi bool) string {
+		if multi {
+			return "{...}"
+		}
+		return "{}"
+	})
+	if err != nil {
+		return "", err
+	}
+	return method + " " + route, nil
+}
+
+func templateRouteSpecificity(template *httptemplate.Template) int {
+	if template == nil {
+		return -1
+	}
+	score := 0
+	for _, segment := range template.Segments {
+		if segment.Variable == nil {
+			score += 1000 + len(decodedTemplateLiteral(segment.Literal))*10
+			continue
+		}
+		for _, pattern := range segment.Variable.Pattern {
+			switch pattern.Wildcard {
+			case httptemplate.NoWildcard:
+				score += 1000 + len(decodedTemplateLiteral(pattern.Literal))*10
+			case httptemplate.SingleWildcard:
+				score += 100
+			case httptemplate.MultiWildcard:
+				score += 10
+			}
+		}
+	}
+	score += 500 + len(template.Verb)*10
+	return score
+}
+
+func templateMethodsOverlap(left string, right string) bool {
+	return left == right
+}
+
+func serveMuxPatternSpecificity(pattern string) int {
+	if pattern == "" {
+		return -1
+	}
+	if space := strings.IndexAny(pattern, " \t"); space >= 0 {
+		pattern = strings.TrimSpace(pattern[space:])
+	}
+	if pattern == "" || pattern[0] != '/' {
+		return -1
+	}
+	score := 0
+	for _, segment := range strings.Split(strings.TrimPrefix(pattern, "/"), "/") {
+		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+			if strings.HasSuffix(segment, "...}") {
+				score += 10
+			} else {
+				score += 100
+			}
+			continue
+		}
+		score += 1000 + len(segment)*10
+	}
+	return score
+}
+
+func unsafeTemplateDispatchPath(escapedPath string) bool {
+	if escapedPath == "" || escapedPath[0] != '/' {
+		return true
+	}
+	parts := strings.Split(strings.TrimPrefix(escapedPath, "/"), "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+type templateRouteToken struct {
+	literal  string
+	wildcard httptemplate.Wildcard
+}
+
+func templateRoutesOverlap(
+	left *httptemplate.Template,
+	right *httptemplate.Template,
+) bool {
+	if left == nil || right == nil || left.Verb != right.Verb {
+		return false
+	}
+	leftTokens := templateRouteTokens(left)
+	rightTokens := templateRouteTokens(right)
+	leftMulti := len(leftTokens) > 0 &&
+		leftTokens[len(leftTokens)-1].wildcard == httptemplate.MultiWildcard
+	rightMulti := len(rightTokens) > 0 &&
+		rightTokens[len(rightTokens)-1].wildcard == httptemplate.MultiWildcard
+	leftPrefix := len(leftTokens)
+	if leftMulti {
+		leftPrefix--
+	}
+	rightPrefix := len(rightTokens)
+	if rightMulti {
+		rightPrefix--
+	}
+	if !leftMulti && !rightMulti && leftPrefix != rightPrefix {
+		return false
+	}
+	if leftMulti && !rightMulti && rightPrefix < leftPrefix ||
+		rightMulti && !leftMulti && leftPrefix < rightPrefix {
+		return false
+	}
+	limit := leftPrefix
+	if rightPrefix < limit {
+		limit = rightPrefix
+	}
+	for index := 0; index < limit; index++ {
+		leftToken := leftTokens[index]
+		rightToken := rightTokens[index]
+		if leftToken.wildcard == httptemplate.NoWildcard &&
+			rightToken.wildcard == httptemplate.NoWildcard &&
+			leftToken.literal != rightToken.literal {
+			return false
+		}
+	}
+	return true
+}
+
+func templateRouteTokens(
+	template *httptemplate.Template,
+) []templateRouteToken {
+	result := make([]templateRouteToken, 0, len(template.Segments))
+	for _, segment := range template.Segments {
+		if segment.Variable == nil {
+			result = append(result, templateRouteToken{
+				literal: decodedTemplateLiteral(segment.Literal),
+			})
+			continue
+		}
+		for _, pattern := range segment.Variable.Pattern {
+			result = append(result, templateRouteToken{
+				literal:  decodedTemplateLiteral(pattern.Literal),
+				wildcard: pattern.Wildcard,
+			})
+		}
+	}
+	return result
+}
+
+func decodedTemplateLiteral(value string) string {
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
+func (router *Router) route(
+	target operation.Operation,
+	decoder Decoder,
+	handler middleware.Handler,
+	encoder Encoder,
+	streaming bool,
+) nethttp.Handler {
+	var invoke middleware.Handler
+	if !streaming {
+		invoke = handler
+		if router.bundle != nil {
+			invoke = router.bundle.Chain()(handler)
+		}
+	}
+	return nethttp.HandlerFunc(func(
+		writer nethttp.ResponseWriter,
+		request *nethttp.Request,
+	) {
+		ctx := request.Context()
+		if router.propagator != nil {
+			ctx = router.propagator.Extract(
+				ctx,
+				propagation.HeaderCarrier(request.Header),
+			)
+		}
+		requestInfo, err := newRequestInfo(
+			target,
+			"tcp",
+			request.RemoteAddr,
+		)
+		if err != nil {
+			router.writeError(ctx, writer, err)
+			return
+		}
+		ctx = operation.WithRequestInfo(ctx, requestInfo)
+		inbound, err := router.metadataPolicy.Extract(httpHeaderCarrier(request.Header))
+		if err != nil {
+			router.writeError(
+				ctx,
+				writer,
+				fmt.Errorf("%w: %w", ErrHeaderTooLarge, err),
+			)
+			return
+		}
+		ctx = metadata.WithInbound(ctx, inbound)
+		request = request.WithContext(ctx)
+
+		decoded, err := decoder(request)
+		if err != nil {
+			router.writeError(ctx, writer, requestDecodeError(err))
+			return
+		}
+		if streaming {
+			streamState := &streamingResponseWriter{
+				ResponseWriter: writer,
+			}
+			var streamWriter nethttp.ResponseWriter = streamState
+			if flusher, ok := writer.(nethttp.Flusher); ok {
+				streamWriter = &flushingStreamingResponseWriter{
+					streamingResponseWriter: streamState,
+					flusher:                 flusher,
+				}
+			}
+			streamHandler := middleware.Handler(func(
+				ctx context.Context,
+				request any,
+			) (any, error) {
+				response, err := handler(ctx, request)
+				if err != nil {
+					return nil, err
+				}
+				return nil, encoder(ctx, streamWriter, response)
+			})
+			if router.bundle != nil {
+				streamHandler = router.bundle.Chain()(streamHandler)
+			}
+			if _, err := streamHandler(ctx, decoded); err != nil &&
+				!streamState.committed {
+				router.writeError(ctx, writer, err)
+			}
+			return
+		}
+		response, err := invoke(ctx, decoded)
+		if err != nil {
+			router.writeError(ctx, writer, err)
+			return
+		}
+
+		buffer := newBufferedResponseWriter(router.maxResponseBytes)
+		if err := encoder(ctx, buffer, response); err != nil {
+			router.writeError(ctx, writer, err)
+			return
+		}
+		buffer.commit(writer)
+	})
+}
+
+// streamingResponseWriter records whether headers became irreversible while
+// retaining flush and ResponseController unwrapping support.
+type streamingResponseWriter struct {
+	nethttp.ResponseWriter
+	committed bool
+}
+
+func (writer *streamingResponseWriter) WriteHeader(status int) {
+	if writer.committed {
+		return
+	}
+	writer.committed = true
+	writer.ResponseWriter.WriteHeader(status)
+}
+
+func (writer *streamingResponseWriter) Write(body []byte) (int, error) {
+	if !writer.committed {
+		writer.WriteHeader(nethttp.StatusOK)
+	}
+	return writer.ResponseWriter.Write(body)
+}
+
+func (writer *streamingResponseWriter) Unwrap() nethttp.ResponseWriter {
+	return writer.ResponseWriter
+}
+
+type flushingStreamingResponseWriter struct {
+	*streamingResponseWriter
+	flusher nethttp.Flusher
+}
+
+func (writer *flushingStreamingResponseWriter) Flush() {
+	if !writer.committed {
+		writer.WriteHeader(nethttp.StatusOK)
+	}
+	writer.flusher.Flush()
+}
+
+func requestDecodeError(err error) error {
+	var maxBytesError *nethttp.MaxBytesError
+	if errors.As(err, &maxBytesError) || errors.Is(err, ErrRequestTooLarge) {
+		return err
+	}
+	return kerrors.Wrap(
+		err,
+		nethttp.StatusBadRequest,
+		"INVALID_REQUEST",
+		"request body is invalid",
+	)
+}
+
+func (router *Router) writeError(
+	ctx context.Context,
+	writer nethttp.ResponseWriter,
+	err error,
+) {
+	router.errorEncoder(ctx, writer, err)
+}
+
+func registerRoute(
+	mux *nethttp.ServeMux,
+	pattern string,
+	handler nethttp.Handler,
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf(
+				"%w: pattern %q: %v",
+				ErrInvalidRoute,
+				pattern,
+				recovered,
+			)
+		}
+	}()
+	mux.Handle(pattern, handler)
+	return nil
+}
+
+type httpHeaderCarrier nethttp.Header
+
+func (carrier httpHeaderCarrier) Values(key string) []string {
+	return nethttp.Header(carrier).Values(key)
+}
+
+func (carrier httpHeaderCarrier) Set(key string, values []string) {
+	header := nethttp.Header(carrier)
+	header.Del(key)
+	for _, value := range values {
+		header.Add(key, value)
+	}
+}
+
+type bufferedResponseWriter struct {
+	header nethttp.Header
+	status int
+	body   bytes.Buffer
+	limit  int64
+}
+
+func newBufferedResponseWriter(limit int64) *bufferedResponseWriter {
+	return &bufferedResponseWriter{
+		header: make(nethttp.Header),
+		limit:  limit,
+	}
+}
+
+func (writer *bufferedResponseWriter) Header() nethttp.Header {
+	return writer.header
+}
+
+func (writer *bufferedResponseWriter) WriteHeader(status int) {
+	if writer.status == 0 {
+		writer.status = status
+	}
+}
+
+func (writer *bufferedResponseWriter) Write(body []byte) (int, error) {
+	if writer.status == 0 {
+		writer.status = nethttp.StatusOK
+	}
+	if int64(writer.body.Len())+int64(len(body)) > writer.limit {
+		return 0, ErrResponseTooLarge
+	}
+	return writer.body.Write(body)
+}
+
+func (writer *bufferedResponseWriter) commit(target nethttp.ResponseWriter) {
+	for key, values := range writer.header {
+		target.Header()[key] = append([]string(nil), values...)
+	}
+	status := writer.status
+	if status == 0 {
+		status = nethttp.StatusOK
+	}
+	target.WriteHeader(status)
+	_, _ = target.Write(writer.body.Bytes())
 }

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -1,0 +1,510 @@
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	nethttp "net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keelab/keelith/health"
+)
+
+const (
+	defaultAddress         = "127.0.0.1:0"
+	defaultServerName      = "keelith.transport.http"
+	defaultMaxRequestBytes = int64(4 * 1024 * 1024)
+	defaultMaxHeaderBytes  = 1 * 1024 * 1024
+)
+
+type serverState uint8
+
+const (
+	serverStateNew serverState = iota
+	serverStateStarting
+	serverStateRunning
+	serverStateStopping
+	serverStateStopped
+)
+
+// ServerOption configures a Server.
+type ServerOption interface {
+	applyServer(*serverOptions) error
+}
+
+type serverOptionFunc func(*serverOptions) error
+
+func (function serverOptionFunc) applyServer(options *serverOptions) error {
+	return function(options)
+}
+
+// HandlerWrapper installs one application-owned outer HTTP boundary around
+// the server's request and header limits plus Router. Construction fails when
+// the wrapper rejects the inner handler or returns a nil handler.
+type HandlerWrapper func(nethttp.Handler) (nethttp.Handler, error)
+
+type serverOptions struct {
+	address         string
+	name            string
+	maxRequestBytes int64
+	maxHeaderBytes  int
+	readTimeout     time.Duration
+	readHeader      time.Duration
+	writeTimeout    time.Duration
+	idleTimeout     time.Duration
+	health          *health.Registry
+	tlsConfig       *tls.Config
+	handlerWrapper  HandlerWrapper
+}
+
+// WithAddress sets the TCP listen address.
+func WithAddress(address string) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil || host == "" || port == "" {
+			return fmt.Errorf("invalid listen address %q", address)
+		}
+		options.address = address
+		return nil
+	})
+}
+
+// WithName sets the stable App diagnostic and health contributor name.
+func WithName(name string) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		normalized := strings.TrimSpace(name)
+		if normalized == "" {
+			return fmt.Errorf("server name is empty")
+		}
+		options.name = normalized
+		return nil
+	})
+}
+
+// WithMaxRequestBodyBytes sets the request body budget.
+func WithMaxRequestBodyBytes(maxBytes int64) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max request body bytes must be positive")
+		}
+		options.maxRequestBytes = maxBytes
+		return nil
+	})
+}
+
+// WithMaxHeaderBytes sets the request header budget.
+func WithMaxHeaderBytes(maxBytes int) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("max header bytes must be positive")
+		}
+		options.maxHeaderBytes = maxBytes
+		return nil
+	})
+}
+
+// WithReadHeaderTimeout bounds the time spent reading request headers.
+func WithReadHeaderTimeout(timeout time.Duration) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("read header timeout must be positive")
+		}
+		options.readHeader = timeout
+		return nil
+	})
+}
+
+// WithReadTimeout bounds the time spent reading a complete request, including
+// its body.
+func WithReadTimeout(timeout time.Duration) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("read timeout must be positive")
+		}
+		options.readTimeout = timeout
+		return nil
+	})
+}
+
+// WithWriteTimeout bounds the time spent writing a response.
+func WithWriteTimeout(timeout time.Duration) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("write timeout must be positive")
+		}
+		options.writeTimeout = timeout
+		return nil
+	})
+}
+
+// WithIdleTimeout bounds how long keep-alive connections remain idle.
+func WithIdleTimeout(timeout time.Duration) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("idle timeout must be positive")
+		}
+		options.idleTimeout = timeout
+		return nil
+	})
+}
+
+// WithHandlerWrapper installs one outer HTTP handler wrapper at construction
+// time. It is intended for application response contracts, security headers,
+// and other boundaries that must also observe server-level request rejection.
+func WithHandlerWrapper(wrapper HandlerWrapper) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if wrapper == nil {
+			return fmt.Errorf("handler wrapper is nil")
+		}
+		if options.handlerWrapper != nil {
+			return fmt.Errorf("handler wrapper is already configured")
+		}
+		options.handlerWrapper = wrapper
+		return nil
+	})
+}
+
+// WithHealth registers listener readiness in registry.
+func WithHealth(registry *health.Registry) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if registry == nil {
+			return fmt.Errorf("health registry is nil")
+		}
+		options.health = registry
+		return nil
+	})
+}
+
+// WithTLS enables the shared TLS/mTLS server profile.
+func WithTLS(config *tls.Config) ServerOption {
+	return serverOptionFunc(func(options *serverOptions) error {
+		if config == nil {
+			return fmt.Errorf("TLS config is nil")
+		}
+		if config.MinVersion < tls.VersionTLS12 {
+			return fmt.Errorf("TLS minimum version must be 1.2 or newer")
+		}
+		options.tlsConfig = config.Clone()
+		return nil
+	})
+}
+
+// Server is a standard-library HTTP lifecycle component.
+type Server struct {
+	name            string
+	address         string
+	router          *Router
+	maxRequestBytes int64
+	maxHeaderBytes  int
+	handler         nethttp.Handler
+	httpServer      *nethttp.Server
+	tlsConfig       *tls.Config
+
+	mu                sync.Mutex
+	state             serverState
+	listener          net.Listener
+	serveErr          error
+	stopErr           error
+	shutdownInitiated bool
+
+	startDone chan struct{}
+	done      chan struct{}
+	stopDone  chan struct{}
+	doneOnce  sync.Once
+	stopOnce  sync.Once
+}
+
+// NewServer validates options and constructs a Server.
+func NewServer(router *Router, optionList ...ServerOption) (*Server, error) {
+	if router == nil {
+		return nil, fmt.Errorf("%w: router is nil", ErrInvalidOption)
+	}
+	options := serverOptions{
+		address:         defaultAddress,
+		name:            defaultServerName,
+		maxRequestBytes: defaultMaxRequestBytes,
+		maxHeaderBytes:  defaultMaxHeaderBytes,
+		readHeader:      5 * time.Second,
+		idleTimeout:     30 * time.Second,
+	}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf("%w: server option %d is nil", ErrInvalidOption, index)
+		}
+		if err := option.applyServer(&options); err != nil {
+			return nil, fmt.Errorf("%w: server option %d: %w", ErrInvalidOption, index, err)
+		}
+	}
+
+	transport := &Server{
+		name:            options.name,
+		address:         options.address,
+		router:          router,
+		maxRequestBytes: options.maxRequestBytes,
+		maxHeaderBytes:  options.maxHeaderBytes,
+		tlsConfig:       options.tlsConfig,
+		state:           serverStateNew,
+		startDone:       make(chan struct{}),
+		done:            make(chan struct{}),
+		stopDone:        make(chan struct{}),
+	}
+	handler := transport.baseHandler()
+	if options.handlerWrapper != nil {
+		var err error
+		handler, err = options.handlerWrapper(handler)
+		if err != nil {
+			return nil, fmt.Errorf("%w: wrap HTTP handler: %w", ErrInvalidOption, err)
+		}
+		if isNilHTTPHandler(handler) {
+			return nil, fmt.Errorf("%w: wrapped HTTP handler is nil", ErrInvalidOption)
+		}
+	}
+	transport.handler = handler
+	transport.httpServer = &nethttp.Server{
+		Handler:           transport.handler,
+		ReadTimeout:       options.readTimeout,
+		ReadHeaderTimeout: options.readHeader,
+		WriteTimeout:      options.writeTimeout,
+		IdleTimeout:       options.idleTimeout,
+		MaxHeaderBytes:    options.maxHeaderBytes,
+		TLSConfig:         options.tlsConfig,
+	}
+	if options.health != nil {
+		if err := options.health.Register(
+			health.KindReadiness,
+			options.name,
+			transport.readiness,
+		); err != nil {
+			return nil, fmt.Errorf("%w: register health: %w", ErrInvalidOption, err)
+		}
+	}
+	return transport, nil
+}
+
+func isNilHTTPHandler(handler nethttp.Handler) bool {
+	if handler == nil {
+		return true
+	}
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// Name returns the stable App diagnostic name.
+func (server *Server) Name() string {
+	return server.name
+}
+
+// Handler returns the fully limited HTTP handler.
+func (server *Server) Handler() nethttp.Handler {
+	if server == nil {
+		return nil
+	}
+	return server.handler
+}
+
+func (server *Server) baseHandler() nethttp.Handler {
+	return nethttp.HandlerFunc(func(
+		writer nethttp.ResponseWriter,
+		request *nethttp.Request,
+	) {
+		if headerSize(request.Header) > int64(server.maxHeaderBytes) {
+			server.router.writeError(request.Context(), writer, ErrHeaderTooLarge)
+			return
+		}
+		if request.ContentLength > server.maxRequestBytes {
+			server.router.writeError(request.Context(), writer, ErrRequestTooLarge)
+			return
+		}
+		request.Body = nethttp.MaxBytesReader(
+			writer,
+			request.Body,
+			server.maxRequestBytes,
+		)
+		server.router.ServeHTTP(writer, request)
+	})
+}
+
+// Start listens synchronously and begins serving in the background.
+func (server *Server) Start(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	server.mu.Lock()
+	if server.state != serverStateNew {
+		server.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	server.state = serverStateStarting
+	server.mu.Unlock()
+	defer close(server.startDone)
+
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "tcp", server.address)
+	if err != nil {
+		server.completeServe(fmt.Errorf("http transport: listen %q: %w", server.address, err))
+		return fmt.Errorf("http transport: listen %q: %w", server.address, err)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		closeErr := listener.Close()
+		result := errors.Join(cause, closeErr)
+		server.completeServe(result)
+		return result
+	}
+
+	server.mu.Lock()
+	server.listener = listener
+	server.state = serverStateRunning
+	server.mu.Unlock()
+	go server.serve(listener)
+	return nil
+}
+
+// Stop gracefully drains inflight requests. It is concurrent-safe and
+// idempotent.
+func (server *Server) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	for {
+		server.mu.Lock()
+		switch server.state {
+		case serverStateNew:
+			server.state = serverStateStopped
+			server.doneOnce.Do(func() { close(server.done) })
+			server.stopOnce.Do(func() { close(server.stopDone) })
+			server.mu.Unlock()
+			return nil
+		case serverStateStarting:
+			startDone := server.startDone
+			server.mu.Unlock()
+			select {
+			case <-startDone:
+				continue
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		case serverStateRunning:
+			server.state = serverStateStopping
+			if !server.shutdownInitiated {
+				server.shutdownInitiated = true
+				go server.shutdown(ctx)
+			}
+			stopDone := server.stopDone
+			server.mu.Unlock()
+			return server.waitStop(ctx, stopDone)
+		case serverStateStopping:
+			stopDone := server.stopDone
+			server.mu.Unlock()
+			return server.waitStop(ctx, stopDone)
+		case serverStateStopped:
+			err := server.stopErr
+			server.mu.Unlock()
+			return err
+		default:
+			server.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// Wait blocks until serving terminates.
+func (server *Server) Wait() error {
+	<-server.done
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	return server.serveErr
+}
+
+// Address returns the allocated listener address after Start.
+func (server *Server) Address() (string, bool) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.listener == nil {
+		return "", false
+	}
+	return server.listener.Addr().String(), true
+}
+
+func (server *Server) serve(listener net.Listener) {
+	var err error
+	if server.tlsConfig != nil {
+		err = server.httpServer.ServeTLS(listener, "", "")
+	} else {
+		err = server.httpServer.Serve(listener)
+	}
+	if errors.Is(err, nethttp.ErrServerClosed) {
+		err = nil
+	}
+	server.completeServe(err)
+}
+
+func (server *Server) completeServe(err error) {
+	server.mu.Lock()
+	if server.serveErr == nil {
+		server.serveErr = err
+	}
+	if server.state != serverStateStopping {
+		server.state = serverStateStopped
+	}
+	server.mu.Unlock()
+	server.doneOnce.Do(func() { close(server.done) })
+}
+
+func (server *Server) shutdown(ctx context.Context) {
+	err := server.httpServer.Shutdown(ctx)
+	if err != nil {
+		err = errors.Join(err, server.httpServer.Close())
+	}
+	<-server.done
+	server.mu.Lock()
+	server.stopErr = errors.Join(err, server.serveErr)
+	server.state = serverStateStopped
+	server.mu.Unlock()
+	server.stopOnce.Do(func() { close(server.stopDone) })
+}
+
+func (server *Server) waitStop(ctx context.Context, stopDone <-chan struct{}) error {
+	select {
+	case <-stopDone:
+		server.mu.Lock()
+		defer server.mu.Unlock()
+		return server.stopErr
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (server *Server) readiness(context.Context) health.Result {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.state == serverStateRunning {
+		return health.Pass("HTTP listener is accepting requests")
+	}
+	return health.Fail("HTTP listener is not accepting requests")
+}
+
+func headerSize(header nethttp.Header) int64 {
+	var size int64
+	for key, values := range header {
+		size += int64(len(key))
+		for _, value := range values {
+			size += int64(len(value))
+		}
+	}
+	return size
+}

--- a/transport/http/sse.go
+++ b/transport/http/sse.go
@@ -1,0 +1,330 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"time"
+
+	ksse "github.com/keelab/keelith/transport/sse"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// ErrInvalidSSE reports malformed configuration, event, or response type.
+	ErrInvalidSSE = ksse.ErrInvalid
+	// ErrSSEUnsupported reports a ResponseWriter without streaming flush.
+	ErrSSEUnsupported = errors.New(
+		"http transport: server-sent events unsupported",
+	)
+	// ErrSSESource reports a terminal producer error after streaming started.
+	ErrSSESource = ksse.ErrSource
+)
+
+const (
+	defaultSSEEventBytes = ksse.DefaultEventBytes
+	maxSSEEventBytes     = ksse.MaximumEventBytes
+	minSSERetry          = ksse.MinimumRetry
+	maxSSERetry          = ksse.MaximumRetry
+)
+
+func validSSEID(value string) bool   { return ksse.ValidID(value) }
+func validSSEName(value string) bool { return ksse.ValidName(value) }
+
+// SSEEventSpec is the construction input for one immutable SSE event.
+type SSEEventSpec = ksse.EventSpec
+
+// SSEEvent is one immutable server-sent event.
+type SSEEvent = ksse.Event
+
+// SSERequest is the immutable reconnection input for one SSE subscription.
+type SSERequest = ksse.Request
+
+// ServerSentEvents is a response backed by an event channel and an optional
+// terminal failure channel.
+type ServerSentEvents = ksse.Stream
+
+// SSEConfig configures a streaming Encoder.
+type SSEConfig = ksse.Config
+
+// DecodeSSERequest reads the standard Last-Event-ID request header.
+func DecodeSSERequest(request *nethttp.Request) (any, error) {
+	if request == nil {
+		return nil, fmt.Errorf("%w: request is nil", ErrInvalidSSE)
+	}
+	values := request.Header.Values("Last-Event-ID")
+	if len(values) > 1 {
+		return nil, fmt.Errorf(
+			"%w: multiple Last-Event-ID values",
+			ErrInvalidSSE,
+		)
+	}
+	value := ""
+	if len(values) == 1 {
+		value = values[0]
+	}
+	return ksse.NewRequest(value)
+}
+
+// NewSSEEvent validates and snapshots one event.
+func NewSSEEvent(spec SSEEventSpec) (SSEEvent, error) {
+	return ksse.NewEvent(spec)
+}
+
+// NewSSEJSONEvent JSON-encodes value as one immutable event.
+func NewSSEJSONEvent(
+	id string,
+	name string,
+	value any,
+	retry time.Duration,
+) (SSEEvent, error) {
+	return ksse.NewJSONEvent(id, name, value, retry)
+}
+
+// NewSSEProtoEvent protojson-encodes message as one immutable event.
+func NewSSEProtoEvent(
+	id string,
+	name string,
+	message proto.Message,
+	retry time.Duration,
+) (SSEEvent, error) {
+	return ksse.NewProtoEvent(id, name, message, retry)
+}
+
+// NewSSEProtoResponseBodyEvent protojson-encodes one
+// google.api.HttpRule.response_body field path as immutable event data.
+func NewSSEProtoResponseBodyEvent(
+	id string,
+	name string,
+	message proto.Message,
+	responseBody string,
+	retry time.Duration,
+) (SSEEvent, error) {
+	payload, err := MarshalProtoResponseBody(message, responseBody)
+	if err != nil {
+		return SSEEvent{}, err
+	}
+	return ksse.NewEvent(ksse.EventSpec{
+		ID: id, Name: name, Data: string(payload), Retry: retry,
+	})
+}
+
+// NewServerSentEvents constructs a streaming response.
+func NewServerSentEvents(
+	events <-chan SSEEvent,
+	failures <-chan error,
+) (ServerSentEvents, error) {
+	return ksse.NewStream(events, failures)
+}
+
+// NewSSEEncoder creates a bounded Server-Sent Events encoder. Routes using it
+// must also opt into WithStreaming. The encoder waits for the first event,
+// heartbeat, clean event-source close, or producer failure before committing
+// HTTP headers so typed failures remain available to the Router error encoder.
+func NewSSEEncoder(config SSEConfig) (Encoder, error) {
+	settings, err := ksse.Resolve(config)
+	if err != nil {
+		return nil, err
+	}
+	return func(
+		ctx context.Context,
+		writer nethttp.ResponseWriter,
+		response any,
+	) error {
+		if ctx == nil || writer == nil {
+			return ErrInvalidSSE
+		}
+		stream, ok := response.(ServerSentEvents)
+		if !ok || stream.Events() == nil {
+			return fmt.Errorf(
+				"%w: response type %T",
+				ErrInvalidSSE,
+				response,
+			)
+		}
+		flusher, ok := writer.(nethttp.Flusher)
+		if !ok {
+			return ErrSSEUnsupported
+		}
+		var ticker *time.Ticker
+		var heartbeat <-chan time.Time
+		if settings.HeartbeatEnabled() {
+			ticker = time.NewTicker(settings.HeartbeatInterval())
+			heartbeat = ticker.C
+			defer ticker.Stop()
+		}
+		events := stream.Events()
+		failures := stream.Failures()
+		firstPayload, firstSignal, failures, err := preflightSSE(
+			ctx,
+			events,
+			failures,
+			heartbeat,
+			settings.MaximumEventBytes(),
+		)
+		if err != nil {
+			return err
+		}
+		writer.Header().Set("Content-Type", ksse.ContentType)
+		writer.Header().Set("Cache-Control", ksse.CacheControl)
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		writer.WriteHeader(nethttp.StatusOK)
+		switch firstSignal {
+		case ssePreflightEvent:
+			if _, err := writer.Write(firstPayload); err != nil {
+				return err
+			}
+		case ssePreflightHeartbeat:
+			if _, err := io.WriteString(writer, ksse.HeartbeatComment); err != nil {
+				return err
+			}
+		case ssePreflightClean:
+		}
+		flusher.Flush()
+		if firstSignal == ssePreflightClean {
+			return nil
+		}
+		for events != nil {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case event, open := <-events:
+				if !open {
+					return nil
+				}
+				payload, err := ksse.Render(
+					event,
+					settings.MaximumEventBytes(),
+				)
+				if errors.Is(err, ksse.ErrEventTooLarge) {
+					return ErrResponseTooLarge
+				}
+				if err != nil {
+					return err
+				}
+				if _, err := writer.Write(payload); err != nil {
+					return err
+				}
+				flusher.Flush()
+			case failureErr, open := <-failures:
+				if !open {
+					failures = nil
+					continue
+				}
+				if failureErr == nil {
+					return ErrSSESource
+				}
+				return fmt.Errorf("%w: %w", ErrSSESource, failureErr)
+			case <-heartbeat:
+				if _, err := io.WriteString(
+					writer,
+					ksse.HeartbeatComment,
+				); err != nil {
+					return err
+				}
+				flusher.Flush()
+			}
+		}
+		return nil
+	}, nil
+}
+
+type ssePreflightSignal uint8
+
+const (
+	ssePreflightClean ssePreflightSignal = iota
+	ssePreflightEvent
+	ssePreflightHeartbeat
+)
+
+func preflightSSE(
+	ctx context.Context,
+	events <-chan SSEEvent,
+	failures <-chan error,
+	heartbeat <-chan time.Time,
+	maximumEventBytes int,
+) ([]byte, ssePreflightSignal, <-chan error, error) {
+	for {
+		if cause := context.Cause(ctx); cause != nil {
+			return nil, ssePreflightClean, failures, cause
+		}
+		if failures != nil {
+			select {
+			case failureErr, open := <-failures:
+				if !open {
+					failures = nil
+					continue
+				}
+				return nil, ssePreflightClean, failures, precommitSSEFailure(failureErr)
+			default:
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ssePreflightClean, failures, context.Cause(ctx)
+		case failureErr, open := <-failures:
+			if !open {
+				failures = nil
+				continue
+			}
+			return nil, ssePreflightClean, failures, precommitSSEFailure(failureErr)
+		case event, open := <-events:
+			if !open {
+				if failures != nil {
+					select {
+					case failureErr, failureOpen := <-failures:
+						if failureOpen {
+							return nil, ssePreflightClean, failures, precommitSSEFailure(failureErr)
+						}
+						failures = nil
+					default:
+					}
+				}
+				if cause := context.Cause(ctx); cause != nil {
+					return nil, ssePreflightClean, failures, cause
+				}
+				return nil, ssePreflightClean, failures, nil
+			}
+			payload, err := renderSSEEvent(event, maximumEventBytes)
+			if err != nil {
+				return nil, ssePreflightClean, failures, err
+			}
+			if cause := context.Cause(ctx); cause != nil {
+				return nil, ssePreflightClean, failures, cause
+			}
+			return payload, ssePreflightEvent, failures, nil
+		case <-heartbeat:
+			if failures != nil {
+				select {
+				case failureErr, open := <-failures:
+					if open {
+						return nil, ssePreflightClean, failures, precommitSSEFailure(failureErr)
+					}
+					failures = nil
+				default:
+				}
+			}
+			if cause := context.Cause(ctx); cause != nil {
+				return nil, ssePreflightClean, failures, cause
+			}
+			return nil, ssePreflightHeartbeat, failures, nil
+		}
+	}
+}
+
+func precommitSSEFailure(err error) error {
+	if err == nil {
+		return ErrSSESource
+	}
+	return err
+}
+
+func renderSSEEvent(event SSEEvent, maximumEventBytes int) ([]byte, error) {
+	payload, err := ksse.Render(event, maximumEventBytes)
+	if errors.Is(err, ksse.ErrEventTooLarge) {
+		return nil, ErrResponseTooLarge
+	}
+	return payload, err
+}

--- a/transport/http/sse_client.go
+++ b/transport/http/sse_client.go
@@ -1,0 +1,431 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/keelab/keelith/operation"
+	"google.golang.org/protobuf/proto"
+)
+
+var errSSEClientClosed = errors.New("http transport: SSE client closed")
+
+// SSEClientOption configures one outbound SSE subscription.
+type SSEClientOption interface {
+	applySSEClient(*sseClientOptions) error
+}
+
+type sseClientOptionFunc func(*sseClientOptions) error
+
+func (function sseClientOptionFunc) applySSEClient(
+	options *sseClientOptions,
+) error {
+	return function(options)
+}
+
+type sseClientOptions struct {
+	lastEventID   string
+	maxEventBytes int
+}
+
+// WithSSELastEventID resumes after the last fully processed event.
+func WithSSELastEventID(value string) SSEClientOption {
+	return sseClientOptionFunc(func(options *sseClientOptions) error {
+		if !validSSEID(value) {
+			return fmt.Errorf("%w: invalid Last-Event-ID", ErrInvalidSSE)
+		}
+		options.lastEventID = value
+		return nil
+	})
+}
+
+// WithSSEClientMaxEventBytes overrides the per-event decode budget.
+func WithSSEClientMaxEventBytes(maxBytes int) SSEClientOption {
+	return sseClientOptionFunc(func(options *sseClientOptions) error {
+		if maxBytes < 256 || maxBytes > maxSSEEventBytes {
+			return fmt.Errorf(
+				"%w: event size is outside supported bounds",
+				ErrInvalidSSE,
+			)
+		}
+		options.maxEventBytes = maxBytes
+		return nil
+	})
+}
+
+// SSEMessage is one immutable decoded SSE message.
+type SSEMessage[T any] struct {
+	id    string
+	name  string
+	value T
+	retry time.Duration
+}
+
+// ID returns the current server reconnection cursor.
+func (message SSEMessage[T]) ID() string { return message.id }
+
+// Name returns the optional event type.
+func (message SSEMessage[T]) Name() string { return message.name }
+
+// Value returns the freshly decoded event value.
+func (message SSEMessage[T]) Value() T { return message.value }
+
+// Retry returns the most recently declared reconnection delay.
+func (message SSEMessage[T]) Retry() time.Duration { return message.retry }
+
+// SSEClientStream owns one HTTP response body and its parser goroutine.
+type SSEClientStream[T any] struct {
+	messages chan SSEMessage[T]
+	done     chan struct{}
+	cancel   context.CancelCauseFunc
+
+	userClosed atomic.Bool
+	mu         sync.Mutex
+	terminal   error
+}
+
+// Recv waits for the next event. A normally completed or explicitly closed
+// stream returns io.EOF.
+func (stream *SSEClientStream[T]) Recv() (SSEMessage[T], error) {
+	if stream == nil {
+		var zero SSEMessage[T]
+		return zero, ErrInvalidSSE
+	}
+	message, open := <-stream.messages
+	if open {
+		return message, nil
+	}
+	var zero SSEMessage[T]
+	err := stream.terminalError()
+	if err == nil || stream.userClosed.Load() &&
+		(errors.Is(err, errSSEClientClosed) ||
+			errors.Is(err, context.Canceled)) {
+		return zero, io.EOF
+	}
+	return zero, err
+}
+
+// Close cancels the subscription and waits for the response body to close.
+func (stream *SSEClientStream[T]) Close(ctx context.Context) error {
+	if stream == nil {
+		return nil
+	}
+	if ctx == nil {
+		return ErrNilContext
+	}
+	stream.userClosed.Store(true)
+	stream.cancel(errSSEClientClosed)
+	select {
+	case <-stream.done:
+		err := stream.terminalError()
+		if err == nil ||
+			errors.Is(err, errSSEClientClosed) ||
+			errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (stream *SSEClientStream[T]) finish(err error) {
+	stream.mu.Lock()
+	stream.terminal = err
+	stream.mu.Unlock()
+	close(stream.messages)
+	close(stream.done)
+}
+
+func (stream *SSEClientStream[T]) terminalError() error {
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	return stream.terminal
+}
+
+// OpenProtoSSE opens a typed Proto SSE subscription through Client.
+//
+// The returned stream retains the Client middleware invocation until EOF,
+// cancellation, or Close. The HTTP response has no total body limit; every
+// individual event remains bounded.
+func OpenProtoSSE[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+	optionList ...SSEClientOption,
+) (*SSEClientStream[T], error) {
+	return openProtoSSE(
+		ctx,
+		client,
+		target,
+		request,
+		factory,
+		"",
+		optionList...,
+	)
+}
+
+// OpenProtoSSEResponseBody opens a typed SSE subscription whose data field
+// contains one google.api.HttpRule.response_body field path value.
+func OpenProtoSSEResponseBody[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+	responseBody string,
+	optionList ...SSEClientOption,
+) (*SSEClientStream[T], error) {
+	return openProtoSSE(
+		ctx,
+		client,
+		target,
+		request,
+		factory,
+		responseBody,
+		optionList...,
+	)
+}
+
+func openProtoSSE[T proto.Message](
+	ctx context.Context,
+	client *Client,
+	target operation.Operation,
+	request *nethttp.Request,
+	factory func() T,
+	responseBody string,
+	optionList ...SSEClientOption,
+) (*SSEClientStream[T], error) {
+	if ctx == nil {
+		return nil, ErrNilContext
+	}
+	if client == nil ||
+		request == nil ||
+		request.URL == nil ||
+		factory == nil ||
+		target.Transport() != "http" ||
+		target.Kind() != operation.KindServerStream {
+		return nil, fmt.Errorf("%w: invalid Proto SSE call", ErrInvalidCall)
+	}
+	options := sseClientOptions{maxEventBytes: defaultSSEEventBytes}
+	for index, option := range optionList {
+		if option == nil {
+			return nil, fmt.Errorf(
+				"%w: SSE client option %d is nil",
+				ErrInvalidCall,
+				index,
+			)
+		}
+		if err := option.applySSEClient(&options); err != nil {
+			return nil, fmt.Errorf(
+				"%w: SSE client option %d: %w",
+				ErrInvalidCall,
+				index,
+				err,
+			)
+		}
+	}
+	probe := factory()
+	if isNilProto(probe) {
+		return nil, fmt.Errorf("%w: Proto factory returned nil", ErrInvalidCall)
+	}
+	if err := ValidateProtoResponseBody(probe, responseBody); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCall, err)
+	}
+	prepared := request.Clone(ctx)
+	if options.lastEventID != "" {
+		prepared.Header.Set("Last-Event-ID", options.lastEventID)
+	}
+	streamContext, cancel := context.WithCancelCause(ctx)
+	stream := &SSEClientStream[T]{
+		messages: make(chan SSEMessage[T]),
+		done:     make(chan struct{}),
+		cancel:   cancel,
+	}
+	ready := make(chan error, 1)
+	go func() {
+		connected := false
+		_, err := client.Invoke(streamContext, target, ClientCall{
+			Request:   prepared,
+			Streaming: true,
+			Decode: func(
+				decodeContext context.Context,
+				response *nethttp.Response,
+			) (any, error) {
+				if err := validateSSEContentType(response); err != nil {
+					return nil, err
+				}
+				connected = true
+				ready <- nil
+				return nil, consumeProtoSSE(
+					decodeContext,
+					response.Body,
+					factory,
+					responseBody,
+					options.maxEventBytes,
+					stream.messages,
+				)
+			},
+		})
+		if !connected {
+			ready <- err
+		}
+		stream.finish(err)
+	}()
+
+	select {
+	case err := <-ready:
+		if err != nil {
+			cancel(err)
+			return nil, err
+		}
+		return stream, nil
+	case <-ctx.Done():
+		cause := context.Cause(ctx)
+		cancel(cause)
+		return nil, cause
+	}
+}
+
+func validateSSEContentType(response *nethttp.Response) error {
+	if response == nil {
+		return fmt.Errorf("%w: response is nil", ErrInvalidSSE)
+	}
+	contentType, _, err := mime.ParseMediaType(
+		response.Header.Get("Content-Type"),
+	)
+	if err != nil || contentType != "text/event-stream" {
+		return fmt.Errorf("%w: response is not text/event-stream", ErrInvalidSSE)
+	}
+	return nil
+}
+
+func consumeProtoSSE[T proto.Message](
+	ctx context.Context,
+	reader io.Reader,
+	factory func() T,
+	responseBody string,
+	maxEventBytes int,
+	target chan<- SSEMessage[T],
+) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 4*1024), maxEventBytes+512)
+	lastID := ""
+	var eventName string
+	var retry time.Duration
+	var data strings.Builder
+	eventBytes := 0
+
+	dispatch := func() error {
+		if data.Len() == 0 {
+			eventName = ""
+			eventBytes = 0
+			return nil
+		}
+		payload := strings.TrimSuffix(data.String(), "\n")
+		message := factory()
+		if isNilProto(message) {
+			return fmt.Errorf("%w: Proto factory returned nil", ErrInvalidSSE)
+		}
+		if err := UnmarshalProtoResponseBody(
+			[]byte(payload),
+			message,
+			responseBody,
+		); err != nil {
+			return fmt.Errorf("%w: decode Proto event", ErrInvalidSSE)
+		}
+		event := SSEMessage[T]{
+			id:    lastID,
+			name:  eventName,
+			value: message,
+			retry: retry,
+		}
+		select {
+		case target <- event:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
+		data.Reset()
+		eventName = ""
+		eventBytes = 0
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !utf8.ValidString(line) {
+			return ErrInvalidSSE
+		}
+		eventBytes += len(line) + 1
+		if eventBytes > maxEventBytes {
+			return ErrResponseTooLarge
+		}
+		if line == "" {
+			if err := dispatch(); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, found := strings.Cut(line, ":")
+		if !found {
+			value = ""
+		} else {
+			value = strings.TrimPrefix(value, " ")
+		}
+		switch field {
+		case "data":
+			data.WriteString(value)
+			data.WriteByte('\n')
+		case "event":
+			if !validSSEName(value) {
+				return ErrInvalidSSE
+			}
+			eventName = value
+		case "id":
+			if !validSSEID(value) {
+				return ErrInvalidSSE
+			}
+			lastID = value
+		case "retry":
+			milliseconds, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				continue
+			}
+			candidate := time.Duration(milliseconds) * time.Millisecond
+			if candidate >= minSSERetry && candidate <= maxSSERetry {
+				retry = candidate
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+		if errors.Is(err, bufio.ErrTooLong) {
+			return ErrResponseTooLarge
+		}
+		return err
+	}
+	if data.Len() > 0 {
+		if err := dispatch(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/transport/httpauth/bearer.go
+++ b/transport/httpauth/bearer.go
@@ -1,0 +1,126 @@
+// Package httpauth provides fail-closed outbound HTTP authentication
+// transports without coupling callers to plaintext credential material.
+package httpauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const maximumAuthorizationBytes = 64 * 1024
+
+var (
+	// ErrInvalidOption reports a nil transport, credential, or request.
+	ErrInvalidOption = errors.New("http auth: invalid option")
+	// ErrInsecureTransport prevents credentials from crossing plaintext HTTP.
+	ErrInsecureTransport = errors.New("http auth: transport security required")
+	// ErrAuthorizationConflict rejects caller-owned Authorization headers.
+	ErrAuthorizationConflict = errors.New("http auth: authorization header conflict")
+	// ErrCredentialUnavailable hides credential provider details from callers.
+	ErrCredentialUnavailable = errors.New("http auth: credential unavailable")
+)
+
+// BearerCredential is the material-free subset implemented by Keelith's
+// Secret-backed bearer lifecycle.
+type BearerCredential interface {
+	GetRequestMetadata(context.Context, ...string) (map[string]string, error)
+	RequireTransportSecurity() bool
+}
+
+// Transport injects one current bearer credential into an independent clone
+// of every HTTPS request. It never mutates the caller-owned request or header.
+type Transport struct {
+	base       http.RoundTripper
+	credential BearerCredential
+}
+
+// NewTransport validates and constructs a bearer-authenticated RoundTripper.
+func NewTransport(
+	base http.RoundTripper,
+	credential BearerCredential,
+) (*Transport, error) {
+	if base == nil || credential == nil ||
+		!credential.RequireTransportSecurity() {
+		return nil, ErrInvalidOption
+	}
+	return &Transport{base: base, credential: credential}, nil
+}
+
+// RoundTrip injects the latest valid token and delegates one HTTPS attempt.
+func (transport *Transport) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	if transport == nil || transport.base == nil ||
+		transport.credential == nil || request == nil || request.URL == nil {
+		return nil, ErrInvalidOption
+	}
+	if !strings.EqualFold(request.URL.Scheme, "https") {
+		return nil, ErrInsecureTransport
+	}
+	for name := range request.Header {
+		if strings.EqualFold(name, "Authorization") {
+			return nil, ErrAuthorizationConflict
+		}
+	}
+	metadata, err := transport.credential.GetRequestMetadata(request.Context())
+	if err != nil {
+		return nil, ErrCredentialUnavailable
+	}
+	authorization, err := authorizationValue(metadata)
+	if err != nil {
+		return nil, err
+	}
+	clone := request.Clone(request.Context())
+	clone.Header.Set("Authorization", authorization)
+	return transport.base.RoundTrip(clone)
+}
+
+// CloseIdleConnections releases idle connections owned by the base transport.
+func (transport *Transport) CloseIdleConnections() {
+	if transport == nil || transport.base == nil {
+		return
+	}
+	if closer, ok := transport.base.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+func authorizationValue(metadata map[string]string) (string, error) {
+	if len(metadata) != 1 {
+		return "", ErrCredentialUnavailable
+	}
+	value := ""
+	found := false
+	for name, candidate := range metadata {
+		if !strings.EqualFold(name, "authorization") || found {
+			return "", ErrCredentialUnavailable
+		}
+		value = candidate
+		found = true
+	}
+	if !found || len(value) > maximumAuthorizationBytes ||
+		!utf8.ValidString(value) || !strings.HasPrefix(value, "Bearer ") ||
+		strings.TrimSpace(strings.TrimPrefix(value, "Bearer ")) == "" {
+		return "", ErrCredentialUnavailable
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return "", ErrCredentialUnavailable
+		}
+	}
+	return value, nil
+}
+
+var _ http.RoundTripper = (*Transport)(nil)
+
+func (transport *Transport) String() string {
+	if transport == nil {
+		return "httpauth.Transport<nil>"
+	}
+	return fmt.Sprintf("httpauth.Transport<configured=%t>", transport.base != nil)
+}

--- a/transport/sse/sse.go
+++ b/transport/sse/sse.go
@@ -1,0 +1,332 @@
+// Package sse defines transport-neutral Server-Sent Events values and
+// bounded wire rendering shared by HTTP transport profiles.
+package sse
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	defaultHeartbeat = 15 * time.Second
+	maxIdentityBytes = 256
+	minHeartbeat     = time.Second
+	maxHeartbeat     = 5 * time.Minute
+
+	// DefaultEventBytes is the default fully rendered event budget.
+	DefaultEventBytes = 64 * 1024
+	// MaximumEventBytes is the largest supported event budget.
+	MaximumEventBytes = 1024 * 1024
+	// MinimumRetry is the smallest accepted browser retry delay.
+	MinimumRetry = 100 * time.Millisecond
+	// MaximumRetry is the largest accepted browser retry delay.
+	MaximumRetry = time.Hour
+
+	// ContentType is the canonical SSE response media type.
+	ContentType = "text/event-stream; charset=utf-8"
+	// CacheControl prevents intermediaries from caching an event stream.
+	CacheControl = "no-cache"
+	// HeartbeatComment is the fixed value used for idle keepalives.
+	HeartbeatComment = ": keelith-keepalive\n\n"
+)
+
+var (
+	// ErrInvalid reports a malformed request, event, stream, or configuration.
+	ErrInvalid = errors.New("sse: invalid server-sent events")
+	// ErrSource reports a terminal producer error after response commitment.
+	ErrSource = errors.New("sse: event source failed")
+	// ErrEventTooLarge reports one rendered event beyond its configured budget.
+	ErrEventTooLarge = errors.New("sse: event too large")
+)
+
+// EventSpec is the construction input for one immutable event.
+type EventSpec struct {
+	ID    string
+	Name  string
+	Data  string
+	Retry time.Duration
+}
+
+// Event is one immutable Server-Sent Event.
+type Event struct {
+	id    string
+	name  string
+	data  string
+	retry time.Duration
+}
+
+// Request is the immutable reconnection input for one subscription.
+type Request struct {
+	lastEventID string
+}
+
+// NewRequest validates a Last-Event-ID value.
+func NewRequest(lastEventID string) (Request, error) {
+	if !validID(lastEventID) {
+		return Request{}, fmt.Errorf("%w: invalid Last-Event-ID", ErrInvalid)
+	}
+	return Request{lastEventID: lastEventID}, nil
+}
+
+// LastEventID returns the optional browser reconnection cursor.
+func (request Request) LastEventID() string { return request.lastEventID }
+
+// NewEvent validates and snapshots one event.
+func NewEvent(spec EventSpec) (Event, error) {
+	if !validID(spec.ID) ||
+		!validName(spec.Name) ||
+		!utf8.ValidString(spec.Data) ||
+		strings.ContainsRune(spec.Data, '\x00') {
+		return Event{}, ErrInvalid
+	}
+	if spec.Retry != 0 &&
+		(spec.Retry < MinimumRetry ||
+			spec.Retry > MaximumRetry ||
+			spec.Retry%time.Millisecond != 0) {
+		return Event{}, fmt.Errorf(
+			"%w: retry is outside supported bounds",
+			ErrInvalid,
+		)
+	}
+	return Event{
+		id:    spec.ID,
+		name:  spec.Name,
+		data:  spec.Data,
+		retry: spec.Retry,
+	}, nil
+}
+
+// NewJSONEvent JSON-encodes value as one immutable event.
+func NewJSONEvent(
+	id string,
+	name string,
+	value any,
+	retry time.Duration,
+) (Event, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return Event{}, fmt.Errorf("%w: encode JSON data", ErrInvalid)
+	}
+	return NewEvent(EventSpec{
+		ID: id, Name: name, Data: string(payload), Retry: retry,
+	})
+}
+
+// NewProtoEvent protojson-encodes message as one immutable event.
+func NewProtoEvent(
+	id string,
+	name string,
+	message proto.Message,
+	retry time.Duration,
+) (Event, error) {
+	if isNilProto(message) {
+		return Event{}, fmt.Errorf("%w: Proto message is nil", ErrInvalid)
+	}
+	payload, err := (protojson.MarshalOptions{
+		UseProtoNames:   false,
+		EmitUnpopulated: false,
+	}).Marshal(message)
+	if err != nil {
+		return Event{}, fmt.Errorf("%w: encode Proto data", ErrInvalid)
+	}
+	return NewEvent(EventSpec{
+		ID: id, Name: name, Data: string(payload), Retry: retry,
+	})
+}
+
+// ID returns the reconnection cursor.
+func (event Event) ID() string { return event.id }
+
+// Name returns the optional event type.
+func (event Event) Name() string { return event.name }
+
+// Data returns immutable UTF-8 event data.
+func (event Event) Data() string { return event.data }
+
+// Retry returns the optional browser reconnection delay.
+func (event Event) Retry() time.Duration { return event.retry }
+
+// Stream is a response backed by events and optional terminal failures.
+type Stream struct {
+	events   <-chan Event
+	failures <-chan error
+}
+
+// NewStream constructs a streaming response.
+func NewStream(
+	events <-chan Event,
+	failures <-chan error,
+) (Stream, error) {
+	if events == nil {
+		return Stream{}, fmt.Errorf("%w: event channel is nil", ErrInvalid)
+	}
+	return Stream{events: events, failures: failures}, nil
+}
+
+// Events returns the immutable event source.
+func (stream Stream) Events() <-chan Event { return stream.events }
+
+// Failures returns the optional terminal failure source.
+func (stream Stream) Failures() <-chan error { return stream.failures }
+
+// Config controls bounded SSE encoding.
+type Config struct {
+	HeartbeatInterval time.Duration
+	DisableHeartbeat  bool
+	MaxEventBytes     int
+}
+
+// Settings is one validated Config snapshot.
+type Settings struct {
+	heartbeat        time.Duration
+	disableHeartbeat bool
+	maxEventBytes    int
+}
+
+// Resolve validates configuration and applies bounded defaults.
+func Resolve(config Config) (Settings, error) {
+	heartbeat := config.HeartbeatInterval
+	if heartbeat == 0 {
+		heartbeat = defaultHeartbeat
+	}
+	if config.DisableHeartbeat && config.HeartbeatInterval != 0 {
+		return Settings{}, fmt.Errorf(
+			"%w: disabled heartbeat has an interval",
+			ErrInvalid,
+		)
+	}
+	if !config.DisableHeartbeat &&
+		(heartbeat < minHeartbeat || heartbeat > maxHeartbeat) {
+		return Settings{}, fmt.Errorf(
+			"%w: heartbeat is outside supported bounds",
+			ErrInvalid,
+		)
+	}
+	maximum := config.MaxEventBytes
+	if maximum == 0 {
+		maximum = DefaultEventBytes
+	}
+	if maximum < 256 || maximum > MaximumEventBytes {
+		return Settings{}, fmt.Errorf(
+			"%w: event size is outside supported bounds",
+			ErrInvalid,
+		)
+	}
+	return Settings{
+		heartbeat:        heartbeat,
+		disableHeartbeat: config.DisableHeartbeat,
+		maxEventBytes:    maximum,
+	}, nil
+}
+
+// HeartbeatInterval returns the resolved keepalive interval.
+func (settings Settings) HeartbeatInterval() time.Duration {
+	return settings.heartbeat
+}
+
+// HeartbeatEnabled reports whether keepalives should be emitted.
+func (settings Settings) HeartbeatEnabled() bool {
+	return !settings.disableHeartbeat
+}
+
+// MaximumEventBytes returns the resolved per-event wire budget.
+func (settings Settings) MaximumEventBytes() int {
+	return settings.maxEventBytes
+}
+
+// Render validates and renders one bounded event.
+func Render(event Event, maximum int) ([]byte, error) {
+	if maximum < 1 ||
+		!validID(event.id) ||
+		!validName(event.name) ||
+		!utf8.ValidString(event.data) ||
+		strings.ContainsRune(event.data, '\x00') ||
+		event.retry != 0 &&
+			(event.retry < MinimumRetry ||
+				event.retry > MaximumRetry ||
+				event.retry%time.Millisecond != 0) {
+		return nil, ErrInvalid
+	}
+	var payload bytes.Buffer
+	if event.id != "" {
+		payload.WriteString("id: ")
+		payload.WriteString(event.id)
+		payload.WriteByte('\n')
+	}
+	if event.name != "" {
+		payload.WriteString("event: ")
+		payload.WriteString(event.name)
+		payload.WriteByte('\n')
+	}
+	if event.retry != 0 {
+		payload.WriteString("retry: ")
+		payload.WriteString(strconv.FormatInt(
+			event.retry.Milliseconds(),
+			10,
+		))
+		payload.WriteByte('\n')
+	}
+	data := strings.ReplaceAll(event.data, "\r\n", "\n")
+	data = strings.ReplaceAll(data, "\r", "\n")
+	for _, line := range strings.Split(data, "\n") {
+		payload.WriteString("data: ")
+		payload.WriteString(line)
+		payload.WriteByte('\n')
+		if payload.Len() > maximum {
+			return nil, ErrEventTooLarge
+		}
+	}
+	payload.WriteByte('\n')
+	if payload.Len() > maximum {
+		return nil, ErrEventTooLarge
+	}
+	return payload.Bytes(), nil
+}
+
+func validID(value string) bool {
+	return len(value) <= maxIdentityBytes &&
+		utf8.ValidString(value) &&
+		!strings.ContainsAny(value, "\r\n\x00")
+}
+
+// ValidID reports whether value is a safe SSE cursor.
+func ValidID(value string) bool { return validID(value) }
+
+func validName(value string) bool {
+	if len(value) > maxIdentityBytes {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z',
+			character >= 'A' && character <= 'Z',
+			character >= '0' && character <= '9',
+			character == '.',
+			character == '_',
+			character == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ValidName reports whether value is a bounded event type.
+func ValidName(value string) bool { return validName(value) }
+
+func isNilProto(message proto.Message) bool {
+	if message == nil {
+		return true
+	}
+	value := message.ProtoReflect()
+	return !value.IsValid()
+}

--- a/transport/tlsconfig/reloader.go
+++ b/transport/tlsconfig/reloader.go
@@ -1,0 +1,425 @@
+// Package tlsconfig provides shared TLS and mTLS profiles for transports.
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/keelab/keelith/secret"
+)
+
+var (
+	// ErrInvalidMaterial reports an unusable certificate, key, or CA bundle.
+	ErrInvalidMaterial = errors.New("tlsconfig: invalid material")
+	// ErrUnavailable reports that required hot-reloaded material is absent.
+	ErrUnavailable = errors.New("tlsconfig: material unavailable")
+	// ErrInvalidOption reports an invalid TLS profile option.
+	ErrInvalidOption = errors.New("tlsconfig: invalid option")
+)
+
+// Material is one atomic certificate/key/CA replacement.
+type Material struct {
+	CertificatePEM []byte
+	PrivateKeyPEM  []byte
+	CAPEM          []byte
+}
+
+type state struct {
+	certificate *tls.Certificate
+	roots       *x509.CertPool
+}
+
+// Reloader atomically publishes immutable TLS material.
+type Reloader struct {
+	current atomic.Pointer[state]
+
+	mu             sync.Mutex
+	requirements   materialRequirements
+	generation     uint64
+	nextSubscriber uint64
+	subscribers    map[uint64]chan uint64
+}
+
+// UpdateSubscription observes successful atomic material replacements.
+// Notifications are coalesced to the latest generation so a slow consumer
+// cannot block TLS handshakes or SecretWatcher progress.
+type UpdateSubscription struct {
+	reloader  *Reloader
+	id        uint64
+	baseline  uint64
+	updates   <-chan uint64
+	closeOnce sync.Once
+}
+
+// Baseline returns the generation active when the subscription was created.
+func (subscription *UpdateSubscription) Baseline() uint64 {
+	if subscription == nil {
+		return 0
+	}
+	return subscription.baseline
+}
+
+// Updates returns a single-slot stream of successful material generations.
+func (subscription *UpdateSubscription) Updates() <-chan uint64 {
+	if subscription == nil {
+		return nil
+	}
+	return subscription.updates
+}
+
+// Close unregisters the subscription. It is safe to call repeatedly.
+func (subscription *UpdateSubscription) Close() {
+	if subscription == nil || subscription.reloader == nil {
+		return
+	}
+	subscription.closeOnce.Do(func() {
+		subscription.reloader.removeSubscriber(subscription.id)
+	})
+}
+
+type materialRequirements uint8
+
+const (
+	requireCertificate materialRequirements = 1 << iota
+	requireRoots
+)
+
+// New validates initial material and constructs a Reloader.
+func New(material Material) (*Reloader, error) {
+	reloader := &Reloader{}
+	if err := reloader.Update(material); err != nil {
+		return nil, err
+	}
+	return reloader, nil
+}
+
+// NewEmpty creates a Reloader that must be populated before handshakes begin.
+//
+// This is intended for a SecretWatcher component, which App starts before
+// transport servers.
+func NewEmpty() *Reloader {
+	return &Reloader{}
+}
+
+// Update validates all material before atomically replacing the current set.
+func (reloader *Reloader) Update(material Material) error {
+	if reloader == nil {
+		return fmt.Errorf("%w: reloader is nil", ErrInvalidOption)
+	}
+	next, err := parseMaterial(material)
+	if err != nil {
+		return err
+	}
+	reloader.mu.Lock()
+	defer reloader.mu.Unlock()
+	if err := validateRequirements(next, reloader.requirements); err != nil {
+		return err
+	}
+	reloader.current.Store(next)
+	reloader.generation++
+	for _, updates := range reloader.subscribers {
+		publishGeneration(updates, reloader.generation)
+	}
+	return nil
+}
+
+// Subscribe observes future successful material replacements without exposing
+// certificates, keys, roots, file paths, or secret versions. The returned
+// baseline lets connection owners distinguish the already-active material from
+// subsequent replacements.
+func (reloader *Reloader) Subscribe() (*UpdateSubscription, error) {
+	if reloader == nil {
+		return nil, fmt.Errorf("%w: reloader is nil", ErrInvalidOption)
+	}
+	reloader.mu.Lock()
+	defer reloader.mu.Unlock()
+	if reloader.subscribers == nil {
+		reloader.subscribers = make(map[uint64]chan uint64)
+	}
+	reloader.nextSubscriber++
+	id := reloader.nextSubscriber
+	updates := make(chan uint64, 1)
+	reloader.subscribers[id] = updates
+	return &UpdateSubscription{
+		reloader: reloader,
+		id:       id,
+		baseline: reloader.generation,
+		updates:  updates,
+	}, nil
+}
+
+// SubscribeUpdates implements secret.UpdateSource without exposing TLS
+// material through the provider-neutral rotation contract.
+func (reloader *Reloader) SubscribeUpdates() (secret.UpdateSubscription, error) {
+	return reloader.Subscribe()
+}
+
+func (reloader *Reloader) removeSubscriber(id uint64) {
+	reloader.mu.Lock()
+	updates, exists := reloader.subscribers[id]
+	if exists {
+		delete(reloader.subscribers, id)
+		close(updates)
+	}
+	reloader.mu.Unlock()
+}
+
+func publishGeneration(updates chan uint64, generation uint64) {
+	select {
+	case <-updates:
+	default:
+	}
+	select {
+	case updates <- generation:
+	default:
+	}
+}
+
+var _ secret.UpdateSource = (*Reloader)(nil)
+
+// Ready reports whether any valid material has been published.
+func (reloader *Reloader) Ready() bool {
+	return reloader != nil && reloader.current.Load() != nil
+}
+
+// ServerOptions controls the server-side TLS profile.
+type ServerOptions struct {
+	MutualTLS  bool
+	NextProtos []string
+}
+
+// ServerConfig returns a TLS 1.2+ server config with hot certificate reload.
+func (reloader *Reloader) ServerConfig(
+	options ServerOptions,
+) (*tls.Config, error) {
+	if reloader == nil {
+		return nil, fmt.Errorf("%w: reloader is nil", ErrInvalidOption)
+	}
+	requirements := requireCertificate
+	if options.MutualTLS {
+		requirements |= requireRoots
+	}
+	if err := reloader.require(requirements); err != nil {
+		return nil, err
+	}
+	nextProtos := normalizedProtocols(options.NextProtos)
+	base := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: nextProtos,
+		GetCertificate: func(
+			*tls.ClientHelloInfo,
+		) (*tls.Certificate, error) {
+			current := reloader.current.Load()
+			if current == nil || current.certificate == nil {
+				return nil, ErrUnavailable
+			}
+			return current.certificate, nil
+		},
+	}
+	if options.MutualTLS {
+		base.ClientAuth = tls.RequireAndVerifyClientCert
+		base.GetConfigForClient = func(
+			*tls.ClientHelloInfo,
+		) (*tls.Config, error) {
+			current := reloader.current.Load()
+			if current == nil ||
+				current.certificate == nil ||
+				current.roots == nil {
+				return nil, ErrUnavailable
+			}
+			config := base.Clone()
+			config.GetConfigForClient = nil
+			config.ClientCAs = current.roots
+			return config, nil
+		}
+	}
+	return base, nil
+}
+
+// ClientOptions controls server identity and optional client authentication.
+type ClientOptions struct {
+	ServerName string
+	MutualTLS  bool
+	NextProtos []string
+}
+
+// ClientConfig returns a TLS 1.2+ client config with hot CA/certificate reload.
+func (reloader *Reloader) ClientConfig(
+	options ClientOptions,
+) (*tls.Config, error) {
+	if reloader == nil {
+		return nil, fmt.Errorf("%w: reloader is nil", ErrInvalidOption)
+	}
+	requirements := requireRoots
+	if options.MutualTLS {
+		requirements |= requireCertificate
+	}
+	if err := reloader.require(requirements); err != nil {
+		return nil, err
+	}
+	serverName := strings.TrimSpace(options.ServerName)
+	config := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         serverName,
+		NextProtos:         normalizedProtocols(options.NextProtos),
+		InsecureSkipVerify: true, // Full dynamic verification is performed below.
+		VerifyConnection: func(connection tls.ConnectionState) error {
+			current := reloader.current.Load()
+			if current == nil || current.roots == nil {
+				return ErrUnavailable
+			}
+			if len(connection.PeerCertificates) == 0 {
+				return fmt.Errorf("%w: peer sent no certificate", ErrUnavailable)
+			}
+			name := serverName
+			if name == "" {
+				name = connection.ServerName
+			}
+			if name == "" {
+				return fmt.Errorf("%w: server name is empty", ErrInvalidOption)
+			}
+			intermediates := x509.NewCertPool()
+			for _, certificate := range connection.PeerCertificates[1:] {
+				intermediates.AddCert(certificate)
+			}
+			_, err := connection.PeerCertificates[0].Verify(x509.VerifyOptions{
+				DNSName:       name,
+				Roots:         current.roots,
+				Intermediates: intermediates,
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			})
+			if err != nil {
+				return fmt.Errorf("tlsconfig: verify server: %w", err)
+			}
+			return nil
+		},
+	}
+	if options.MutualTLS {
+		config.GetClientCertificate = func(
+			*tls.CertificateRequestInfo,
+		) (*tls.Certificate, error) {
+			current := reloader.current.Load()
+			if current == nil || current.certificate == nil {
+				return nil, ErrUnavailable
+			}
+			return current.certificate, nil
+		}
+	}
+	return config, nil
+}
+
+func (reloader *Reloader) require(
+	requirements materialRequirements,
+) error {
+	reloader.mu.Lock()
+	defer reloader.mu.Unlock()
+	combined := reloader.requirements | requirements
+	if err := validateRequirements(
+		reloader.current.Load(),
+		combined,
+	); err != nil {
+		return err
+	}
+	reloader.requirements = combined
+	return nil
+}
+
+func validateRequirements(
+	current *state,
+	requirements materialRequirements,
+) error {
+	// NewEmpty intentionally declares a profile before SecretWatcher publishes
+	// the initial complete replacement.
+	if current == nil {
+		return nil
+	}
+	if requirements&requireCertificate != 0 &&
+		current.certificate == nil {
+		return fmt.Errorf(
+			"%w: active TLS profile requires a certificate and private key",
+			ErrInvalidMaterial,
+		)
+	}
+	if requirements&requireRoots != 0 && current.roots == nil {
+		return fmt.Errorf(
+			"%w: active TLS profile requires a CA bundle",
+			ErrInvalidMaterial,
+		)
+	}
+	return nil
+}
+
+func parseMaterial(material Material) (*state, error) {
+	hasCertificate := len(material.CertificatePEM) > 0 ||
+		len(material.PrivateKeyPEM) > 0
+	var certificate *tls.Certificate
+	if hasCertificate {
+		if len(material.CertificatePEM) == 0 ||
+			len(material.PrivateKeyPEM) == 0 {
+			return nil, fmt.Errorf(
+				"%w: certificate and private key must be replaced together",
+				ErrInvalidMaterial,
+			)
+		}
+		parsed, err := tls.X509KeyPair(
+			append([]byte(nil), material.CertificatePEM...),
+			append([]byte(nil), material.PrivateKeyPEM...),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("%w: key pair: %w", ErrInvalidMaterial, err)
+		}
+		certificate = &parsed
+	}
+
+	var roots *x509.CertPool
+	if len(material.CAPEM) > 0 {
+		roots = x509.NewCertPool()
+		if !roots.AppendCertsFromPEM(material.CAPEM) {
+			return nil, fmt.Errorf("%w: CA bundle", ErrInvalidMaterial)
+		}
+	}
+	if certificate == nil && roots == nil {
+		return nil, fmt.Errorf("%w: material is empty", ErrInvalidMaterial)
+	}
+	return &state{certificate: certificate, roots: roots}, nil
+}
+
+func normalizedProtocols(protocols []string) []string {
+	if len(protocols) == 0 {
+		return []string{"h2", "http/1.1"}
+	}
+	result := make([]string, 0, len(protocols))
+	seen := make(map[string]struct{}, len(protocols))
+	for _, protocol := range protocols {
+		normalized := strings.TrimSpace(protocol)
+		if normalized == "" {
+			continue
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	return result
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/transport/tlsconfig/secret.go
+++ b/transport/tlsconfig/secret.go
@@ -1,0 +1,323 @@
+package tlsconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/keelab/keelith/secret"
+)
+
+// Secret watcher lifecycle states.
+const (
+	secretReconnectInitial = 250 * time.Millisecond
+	secretReconnectMaximum = 5 * time.Second
+)
+
+// SecretWatcherState is a bounded lifecycle state.
+type SecretWatcherState string
+
+const (
+	// SecretWatcherNew is the state before watching starts.
+	SecretWatcherNew SecretWatcherState = "new"
+	// SecretWatcherRunning is the active watch state.
+	SecretWatcherRunning SecretWatcherState = "running"
+	// SecretWatcherStopped is the terminal stopped state.
+	SecretWatcherStopped SecretWatcherState = "stopped"
+	// SecretWatcherFailed is the state after a terminal watch failure.
+	SecretWatcherFailed SecretWatcherState = "failed"
+)
+
+// SecretWatcherDescription is a material-free operational snapshot.
+type SecretWatcherDescription struct {
+	State      SecretWatcherState
+	Running    bool
+	LastFailed bool
+	Reloads    uint64
+	Reconnects uint64
+	Failures   uint64
+}
+
+type secretMaterial struct {
+	CertificatePEM string `json:"certificate_pem"`
+	PrivateKeyPEM  string `json:"private_key_pem"`
+	CAPEM          string `json:"ca_pem"`
+}
+
+// SecretManager resolves and watches complete secret replacements.
+type SecretManager interface {
+	Resolve(context.Context, secret.Reference) (secret.Value, error)
+	Watch(context.Context, secret.Reference) (secret.Watcher, error)
+}
+
+// SecretWatcher atomically updates a Reloader from one secret JSON bundle.
+//
+// Keeping the certificate, private key, and CA in one secret prevents
+// transient mismatched key-pair updates.
+type SecretWatcher struct {
+	manager   SecretManager
+	reference secret.Reference
+	reloader  *Reloader
+
+	mu        sync.Mutex
+	cancel    context.CancelFunc
+	watcher   secret.Watcher
+	done      chan struct{}
+	lastError error
+	version   string
+	running   bool
+	state     SecretWatcherState
+
+	reloads    atomic.Uint64
+	reconnects atomic.Uint64
+	failures   atomic.Uint64
+}
+
+// NewSecretWatcher constructs an App lifecycle component.
+func NewSecretWatcher(
+	manager SecretManager,
+	reference secret.Reference,
+	reloader *Reloader,
+) (*SecretWatcher, error) {
+	if isNil(manager) || reloader == nil {
+		return nil, fmt.Errorf(
+			"%w: secret manager and reloader are required",
+			ErrInvalidOption,
+		)
+	}
+	if _, err := secret.NewReference(
+		reference.Provider(),
+		reference.Key(),
+	); err != nil {
+		return nil, err
+	}
+	return &SecretWatcher{
+		manager:   manager,
+		reference: reference,
+		reloader:  reloader,
+		done:      make(chan struct{}),
+		state:     SecretWatcherNew,
+	}, nil
+}
+
+// Start resolves initial material before opening the update watcher.
+func (watcher *SecretWatcher) Start(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	watcher.mu.Lock()
+	if watcher.running || watcher.state == SecretWatcherStopped {
+		watcher.mu.Unlock()
+		return fmt.Errorf("%w: watcher already started", ErrInvalidOption)
+	}
+	watcher.running = true
+	watcher.state = SecretWatcherRunning
+	watcher.mu.Unlock()
+
+	value, err := watcher.manager.Resolve(ctx, watcher.reference)
+	if err != nil {
+		watcher.failStart(err)
+		return err
+	}
+	if err := watcher.apply(value); err != nil {
+		watcher.failStart(err)
+		return err
+	}
+	source, err := watcher.manager.Watch(ctx, watcher.reference)
+	if err != nil {
+		watcher.failStart(err)
+		return err
+	}
+	watchContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	watcher.mu.Lock()
+	watcher.cancel = cancel
+	watcher.watcher = source
+	watcher.mu.Unlock()
+	go watcher.run(watchContext, source)
+	return nil
+}
+
+// Shutdown stops watching. It is safe to call repeatedly.
+func (watcher *SecretWatcher) Shutdown(ctx context.Context) error {
+	if watcher == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	watcher.mu.Lock()
+	cancel := watcher.cancel
+	source := watcher.watcher
+	done := watcher.done
+	running := watcher.running
+	watcher.mu.Unlock()
+	if !running {
+		return nil
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if source != nil {
+		_ = source.Close()
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+// LastError returns the latest invalid update or watcher failure.
+func (watcher *SecretWatcher) LastError() error {
+	if watcher == nil {
+		return fmt.Errorf("%w: watcher is nil", ErrInvalidOption)
+	}
+	watcher.mu.Lock()
+	defer watcher.mu.Unlock()
+	return watcher.lastError
+}
+
+// Description returns lifecycle and aggregate reload state without secret
+// references, material, versions, paths, or error text.
+func (watcher *SecretWatcher) Description() SecretWatcherDescription {
+	if watcher == nil {
+		return SecretWatcherDescription{State: SecretWatcherStopped}
+	}
+	watcher.mu.Lock()
+	description := SecretWatcherDescription{
+		State:      watcher.state,
+		Running:    watcher.running,
+		LastFailed: watcher.lastError != nil,
+	}
+	watcher.mu.Unlock()
+	description.Reloads = watcher.reloads.Load()
+	description.Reconnects = watcher.reconnects.Load()
+	description.Failures = watcher.failures.Load()
+	return description
+}
+
+func (watcher *SecretWatcher) run(
+	ctx context.Context,
+	source secret.Watcher,
+) {
+	defer func() {
+		watcher.mu.Lock()
+		watcher.running = false
+		if watcher.state != SecretWatcherFailed {
+			watcher.state = SecretWatcherStopped
+		}
+		watcher.mu.Unlock()
+		close(watcher.done)
+	}()
+	for {
+		value, err := source.Next(ctx)
+		if err != nil {
+			if context.Cause(ctx) != nil {
+				return
+			}
+			watcher.record(err)
+			_ = source.Close()
+			source, err = watcher.reconnect(ctx)
+			if err != nil {
+				return
+			}
+			continue
+		}
+		if err := watcher.apply(value); err != nil {
+			watcher.record(err)
+			continue
+		}
+		watcher.record(nil)
+	}
+}
+
+func (watcher *SecretWatcher) reconnect(
+	ctx context.Context,
+) (secret.Watcher, error) {
+	delay := secretReconnectInitial
+	for {
+		if cause := context.Cause(ctx); cause != nil {
+			return nil, cause
+		}
+		value, err := watcher.manager.Resolve(ctx, watcher.reference)
+		if err == nil {
+			err = watcher.apply(value)
+		}
+		if err == nil {
+			var source secret.Watcher
+			source, err = watcher.manager.Watch(ctx, watcher.reference)
+			if err == nil {
+				watcher.mu.Lock()
+				watcher.watcher = source
+				watcher.mu.Unlock()
+				watcher.reconnects.Add(1)
+				watcher.record(nil)
+				return source, nil
+			}
+		}
+		watcher.record(err)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil, context.Cause(ctx)
+		case <-timer.C:
+		}
+		delay *= 2
+		if delay > secretReconnectMaximum {
+			delay = secretReconnectMaximum
+		}
+	}
+}
+
+func (watcher *SecretWatcher) apply(value secret.Value) error {
+	if value.Expired(time.Now()) {
+		return fmt.Errorf("%w: secret value is expired", secret.ErrInvalidValue)
+	}
+	var encoded secretMaterial
+	if err := json.Unmarshal(value.Bytes(), &encoded); err != nil {
+		return fmt.Errorf("%w: secret JSON: %w", ErrInvalidMaterial, err)
+	}
+	if err := watcher.reloader.Update(Material{
+		CertificatePEM: []byte(encoded.CertificatePEM),
+		PrivateKeyPEM:  []byte(encoded.PrivateKeyPEM),
+		CAPEM:          []byte(encoded.CAPEM),
+	}); err != nil {
+		return err
+	}
+	watcher.mu.Lock()
+	changed := watcher.version != value.Version()
+	watcher.version = value.Version()
+	watcher.mu.Unlock()
+	if changed {
+		watcher.reloads.Add(1)
+	}
+	return nil
+}
+
+func (watcher *SecretWatcher) failStart(err error) {
+	watcher.mu.Lock()
+	watcher.running = false
+	watcher.state = SecretWatcherFailed
+	watcher.lastError = err
+	watcher.failures.Add(1)
+	watcher.mu.Unlock()
+}
+
+func (watcher *SecretWatcher) record(err error) {
+	watcher.mu.Lock()
+	watcher.lastError = err
+	watcher.mu.Unlock()
+	if err != nil {
+		watcher.failures.Add(1)
+	}
+}

--- a/transport/websocket/config.go
+++ b/transport/websocket/config.go
@@ -1,0 +1,312 @@
+package websocket
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+	"unicode"
+
+	coderws "github.com/coder/websocket"
+	kerrors "github.com/keelab/keelith/errors"
+)
+
+const (
+	defaultName           = "keelith.websocket"
+	defaultMaxConnections = 1024
+	defaultMaxMessage     = int64(1024 * 1024)
+	maxConnections        = 1_000_000
+	maxMessageBytes       = int64(16 * 1024 * 1024)
+)
+
+var (
+	// ErrInvalidOption reports malformed configuration, requests, or messages.
+	ErrInvalidOption = errors.New("websocket: invalid option")
+	// ErrNotRunning reports a handshake outside the Hub lifecycle.
+	ErrNotRunning = errors.New("websocket: hub is not running")
+	// ErrClosed reports cancellation caused by Hub shutdown.
+	ErrClosed = errors.New("websocket: hub is closed")
+	// ErrHandshake is the stable pre-upgrade HTTP error.
+	ErrHandshake = kerrors.New(
+		400,
+		"WEBSOCKET_HANDSHAKE_FAILED",
+		"websocket handshake failed",
+	)
+	// ErrCapacity is the stable pre-upgrade connection-capacity error.
+	ErrCapacity = kerrors.New(
+		503,
+		"WEBSOCKET_CAPACITY_EXCEEDED",
+		"websocket connection capacity is exceeded",
+	)
+	// ErrMessageTooLarge reports a message outside the configured byte budget.
+	ErrMessageTooLarge = errors.New("websocket: message is too large")
+	// ErrConnectionClosed reports a non-normal peer or transport termination.
+	ErrConnectionClosed = errors.New("websocket: connection closed")
+	// ErrHeartbeat reports a failed opt-in ping/pong liveness check.
+	ErrHeartbeat = errors.New("websocket: heartbeat failed")
+)
+
+// CompressionMode selects the RFC 7692 per-message deflate policy.
+type CompressionMode string
+
+const (
+	// CompressionDisabled avoids compression CPU and per-connection state.
+	CompressionDisabled CompressionMode = "disabled"
+	// CompressionNoContextTakeover resets compression state per message.
+	CompressionNoContextTakeover CompressionMode = "no-context-takeover"
+	// CompressionContextTakeover reuses state and consumes more connection memory.
+	CompressionContextTakeover CompressionMode = "context-takeover"
+)
+
+// Options configure one lifecycle-owned WebSocket Hub.
+type Options struct {
+	Name                 string          `config:"name"`
+	OriginPatterns       []string        `config:"origin_patterns"`
+	AllowAnyOrigin       bool            `config:"allow_any_origin"`
+	Subprotocols         []string        `config:"subprotocols"`
+	RequireSubprotocol   bool            `config:"require_subprotocol"`
+	Compression          CompressionMode `config:"compression"`
+	CompressionThreshold int             `config:"compression_threshold"`
+	MaxConnections       int             `config:"max_connections"`
+	MaxReadBytes         int64           `config:"max_read_bytes"`
+	MaxWriteBytes        int64           `config:"max_write_bytes"`
+	PingInterval         time.Duration   `config:"ping_interval"`
+	PingTimeout          time.Duration   `config:"ping_timeout"`
+}
+
+// NormalizeOptions applies safe defaults and validates bounded resources.
+func NormalizeOptions(input Options) (Options, error) {
+	options := input
+	options.Name = strings.TrimSpace(options.Name)
+	if options.Name == "" {
+		options.Name = defaultName
+	}
+	if options.Compression == "" {
+		options.Compression = CompressionDisabled
+	}
+	if options.MaxConnections == 0 {
+		options.MaxConnections = defaultMaxConnections
+	}
+	if options.MaxReadBytes == 0 {
+		options.MaxReadBytes = defaultMaxMessage
+	}
+	if options.MaxWriteBytes == 0 {
+		options.MaxWriteBytes = defaultMaxMessage
+	}
+	if !validName(options.Name) ||
+		options.MaxConnections < 1 ||
+		options.MaxConnections > maxConnections ||
+		options.MaxReadBytes < 1 ||
+		options.MaxReadBytes > maxMessageBytes ||
+		options.MaxWriteBytes < 1 ||
+		options.MaxWriteBytes > maxMessageBytes {
+		return Options{}, fmt.Errorf(
+			"%w: name or resource budget",
+			ErrInvalidOption,
+		)
+	}
+	switch options.Compression {
+	case CompressionDisabled:
+		if options.CompressionThreshold != 0 {
+			return Options{}, fmt.Errorf(
+				"%w: compression threshold requires compression",
+				ErrInvalidOption,
+			)
+		}
+	case CompressionNoContextTakeover, CompressionContextTakeover:
+		if options.CompressionThreshold < 0 ||
+			options.CompressionThreshold > int(maxMessageBytes) {
+			return Options{}, fmt.Errorf(
+				"%w: compression threshold",
+				ErrInvalidOption,
+			)
+		}
+	default:
+		return Options{}, fmt.Errorf(
+			"%w: compression mode %q",
+			ErrInvalidOption,
+			options.Compression,
+		)
+	}
+	if options.PingInterval == 0 {
+		if options.PingTimeout != 0 {
+			return Options{}, fmt.Errorf(
+				"%w: ping timeout requires ping interval",
+				ErrInvalidOption,
+			)
+		}
+	} else if options.PingInterval < time.Second ||
+		options.PingInterval > 10*time.Minute ||
+		options.PingTimeout < 100*time.Millisecond ||
+		options.PingTimeout >= options.PingInterval {
+		return Options{}, fmt.Errorf(
+			"%w: heartbeat budget",
+			ErrInvalidOption,
+		)
+	}
+	origins, err := normalizeOrigins(options.OriginPatterns)
+	if err != nil {
+		return Options{}, err
+	}
+	subprotocols, err := normalizeSubprotocols(options.Subprotocols)
+	if err != nil {
+		return Options{}, err
+	}
+	if options.AllowAnyOrigin && len(origins) != 0 {
+		return Options{}, fmt.Errorf(
+			"%w: allow-any-origin conflicts with origin patterns",
+			ErrInvalidOption,
+		)
+	}
+	if options.RequireSubprotocol && len(subprotocols) == 0 {
+		return Options{}, fmt.Errorf(
+			"%w: required subprotocol list is empty",
+			ErrInvalidOption,
+		)
+	}
+	options.OriginPatterns = origins
+	options.Subprotocols = subprotocols
+	return options, nil
+}
+
+// ValidateOptions validates Options without constructing a Hub.
+func ValidateOptions(options Options) error {
+	_, err := NormalizeOptions(options)
+	return err
+}
+
+func (options Options) acceptOptions() *coderws.AcceptOptions {
+	return &coderws.AcceptOptions{
+		Subprotocols:         append([]string(nil), options.Subprotocols...),
+		InsecureSkipVerify:   options.AllowAnyOrigin,
+		OriginPatterns:       append([]string(nil), options.OriginPatterns...),
+		CompressionMode:      options.coderCompression(),
+		CompressionThreshold: options.CompressionThreshold,
+	}
+}
+
+func (options Options) coderCompression() coderws.CompressionMode {
+	switch options.Compression {
+	case CompressionNoContextTakeover:
+		return coderws.CompressionNoContextTakeover
+	case CompressionContextTakeover:
+		return coderws.CompressionContextTakeover
+	default:
+		return coderws.CompressionDisabled
+	}
+}
+
+func normalizeOrigins(values []string) ([]string, error) {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	if len(values) > 32 {
+		return nil, fmt.Errorf(
+			"%w: too many origin patterns",
+			ErrInvalidOption,
+		)
+	}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if !validPlainText(value, 256) || value == "*" {
+			return nil, fmt.Errorf(
+				"%w: origin pattern",
+				ErrInvalidOption,
+			)
+		}
+		if _, err := path.Match(value, value); err != nil {
+			return nil, fmt.Errorf(
+				"%w: origin pattern",
+				ErrInvalidOption,
+			)
+		}
+		normalized := strings.ToLower(value)
+		if _, duplicate := seen[normalized]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate origin pattern",
+				ErrInvalidOption,
+			)
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, value)
+	}
+	return result, nil
+}
+
+func normalizeSubprotocols(values []string) ([]string, error) {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	if len(values) > 32 {
+		return nil, fmt.Errorf(
+			"%w: too many subprotocols",
+			ErrInvalidOption,
+		)
+	}
+	for _, value := range values {
+		if !validSubprotocol(value) {
+			return nil, fmt.Errorf(
+				"%w: subprotocol",
+				ErrInvalidOption,
+			)
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate subprotocol",
+				ErrInvalidOption,
+			)
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result, nil
+}
+
+func validSubprotocol(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			strings.ContainsRune("!#$%&'*+-.^_`|~", character) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validPlainText(value string, maximum int) bool {
+	if value == "" || len(value) > maximum ||
+		strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validName(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z',
+			character >= 'A' && character <= 'Z',
+			character >= '0' && character <= '9',
+			character == '.',
+			character == '_',
+			character == '-',
+			character == '/',
+			character == ':':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/transport/websocket/hub.go
+++ b/transport/websocket/hub.go
@@ -1,0 +1,415 @@
+// Package websocket provides an explicit, lifecycle-owned RFC 6455 adapter
+// for standard Keelith HTTP routes.
+package websocket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	coderws "github.com/coder/websocket"
+	"github.com/keelab/keelith/middleware"
+	"github.com/keelab/keelith/operation"
+)
+
+type hubState uint8
+
+const (
+	hubNew hubState = iota
+	hubRunning
+	hubClosing
+	hubStopped
+)
+
+// Description is a low-cardinality, value-free Hub snapshot.
+type Description struct {
+	State             string
+	Ready             bool
+	Active            int
+	Pending           int
+	Accepted          uint64
+	Finished          uint64
+	Rejected          uint64
+	Sent              uint64
+	Received          uint64
+	HeartbeatFailures uint64
+	Closed            bool
+}
+
+// Hub owns upgraded connections that net/http no longer manages.
+type Hub struct {
+	options Options
+	streams *middleware.StreamBundle
+
+	mu          sync.Mutex
+	state       hubState
+	pending     int
+	connections map[*Connection]struct{}
+	drained     chan struct{}
+	drainOnce   sync.Once
+
+	accepted          atomic.Uint64
+	finished          atomic.Uint64
+	rejected          atomic.Uint64
+	sent              atomic.Uint64
+	received          atomic.Uint64
+	heartbeatFailures atomic.Uint64
+}
+
+// NewHub creates an instance-scoped WebSocket lifecycle component.
+func NewHub(
+	options Options,
+	streams *middleware.StreamBundle,
+) (*Hub, error) {
+	normalized, err := NormalizeOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	return &Hub{
+		options:     normalized,
+		streams:     streams,
+		state:       hubNew,
+		connections: make(map[*Connection]struct{}),
+		drained:     make(chan struct{}),
+	}, nil
+}
+
+// Name returns the App component name.
+func (hub *Hub) Name() string {
+	if hub == nil {
+		return defaultName
+	}
+	return hub.options.Name
+}
+
+// Start opens the handshake gate before HTTP servers start.
+func (hub *Hub) Start(ctx context.Context) error {
+	if hub == nil || ctx == nil {
+		return fmt.Errorf(
+			"%w: hub or context is nil",
+			ErrInvalidOption,
+		)
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	if hub.state != hubNew {
+		return ErrNotRunning
+	}
+	hub.state = hubRunning
+	return nil
+}
+
+// Stop rejects handshakes, cancels sessions, closes hijacked connections, and
+// waits for handlers to leave or ctx to expire.
+func (hub *Hub) Stop(ctx context.Context) error {
+	if hub == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("%w: context is nil", ErrInvalidOption)
+	}
+	hub.mu.Lock()
+	connections := make([]*Connection, 0)
+	switch hub.state {
+	case hubNew:
+		hub.state = hubStopped
+		hub.maybeDrainLocked()
+	case hubRunning:
+		hub.state = hubClosing
+		for connection := range hub.connections {
+			connections = append(connections, connection)
+		}
+		hub.maybeDrainLocked()
+	case hubClosing, hubStopped:
+		hub.maybeDrainLocked()
+	}
+	drained := hub.drained
+	hub.mu.Unlock()
+	for _, connection := range connections {
+		connection.cancel(ErrClosed)
+		_ = connection.raw.CloseNow()
+	}
+
+	select {
+	case <-drained:
+		hub.mu.Lock()
+		hub.state = hubStopped
+		hub.mu.Unlock()
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+// Describe returns aggregate state without route, origin, peer, or payload.
+func (hub *Hub) Describe() Description {
+	if hub == nil {
+		return Description{Closed: true}
+	}
+	hub.mu.Lock()
+	active := len(hub.connections)
+	pending := hub.pending
+	state := hub.state.String()
+	ready := hub.state == hubRunning
+	closed := hub.state == hubClosing || hub.state == hubStopped
+	hub.mu.Unlock()
+	return Description{
+		State:             state,
+		Ready:             ready,
+		Active:            active,
+		Pending:           pending,
+		Accepted:          hub.accepted.Load(),
+		Finished:          hub.finished.Load(),
+		Rejected:          hub.rejected.Load(),
+		Sent:              hub.sent.Load(),
+		Received:          hub.received.Load(),
+		HeartbeatFailures: hub.heartbeatFailures.Load(),
+		Closed:            closed,
+	}
+}
+
+func (state hubState) String() string {
+	switch state {
+	case hubNew:
+		return "new"
+	case hubRunning:
+		return "active"
+	case hubClosing:
+		return "draining"
+	case hubStopped:
+		return "stopped"
+	default:
+		return "unknown"
+	}
+}
+
+// Encode upgrades a Session returned by a Keelith streaming HTTP route.
+func (hub *Hub) Encode(
+	ctx context.Context,
+	writer http.ResponseWriter,
+	response any,
+) error {
+	if hub == nil || ctx == nil || writer == nil {
+		return fmt.Errorf(
+			"%w: hub, context, or writer is nil",
+			ErrInvalidOption,
+		)
+	}
+	target, ok := operation.FromContext(ctx)
+	if !ok || target.Kind() != operation.KindBidiStream {
+		return fmt.Errorf(
+			"%w: websocket route must use bidi-stream operation",
+			ErrInvalidOption,
+		)
+	}
+	session, ok := response.(Session)
+	if !ok || session.request.state == nil || session.handler == nil {
+		return fmt.Errorf(
+			"%w: response type %T",
+			ErrInvalidOption,
+			response,
+		)
+	}
+	if !hub.reserve() {
+		hub.rejected.Add(1)
+		if hub.isRunning() {
+			return ErrCapacity
+		}
+		return ErrNotRunning
+	}
+	reserved := true
+	defer func() {
+		if reserved {
+			hub.releaseReservation()
+		}
+	}()
+
+	request := session.request.consume()
+	if request == nil {
+		return fmt.Errorf(
+			"%w: websocket request was already consumed",
+			ErrInvalidOption,
+		)
+	}
+	request = request.WithContext(ctx)
+	headers := cloneHeader(writer.Header())
+	handshake := &handshakeWriter{ResponseWriter: writer}
+	raw, err := coderws.Accept(
+		handshake,
+		request,
+		hub.options.acceptOptions(),
+	)
+	if err != nil {
+		restoreHeader(writer.Header(), headers)
+		hub.rejected.Add(1)
+		return ErrHandshake
+	}
+	if hub.options.RequireSubprotocol && raw.Subprotocol() == "" {
+		hub.rejected.Add(1)
+		_ = raw.Close(
+			coderws.StatusPolicyViolation,
+			"subprotocol required",
+		)
+		return ErrHandshake
+	}
+	raw.SetReadLimit(hub.options.MaxReadBytes)
+	connection, err := hub.activate(ctx, raw)
+	reserved = false
+	if err != nil {
+		hub.rejected.Add(1)
+		_ = raw.CloseNow()
+		return err
+	}
+	defer hub.remove(connection)
+
+	if err := connection.create(); err != nil {
+		_ = raw.Close(
+			coderws.StatusPolicyViolation,
+			"stream rejected",
+		)
+		_ = connection.complete(err)
+		return err
+	}
+	connection.startHeartbeat()
+	sessionErr := session.handler(connection.context, connection)
+	if errors.Is(sessionErr, io.EOF) {
+		sessionErr = nil
+	}
+	finishErr := connection.complete(sessionErr)
+	result := errors.Join(sessionErr, finishErr)
+	switch {
+	case result == nil:
+		_ = raw.Close(coderws.StatusNormalClosure, "")
+	case errors.Is(result, ErrClosed):
+		_ = raw.CloseNow()
+	default:
+		_ = raw.Close(
+			coderws.StatusInternalError,
+			"session failed",
+		)
+	}
+	return result
+}
+
+func (hub *Hub) reserve() bool {
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	if hub.state != hubRunning ||
+		hub.pending+len(hub.connections) >= hub.options.MaxConnections {
+		return false
+	}
+	hub.pending++
+	return true
+}
+
+func (hub *Hub) releaseReservation() {
+	hub.mu.Lock()
+	if hub.pending > 0 {
+		hub.pending--
+	}
+	hub.maybeDrainLocked()
+	hub.mu.Unlock()
+}
+
+func (hub *Hub) activate(
+	ctx context.Context,
+	raw *coderws.Conn,
+) (*Connection, error) {
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	if hub.pending > 0 {
+		hub.pending--
+	}
+	if hub.state != hubRunning {
+		hub.maybeDrainLocked()
+		return nil, ErrClosed
+	}
+	sessionContext, cancel := context.WithCancelCause(ctx)
+	connection := newConnection(
+		sessionContext,
+		cancel,
+		raw,
+		hub,
+	)
+	hub.connections[connection] = struct{}{}
+	hub.accepted.Add(1)
+	return connection, nil
+}
+
+func (hub *Hub) remove(connection *Connection) {
+	if connection == nil {
+		return
+	}
+	connection.cancel(nil)
+	hub.mu.Lock()
+	if _, exists := hub.connections[connection]; exists {
+		delete(hub.connections, connection)
+		hub.finished.Add(1)
+	}
+	hub.maybeDrainLocked()
+	hub.mu.Unlock()
+}
+
+func (hub *Hub) isRunning() bool {
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	return hub.state == hubRunning
+}
+
+func (hub *Hub) maybeDrainLocked() {
+	if (hub.state == hubClosing || hub.state == hubStopped) &&
+		hub.pending == 0 &&
+		len(hub.connections) == 0 {
+		hub.drainOnce.Do(func() { close(hub.drained) })
+	}
+}
+
+type handshakeWriter struct {
+	http.ResponseWriter
+	upgraded bool
+}
+
+func (writer *handshakeWriter) WriteHeader(status int) {
+	if writer.upgraded {
+		return
+	}
+	if status == http.StatusSwitchingProtocols {
+		writer.upgraded = true
+		writer.ResponseWriter.WriteHeader(status)
+	}
+}
+
+func (writer *handshakeWriter) Write(content []byte) (int, error) {
+	if writer.upgraded {
+		return writer.ResponseWriter.Write(content)
+	}
+	return len(content), nil
+}
+
+func (writer *handshakeWriter) Unwrap() http.ResponseWriter {
+	return writer.ResponseWriter
+}
+
+func cloneHeader(header http.Header) http.Header {
+	result := make(http.Header, len(header))
+	for key, values := range header {
+		result[key] = append([]string(nil), values...)
+	}
+	return result
+}
+
+func restoreHeader(target, snapshot http.Header) {
+	for key := range target {
+		delete(target, key)
+	}
+	for key, values := range snapshot {
+		target[key] = append([]string(nil), values...)
+	}
+}

--- a/transport/websocket/message.go
+++ b/transport/websocket/message.go
@@ -1,0 +1,349 @@
+package websocket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	coderws "github.com/coder/websocket"
+	"github.com/keelab/keelith/middleware"
+)
+
+// MessageType identifies a complete text or binary WebSocket message.
+type MessageType string
+
+const (
+	// MessageText contains valid UTF-8.
+	MessageText MessageType = "text"
+	// MessageBinary contains arbitrary bytes.
+	MessageBinary MessageType = "binary"
+)
+
+// StatusCode is an RFC 6455 close status.
+type StatusCode int
+
+const (
+	// StatusNormalClosure indicates successful session completion.
+	StatusNormalClosure StatusCode = 1000
+	// StatusGoingAway indicates process or endpoint shutdown.
+	StatusGoingAway StatusCode = 1001
+	// StatusPolicyViolation indicates an application policy rejection.
+	StatusPolicyViolation StatusCode = 1008
+	// StatusMessageTooBig indicates a message beyond the accepted budget.
+	StatusMessageTooBig StatusCode = 1009
+	// StatusInternalError indicates an unexpected session failure.
+	StatusInternalError StatusCode = 1011
+)
+
+// Message is an immutable complete WebSocket message.
+type Message struct {
+	messageType MessageType
+	content     []byte
+}
+
+// NewMessage validates and snapshots one complete message.
+func NewMessage(messageType MessageType, content []byte) (Message, error) {
+	if messageType != MessageText && messageType != MessageBinary {
+		return Message{}, fmt.Errorf(
+			"%w: message type %q",
+			ErrInvalidOption,
+			messageType,
+		)
+	}
+	if messageType == MessageText && !utf8.Valid(content) {
+		return Message{}, fmt.Errorf(
+			"%w: text message is not UTF-8",
+			ErrInvalidOption,
+		)
+	}
+	return Message{
+		messageType: messageType,
+		content:     append([]byte(nil), content...),
+	}, nil
+}
+
+// Type returns the message kind.
+func (message Message) Type() MessageType { return message.messageType }
+
+// Bytes returns an independent payload copy.
+func (message Message) Bytes() []byte {
+	return append([]byte(nil), message.content...)
+}
+
+// Connection exposes bounded complete-message operations.
+//
+// Read must not be called concurrently. Write and Ping may run concurrently
+// with Read and with other writes.
+type Connection struct {
+	raw       *coderws.Conn
+	hub       *Hub
+	context   context.Context
+	cancel    context.CancelCauseFunc
+	events    middleware.StreamHandler
+	send      atomic.Uint64
+	receive   atomic.Uint64
+	finish    sync.Once
+	finishErr error
+}
+
+func newConnection(
+	ctx context.Context,
+	cancel context.CancelCauseFunc,
+	raw *coderws.Conn,
+	hub *Hub,
+) *Connection {
+	connection := &Connection{
+		raw:     raw,
+		hub:     hub,
+		context: ctx,
+		cancel:  cancel,
+	}
+	terminal := middleware.StreamHandler(func(
+		ctx context.Context,
+		event middleware.StreamEvent,
+	) error {
+		switch event.Phase {
+		case middleware.StreamPhaseCreate, middleware.StreamPhaseFinish:
+			return nil
+		case middleware.StreamPhaseSend:
+			message, ok := event.Message.(Message)
+			if !ok {
+				return fmt.Errorf(
+					"%w: send message type %T",
+					ErrInvalidOption,
+					event.Message,
+				)
+			}
+			if int64(len(message.content)) > hub.options.MaxWriteBytes {
+				return ErrMessageTooLarge
+			}
+			return raw.Write(
+				ctx,
+				coderMessageType(message.messageType),
+				message.content,
+			)
+		case middleware.StreamPhaseReceive:
+			target, ok := event.Message.(*Message)
+			if !ok || target == nil {
+				return fmt.Errorf(
+					"%w: receive message target",
+					ErrInvalidOption,
+				)
+			}
+			messageType, content, err := raw.Read(ctx)
+			if err != nil {
+				return err
+			}
+			*target = Message{
+				messageType: keelithMessageType(messageType),
+				content:     append([]byte(nil), content...),
+			}
+			return nil
+		default:
+			return fmt.Errorf(
+				"%w: stream phase %q",
+				ErrInvalidOption,
+				event.Phase,
+			)
+		}
+	})
+	if hub.streams != nil {
+		terminal = hub.streams.Chain()(terminal)
+	}
+	connection.events = terminal
+	return connection
+}
+
+// Read receives one complete message.
+func (connection *Connection) Read(ctx context.Context) (Message, error) {
+	if connection == nil || ctx == nil {
+		return Message{}, fmt.Errorf(
+			"%w: connection or context is nil",
+			ErrInvalidOption,
+		)
+	}
+	var message Message
+	err := connection.events(ctx, middleware.StreamEvent{
+		Side:     middleware.StreamSideServer,
+		Phase:    middleware.StreamPhaseReceive,
+		Sequence: connection.receive.Add(1),
+		Message:  &message,
+	})
+	if err != nil {
+		return Message{}, connection.mapError(ctx, err)
+	}
+	connection.hub.received.Add(1)
+	return message, nil
+}
+
+// Write sends one immutable complete message.
+func (connection *Connection) Write(
+	ctx context.Context,
+	message Message,
+) error {
+	if connection == nil || ctx == nil {
+		return fmt.Errorf(
+			"%w: connection or context is nil",
+			ErrInvalidOption,
+		)
+	}
+	if _, err := NewMessage(message.messageType, message.content); err != nil {
+		return err
+	}
+	err := connection.events(ctx, middleware.StreamEvent{
+		Side:     middleware.StreamSideServer,
+		Phase:    middleware.StreamPhaseSend,
+		Sequence: connection.send.Add(1),
+		Message:  message,
+	})
+	if err != nil {
+		return connection.mapError(ctx, err)
+	}
+	connection.hub.sent.Add(1)
+	return nil
+}
+
+// Ping sends a control-frame ping and waits for the peer pong.
+//
+// A reader must be active, as required by the underlying RFC 6455 runtime.
+func (connection *Connection) Ping(ctx context.Context) error {
+	if connection == nil || ctx == nil {
+		return fmt.Errorf(
+			"%w: connection or context is nil",
+			ErrInvalidOption,
+		)
+	}
+	return connection.mapError(ctx, connection.raw.Ping(ctx))
+}
+
+// CloseRead starts a control-frame read loop for a write-only connection.
+// Read must not be called after this method.
+func (connection *Connection) CloseRead(ctx context.Context) context.Context {
+	if connection == nil || ctx == nil {
+		closed, cancel := context.WithCancel(context.Background())
+		cancel()
+		return closed
+	}
+	return connection.raw.CloseRead(ctx)
+}
+
+// Close performs the RFC 6455 close handshake with a stable reason.
+func (connection *Connection) Close(code StatusCode, reason string) error {
+	if connection == nil {
+		return nil
+	}
+	if len(reason) > 123 || !utf8.ValidString(reason) {
+		return fmt.Errorf("%w: close reason", ErrInvalidOption)
+	}
+	return connection.raw.Close(coderws.StatusCode(code), reason)
+}
+
+// Subprotocol returns the negotiated subprotocol, or empty when optional.
+func (connection *Connection) Subprotocol() string {
+	if connection == nil {
+		return ""
+	}
+	return connection.raw.Subprotocol()
+}
+
+func (connection *Connection) create() error {
+	return connection.events(connection.context, middleware.StreamEvent{
+		Side:  middleware.StreamSideServer,
+		Phase: middleware.StreamPhaseCreate,
+	})
+}
+
+func (connection *Connection) complete(err error) error {
+	connection.finish.Do(func() {
+		connection.finishErr = connection.events(
+			connection.context,
+			middleware.StreamEvent{
+				Side:  middleware.StreamSideServer,
+				Phase: middleware.StreamPhaseFinish,
+				Error: err,
+			},
+		)
+	})
+	return connection.finishErr
+}
+
+func (connection *Connection) startHeartbeat() {
+	if connection.hub.options.PingInterval == 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(connection.hub.options.PingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-connection.context.Done():
+				return
+			case <-ticker.C:
+				pingContext, cancel := context.WithTimeout(
+					connection.context,
+					connection.hub.options.PingTimeout,
+				)
+				err := connection.raw.Ping(pingContext)
+				cancel()
+				if err != nil {
+					connection.hub.heartbeatFailures.Add(1)
+					connection.cancel(ErrHeartbeat)
+					_ = connection.raw.CloseNow()
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (connection *Connection) mapError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	if cause := context.Cause(connection.context); cause != nil {
+		return cause
+	}
+	if errors.Is(err, coderws.ErrMessageTooBig) ||
+		errors.Is(err, ErrMessageTooLarge) {
+		return ErrMessageTooLarge
+	}
+	status := coderws.CloseStatus(err)
+	switch status {
+	case coderws.StatusNormalClosure, coderws.StatusGoingAway:
+		return io.EOF
+	case -1:
+		if errors.Is(err, net.ErrClosed) {
+			return ErrConnectionClosed
+		}
+	default:
+		return fmt.Errorf(
+			"%w: status %d",
+			ErrConnectionClosed,
+			status,
+		)
+	}
+	return ErrConnectionClosed
+}
+
+func coderMessageType(messageType MessageType) coderws.MessageType {
+	if messageType == MessageText {
+		return coderws.MessageText
+	}
+	return coderws.MessageBinary
+}
+
+func keelithMessageType(messageType coderws.MessageType) MessageType {
+	if messageType == coderws.MessageText {
+		return MessageText
+	}
+	return MessageBinary
+}

--- a/transport/websocket/ops.go
+++ b/transport/websocket/ops.go
@@ -1,0 +1,47 @@
+package websocket
+
+import (
+	"context"
+
+	"github.com/keelab/keelith/ops"
+)
+
+// RuntimeStatus adapts a Hub to the low-sensitive Ops Runtime Catalog.
+func RuntimeStatus(hub *Hub) ops.RuntimeStatusProvider {
+	if hub == nil {
+		return nil
+	}
+	return func(
+		ctx context.Context,
+	) (ops.RuntimeStatus, error) {
+		if ctx == nil {
+			return ops.RuntimeStatus{}, ErrInvalidOption
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return ops.RuntimeStatus{}, cause
+		}
+		description := hub.Describe()
+		return ops.RuntimeStatus{
+			State:  description.State,
+			Ready:  description.Ready,
+			Active: description.Active,
+			Counters: []ops.RuntimeCounter{
+				{Name: "accepted", Value: description.Accepted},
+				{Name: "finished", Value: description.Finished},
+				{Name: "rejected", Value: description.Rejected},
+				{Name: "sent", Value: description.Sent},
+				{Name: "received", Value: description.Received},
+				{
+					Name:  "heartbeat_failures",
+					Value: description.HeartbeatFailures,
+				},
+			},
+			Capabilities: []string{
+				"bidi-stream",
+				"connection-drain",
+				"origin-policy",
+				"subprotocol",
+			},
+		}, nil
+	}
+}

--- a/transport/websocket/session.go
+++ b/transport/websocket/session.go
@@ -1,0 +1,107 @@
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+)
+
+// Request is the validated, request-scoped WebSocket upgrade input.
+//
+// It intentionally does not expose the underlying *http.Request. Authentication
+// and Metadata should be read from context by ordinary Keelith middleware.
+type Request struct {
+	state *requestState
+}
+
+type requestState struct {
+	raw      *http.Request
+	consumed atomic.Bool
+}
+
+// Origin returns the browser Origin header for application-level auditing.
+func (request Request) Origin() string {
+	if request.state == nil || request.state.raw == nil {
+		return ""
+	}
+	return request.state.raw.Header.Get("Origin")
+}
+
+// RequestedSubprotocols returns a bounded snapshot of client offers.
+func (request Request) RequestedSubprotocols() []string {
+	if request.state == nil || request.state.raw == nil {
+		return nil
+	}
+	result := make([]string, 0)
+	for _, header := range request.state.raw.Header.Values(
+		"Sec-WebSocket-Protocol",
+	) {
+		for _, value := range strings.Split(header, ",") {
+			value = strings.TrimSpace(value)
+			if validSubprotocol(value) {
+				result = append(result, value)
+				if len(result) == 32 {
+					return result
+				}
+			}
+		}
+	}
+	return result
+}
+
+// DecodeRequest validates the request shape before ordinary middleware runs.
+func DecodeRequest(request *http.Request) (any, error) {
+	if request == nil ||
+		request.Method != http.MethodGet ||
+		!headerContainsToken(request.Header, "Connection", "upgrade") ||
+		!headerContainsToken(request.Header, "Upgrade", "websocket") {
+		return nil, ErrHandshake
+	}
+	return Request{state: &requestState{raw: request}}, nil
+}
+
+// SessionHandler owns one upgraded connection until it returns.
+type SessionHandler func(context.Context, *Connection) error
+
+// Session binds the decoded request to its application handler.
+type Session struct {
+	request Request
+	handler SessionHandler
+}
+
+// NewSession constructs the response consumed by Hub.Encode.
+func NewSession(request Request, handler SessionHandler) (Session, error) {
+	if request.state == nil || request.state.raw == nil || handler == nil {
+		return Session{}, fmt.Errorf(
+			"%w: request or handler is nil",
+			ErrInvalidOption,
+		)
+	}
+	return Session{request: request, handler: handler}, nil
+}
+
+func (request Request) consume() *http.Request {
+	if request.state == nil ||
+		request.state.raw == nil ||
+		!request.state.consumed.CompareAndSwap(false, true) {
+		return nil
+	}
+	return request.state.raw
+}
+
+func headerContainsToken(
+	header http.Header,
+	name string,
+	target string,
+) bool {
+	for _, value := range header.Values(name) {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), target) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 变更说明

补齐 Keelith 核心传输能力，新增 gRPC、HTTP、SSE、WebSocket、TLS 与 bearer 认证适配，并接入运行时诊断。

同时将 continuation HTTP 实现移动到 `transport/http/continuation` 子包，生成器改为引用该子包，在保持 continuation v1 API 版本不变的前提下解除内部循环依赖；生成协议标识同步调整为 `v1`。

关联 Issue：无

## 变更类型

- [ ] 缺陷修复
- [x] 新功能
- [x] 破坏性变更
- [ ] 重构或性能优化
- [ ] 测试、文档或工程配置

## 验证

- `go mod verify`
- `go test -race -shuffle=on -coverprofile=coverage.out ./...`
- `golangci-lint run --timeout=5m ./...`
- `govulncheck ./...`
- `go run github.com/bufbuild/buf/cmd/buf@v1.69.0 lint`
- 重复执行 `buf generate`，生成产物保持稳定

## 兼容性与风险

新增公开 transport API；continuation 的 protobuf 包和服务版本仍为 v1，但生成协议标识从 `v20` 调整为 `v1`。依赖该标识做兼容判断的调用方需要同步更新。

本次恢复的传输层以编译、race、lint 和漏洞扫描验证；尚未补充独立的网络集成测试。

## 检查清单

- [x] 我已阅读并遵循 `CONTRIBUTING.md`。
- [ ] 我已补充或更新相关测试。
- [ ] 我已补充或更新相关文档。
- [x] 本地测试和静态检查已通过。
- [x] 变更中不包含凭据、Token 或其他敏感信息。
