### PR TITLE
fix: preserve caller source in wrapped logs

### DIFF
--- a/observability/bundle.go
+++ b/observability/bundle.go
@@ -58,7 +58,7 @@ type Config struct {
 // Bundle owns all providers for one App.
 type Bundle struct {
 	resource   *kresource.Resource
-	logger     *slog.Logger
+	logger     *logging.Logger
 	logging    *logging.Controller
 	audit      *audit.Logger
 	tracing    *tracing.Provider
@@ -133,7 +133,7 @@ func New(config Config) (*Bundle, error) {
 		if auditErr != nil {
 			return nil, auditErr
 		}
-		auditLogger, auditErr = audit.NewWithPolicy(auditBase, config.AuditPolicy)
+		auditLogger, auditErr = audit.NewWithPolicy(auditBase.Slog(), config.AuditPolicy)
 		if auditErr != nil {
 			return nil, auditErr
 		}
@@ -285,8 +285,8 @@ func (bundle *Bundle) Resource() *kresource.Resource {
 	return bundle.resource
 }
 
-// Logger returns the instance slog Logger.
-func (bundle *Bundle) Logger() *slog.Logger {
+// Logger returns the instance caller-aware logger.
+func (bundle *Bundle) Logger() *logging.Logger {
 	return bundle.logger
 }
 

--- a/observability/logging/logging.go
+++ b/observability/logging/logging.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"runtime"
+	"time"
 
 	kresource "github.com/keelab/keelith/observability/resource"
 	"github.com/keelab/keelith/placement"
@@ -22,18 +24,129 @@ type ContextHandler struct {
 }
 
 // New creates an instance Logger with immutable Resource attributes.
-func New(
-	h slog.Handler,
-	resource *kresource.Resource,
-	redacter Redacter,
-) (*slog.Logger, error) {
+func New(h slog.Handler, resource *kresource.Resource, redacter Redacter) (*Logger, error) {
 	if h == nil || resource == nil {
 		return nil, fmt.Errorf("%w: handler or resource is nil", ErrInvalidOption)
 	}
-	return slog.New(&ContextHandler{
-		handler:  h.WithAttrs(resource.SlogAttributes()),
-		redacter: redacter,
-	}), nil
+	return &Logger{
+		base: slog.New(&ContextHandler{
+			handler:  h.WithAttrs(resource.SlogAttributes()),
+			redacter: redacter,
+		}),
+	}, nil
+}
+
+// Logger is the application logger facade. It records the caller of the
+// facade, so business logging wrappers can keep source locations accurate.
+type Logger struct {
+	base       *slog.Logger
+	callerSkip int
+}
+
+// Slog returns the underlying slog logger for integrations that require it.
+func (l *Logger) Slog() *slog.Logger {
+	if l == nil {
+		return nil
+	}
+	return l.base
+}
+
+// Handler returns the underlying handler tree.
+func (l *Logger) Handler() slog.Handler {
+	if l == nil || l.base == nil {
+		return nil
+	}
+	return l.base.Handler()
+}
+
+// Enabled reports whether level is enabled.
+func (l *Logger) Enabled(ctx context.Context, level slog.Level) bool {
+	return l != nil && l.base != nil && l.base.Enabled(ctx, level)
+}
+
+// WithCallerSkip returns a logger that skips additional facade frames.
+func (l *Logger) WithCallerSkip(skip int) *Logger {
+	if l == nil {
+		return nil
+	}
+	if skip < 0 {
+		skip = 0
+	}
+	return &Logger{base: l.base, callerSkip: l.callerSkip + skip}
+}
+
+// With returns a logger with bound attributes.
+func (l *Logger) With(args ...any) *Logger {
+	if l == nil || l.base == nil {
+		return nil
+	}
+	return &Logger{base: l.base.With(args...), callerSkip: l.callerSkip}
+}
+
+// WithGroup returns a logger with a bound group.
+func (l *Logger) WithGroup(name string) *Logger {
+	if l == nil || l.base == nil {
+		return nil
+	}
+	return &Logger{base: l.base.WithGroup(name), callerSkip: l.callerSkip}
+}
+
+func (l *Logger) DebugContext(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelDebug, msg, args...)
+}
+
+func (l *Logger) Debug(msg string, args ...any) {
+	l.DebugContext(context.Background(), msg, args...)
+}
+
+func (l *Logger) InfoContext(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelInfo, msg, args...)
+}
+
+func (l *Logger) Info(msg string, args ...any) {
+	l.InfoContext(context.Background(), msg, args...)
+}
+
+func (l *Logger) WarnContext(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelWarn, msg, args...)
+}
+
+func (l *Logger) Warn(msg string, args ...any) {
+	l.WarnContext(context.Background(), msg, args...)
+}
+
+func (l *Logger) ErrorContext(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelError, msg, args...)
+}
+
+func (l *Logger) Error(msg string, args ...any) {
+	l.ErrorContext(context.Background(), msg, args...)
+}
+
+func (l *Logger) Log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	l.log(ctx, level, msg, args...)
+}
+
+func (l *Logger) LogAttrs(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
+	if l == nil || l.base == nil || !l.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3+l.callerSkip, pcs[:])
+	record := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	record.AddAttrs(attrs...)
+	_ = l.base.Handler().Handle(ctx, record)
+}
+
+func (l *Logger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	if l == nil || l.base == nil || !l.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3+l.callerSkip, pcs[:])
+	record := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	record.Add(args...)
+	_ = l.base.Handler().Handle(ctx, record)
 }
 
 // Enabled delegates level filtering to the wrapped Handler.
