### PR TITLE
chore: bump scaffold default to v0.0.4

### DIFF
--- a/internal/scaffold/new.go
+++ b/internal/scaffold/new.go
@@ -17,7 +17,7 @@ const (
 	// with the first published release that contains the root facade. The
 	// current checkout still uses the last published baseline until that
 	// release is tagged.
-	defaultFrameworkVersion = "v0.0.3"
+	defaultFrameworkVersion = "v0.0.4"
 	defaultGoVersion        = "1.26.6"
 )
 


### PR DESCRIPTION
## 变更说明

将 `keelith new` 脚手架默认使用的 Keelith 版本从 `v0.0.3` 更新为 `v0.0.4`，与本次最新主分支发布版本保持一致。

关联 Issue：无

## 变更类型

- [ ] 缺陷修复
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 重构或性能优化
- [x] 测试、文档或工程配置

## 验证

- `go test ./...`
- `gofmt` 与 `git diff --check`

## 兼容性与风险

无；仅更新新项目脚手架的默认依赖版本。

## 检查清单

- [x] 我已阅读并遵循 `CONTRIBUTING.md`。
- [x] 我已补充或更新相关测试。
- [x] 我已补充或更新相关文档。
- [x] 本地测试和静态检查已通过。
- [x] 变更中不包含凭据、Token 或其他敏感信息。