@@ -45,10 +158,7 @@ func (h *ContextHandler) Enabled(
 }
 
 // Handle redacts attributes and adds valid trace correlation before delegation.
-func (h *ContextHandler) Handle(
-	ctx context.Context,
-	record slog.Record,
-) error {
+func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 	safe := slog.NewRecord(
 		record.Time,
 		record.Level,

--- a/observability/logging/logging_test.go
+++ b/observability/logging/logging_test.go
@@ -1,0 +1,40 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type callerHandler struct {
+	pc uintptr
+}
+
+func (handler *callerHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (handler *callerHandler) Handle(_ context.Context, record slog.Record) error {
+	handler.pc = record.PC
+	return nil
+}
+
+func (handler *callerHandler) WithAttrs([]slog.Attr) slog.Handler { return handler }
+
+func (handler *callerHandler) WithGroup(string) slog.Handler { return handler }
+
+func TestLoggerCallerSkip(t *testing.T) {
+	handler := &callerHandler{}
+	base := &Logger{base: slog.New(handler)}
+	logger := base.WithCallerSkip(1)
+
+	emitWrapped(logger)
+	function := runtime.FuncForPC(handler.pc)
+	if function == nil || !strings.HasSuffix(function.Name(), ".TestLoggerCallerSkip") {
+		t.Fatalf("source function = %v, want TestLoggerCallerSkip", function)
+	}
+}
+
+func emitWrapped(logger *Logger) {
+	logger.ErrorContext(context.Background(), "wrapped")
+}

--- a/observability/logging/runtime.go
+++ b/observability/logging/runtime.go
@@ -3,21 +3,30 @@ package logging
 import "log/slog"
 
 // Dependencies is the stable wiring output for application constructors.
-// It keeps slog as the public logging API while making policy ownership
-// explicit in dependency manifests.
+// It keeps the caller-aware logger and policy ownership together in the
+// dependency manifest.
 type Dependencies struct {
-	Logger     *slog.Logger
+	Logger     *Logger
 	Controller *Controller
 }
 
-// ProvideLogger exposes the standard slog API from a wiring dependency set.
-func ProvideLogger(dependencies Dependencies) *slog.Logger { return dependencies.Logger }
+// ProvideLogger exposes the caller-aware logger from a wiring dependency set.
+func ProvideLogger(dependencies Dependencies) *Logger { return dependencies.Logger }
+
+// ProvideSlog exposes the underlying standard logger for integrations that
+// have not adopted the Keelith facade.
+func ProvideSlog(dependencies Dependencies) *slog.Logger {
+	if dependencies.Logger == nil {
+		return nil
+	}
+	return dependencies.Logger.Slog()
+}
 
 // ProvideController exposes the dynamic policy controller to wiring.
 func ProvideController(dependencies Dependencies) *Controller { return dependencies.Controller }
 
 // NewDependencies validates one wiring-ready dependency set.
-func NewDependencies(logger *slog.Logger, controller *Controller) (Dependencies, error) {
+func NewDependencies(logger *Logger, controller *Controller) (Dependencies, error) {
 	if logger == nil || controller == nil {
 		return Dependencies{}, ErrInvalidOption
 	}


### PR DESCRIPTION
## 变更
- 新增 caller-aware logging facade，包装日志可保留真实调用方 source
- 通过 DI 注入新日志句柄，保留 Slog() 供底层集成
- 增加 caller skip 行为测试

## 验证
- go test ./...
- go vet ./observability/...
